### PR TITLE
Removed global helper func

### DIFF
--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -82,8 +82,3 @@ func (c *Committer) Commit(args []string) {
 		}
 	}
 }
-
-// ShowCommitHelp displays help for the commit command.
-func ShowCommitHelp() {
-	fmt.Println("Usage: ggc commit <message> | ggc commit amend <message> | ggc commit allow-empty | ggc commit tmp")
-}

--- a/cmd/commit_test.go
+++ b/cmd/commit_test.go
@@ -143,8 +143,8 @@ func TestCommitter_Commit_Amend_WithMessage(t *testing.T) {
 		outputWriter: &buf,
 		helper:       NewHelper(),
 		execCommand: func(name string, arg ...string) *exec.Cmd {
-            if name == "git" && len(arg) == 4 && arg[0] == "commit" &&
-               arg[1] == "--amend" && arg[2] == "-m" && arg[3] == "updated message" {
+			if name == "git" && len(arg) == 4 && arg[0] == "commit" &&
+				arg[1] == "--amend" && arg[2] == "-m" && arg[3] == "updated message" {
 				commandCalled = true
 			}
 			return exec.Command("echo")
@@ -211,16 +211,4 @@ func TestCommitter_Commit_Tmp_Error(t *testing.T) {
 	if output != "Error: tmp commit failed\n" {
 		t.Errorf("Expected tmp error message, got: %q", output)
 	}
-}
-
-func TestShowCommitHelp(t *testing.T) {
-	// Verify that ShowCommitHelp function can be called
-	defer func() {
-		if r := recover(); r != nil {
-			t.Errorf("ShowCommitHelp should not panic: %v", r)
-		}
-	}()
-
-	ShowCommitHelp()
-	// Verify that the function executes normally
 }


### PR DESCRIPTION
## What
- Removed the redundant `ShowCommitHelp` function from `cmd/commit.go`
- Removed the corresponding test from `cmd/commit_test.go`

## Why
The help message functionality is already centralized in `cmd/templates/help.go`, which provides a more maintainable and consistent way to manage help messages. The removed function was duplicating this functionality.

## Benefits
- Reduces code duplication
- Improves maintainability by centralizing help message management
- Ensures consistent help message formatting across the application

## Verification
- Confirmed that no other global help functions exist in the codebase
- Verified that help messages are properly handled through the `Helper` struct in `cmd/help.go`
- All tests pass after the removal