### PR TITLE
feat(help): add ASCII art logo to help command output

### DIFF
--- a/cmd/help.go
+++ b/cmd/help.go
@@ -23,7 +23,12 @@ func NewHelper() *Helper {
 
 // ShowHelp shows the main help message.
 func (h *Helper) ShowHelp() {
-	_, _ = fmt.Fprint(h.outputWriter, templates.RenderMainHelp())
+	helpMsg, err := templates.RenderMainHelp()
+	if err != nil {
+		_, _ = fmt.Fprintf(h.outputWriter, "Error: %v\n", err)
+		return
+	}
+	_, _ = fmt.Fprint(h.outputWriter, helpMsg)
 }
 
 // ShowCommandHelp shows help message for a command.

--- a/cmd/templates/help_test.go
+++ b/cmd/templates/help_test.go
@@ -7,18 +7,60 @@ import (
 )
 
 func TestRenderMainHelp(t *testing.T) {
-	result := RenderMainHelp()
-
-	if result == "" {
-		t.Error("RenderMainHelp should return non-empty string")
+	tests := []struct {
+		name     string
+		logo     string
+		expected []string
+	}{
+		{
+			name: "full logo",
+			logo: Logo,
+			expected: []string{
+				"ggc: A Go-based CLI tool to streamline Git operations",
+				"Usage:",
+			},
+		},
+		{
+			name: "small logo",
+			logo: SmallLogo,
+			expected: []string{
+				"ggc: A Go-based CLI tool",
+				"Usage:",
+				"ggc <command>",
+			},
+		},
 	}
 
-	if !strings.Contains(result, "ggc") {
-		t.Error("RenderMainHelp should contain 'ggc' in output")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := RenderMainHelp()
+			if err != nil {
+				t.Fatalf("RenderMainHelp() should not return error: %v", err)
+			}
+			for _, want := range tt.expected {
+				if !strings.Contains(result, want) {
+					t.Errorf("expected help output to contain %q", want)
+				}
+			}
+		})
+	}
+}
+
+func TestLogoConstants(t *testing.T) {
+	if Logo == "" {
+		t.Error("Logo constant should not be empty")
 	}
 
-	if !strings.Contains(result, "Usage:") {
-		t.Error("RenderMainHelp should contain 'Usage:' in output")
+	if SmallLogo == "" {
+		t.Error("SmallLogo constant should not be empty")
+	}
+
+	if !strings.Contains(Logo, "_") {
+		t.Error("Logo should contain ASCII art characters")
+	}
+
+	if !strings.Contains(SmallLogo, "ggc") {
+		t.Error("SmallLogo should contain 'ggc'")
 	}
 }
 

--- a/cmd/templates/logo.go
+++ b/cmd/templates/logo.go
@@ -1,0 +1,17 @@
+package templates
+
+// Logo is the full ASCII art banner displayed in the main help screen
+const Logo = `
+   __ _  __ _  ___ 
+  / _` + "`" + ` |/ _` + "`" + ` |/ __|
+ | (_| | (_| | (__ 
+  \__, |\__, |\___|
+  |___/ |___/      
+`
+
+// SmallLogo is a compact version of the logo for minimal output contexts
+const SmallLogo = `
+  ╔═════════════════════╗
+  ║ ggc — A Go Git CLI  ║
+  ╚═════════════════════╝
+`


### PR DESCRIPTION
Closes #34.
Adds ASCII art logo to `ggc help` and when just running `ggc`.

## Summary
- Create cmd/templates/logo.go with full and small ASCII logos
- Update help template to include the logo at the top
- Modify help command to conditionally show small logo for narrow terminals
- Update help command tests for new output format
- Enhance visual appeal of 'ggc help' and 'ggc' outputs