### PR TITLE
Chore: Refactor stash-pull-pop to use git pull --autostash for cleaner workflow

### DIFF
--- a/cmd/stash_pull_pop.go
+++ b/cmd/stash_pull_pop.go
@@ -24,8 +24,8 @@ func NewStashPullPopper() *StashPullPopper {
 	}
 }
 
-// PullWithAutoStash executes `git pull --autostash`.
-func (s *StashPullPopper) PullWithAutoStash() {
+// StashPullPop executes stash, pull, and pop commands in sequence using --autostash.
+func (s *StashPullPopper) StashPullPop() {
 	pullCmd := s.execCommand("git", "pull", "--autostash")
 	if err := pullCmd.Run(); err != nil {
 		_, _ = fmt.Fprintf(s.outputWriter, "Error pulling changes with autostash: %v\n", err)

--- a/cmd/stash_pull_pop.go
+++ b/cmd/stash_pull_pop.go
@@ -24,28 +24,13 @@ func NewStashPullPopper() *StashPullPopper {
 	}
 }
 
-// StashPullPop executes stash, pull, and pop commands in sequence.
-func (s *StashPullPopper) StashPullPop() {
-	// Stash changes
-	stashCmd := s.execCommand("git", "stash")
-	if err := stashCmd.Run(); err != nil {
-		_, _ = fmt.Fprintf(s.outputWriter, "Error stashing changes: stash error\n")
-		return
-	}
-
-	// Pull changes
-	pullCmd := s.execCommand("git", "pull")
+// PullWithAutoStash executes `git pull --autostash`.
+func (s *StashPullPopper) PullWithAutoStash() {
+	pullCmd := s.execCommand("git", "pull", "--autostash")
 	if err := pullCmd.Run(); err != nil {
-		_, _ = fmt.Fprintf(s.outputWriter, "Error pulling changes: pull error\n")
+		_, _ = fmt.Fprintf(s.outputWriter, "Error pulling changes with autostash: %v\n", err)
 		return
 	}
 
-	// Pop stashed changes
-	popCmd := s.execCommand("git", "stash", "pop")
-	if err := popCmd.Run(); err != nil {
-		_, _ = fmt.Fprintf(s.outputWriter, "Error popping stashed changes: pop error\n")
-		return
-	}
-
-	_, _ = fmt.Fprintf(s.outputWriter, "operation successful\n")
+	_, _ = fmt.Fprintf(s.outputWriter, "operation successful with autostash\n")
 }


### PR DESCRIPTION
This PR improves the stash-pull-pop functionality by replacing the manual sequence of git stash, git pull, and git stash pop commands with a single git pull --autostash command.

Simplifies the code by leveraging Git's built-in --autostash feature.

Reduces potential errors caused by manual stash/pop handling.

Maintains the same functionality but in a cleaner, more reliable way.

This change improves maintainability and aligns with best practices recommended by Git.