### PR TITLE
feat: add version command with dynamic build information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,12 @@ deps: install-tools
 	go mod tidy
 	@echo "Dependencies installed successfully"
 
+VERSION := $(shell git describe --tags --always --dirty)
+COMMIT := $(shell git rev-parse --short HEAD)
+DATE := $(shell date -u '+%Y-%m-%d_%H:%M:%S')
+
 build:
-	go build -o $(APP_NAME) main.go
+	go build -ldflags="-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o ggc
 
 run: build
 	./$(APP_NAME)

--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ ggc
 - `status` - Show the working tree status
   - `status short` - Show concise output (porcelain format)
 
+- `version` - Show the currently installed ggc version
+
 - `add-commit-push` - Add all changes, commit, and push in one command
 - `commit-push-interactive` - Commit and push interactively
 - `pull-rebase-push` - Pull with rebase and push in one command

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -22,6 +22,7 @@ type Executer interface {
 	Push(args []string)
 	Reset(args []string)
 	Diff(args []string)
+	Version(args []string)
 	Status(args []string)
 	Clean(args []string)
 	PullRebasePush()
@@ -45,7 +46,8 @@ type Cmd struct {
 	remoteer         *Remoteer
 	rebaser          *Rebaser
 	stasher          *Stasher
-    statuseer        *Statuseer
+	statuseer        *Statuseer
+	versioneer       *Versioneer
 	commitPusher     *CommitPusher
 	addCommitPusher  *AddCommitPusher
 	completer        *Completer
@@ -74,7 +76,8 @@ func NewCmd() *Cmd {
 		remoteer:         NewRemoteer(),
 		rebaser:          NewRebaser(),
 		stasher:          NewStasher(),
-        statuseer:        NewStatuseer(),
+		statuseer:        NewStatuseer(),
+		versioneer:       NewVersioneer(),
 		commitPusher:     NewCommitPusher(),
 		addCommitPusher:  NewAddCommitPusher(),
 		completer:        NewCompleter(),
@@ -113,6 +116,11 @@ func (c *Cmd) Status(args []string) {
 // Diff executes the diff command with the given arguments.
 func (c *Cmd) Diff(args []string) {
 	c.differ.Diff(args)
+}
+
+// Version executes the version command with the given arguments.
+func (c *Cmd) Version(args []string) {
+	c.versioneer.Version(args)
 }
 
 // Pull executes the pull command with the given arguments.
@@ -198,6 +206,8 @@ func (c *Cmd) Route(args []string) {
 		c.Reset(args[1:])
 	case "clean":
 		c.Clean(args[1:])
+	case "version":
+		c.Version(args[1:])
 	case "clean-interactive":
 		c.cleaner.CleanInteractive()
 	case "pull-rebase-push":

--- a/cmd/constructor_test.go
+++ b/cmd/constructor_test.go
@@ -181,6 +181,17 @@ func TestNewStatuseer(t *testing.T) {
 	}
 }
 
+func TestNewVersioneer(t *testing.T) {
+	versioneer := NewVersioneer()
+	if versioneer == nil {
+		t.Fatal("Expected Statuseer, got nil")
+	}
+	// Basic field checks
+	if versioneer.outputWriter == nil || versioneer.helper == nil || versioneer.execCommand == nil {
+		t.Error("Expected all fields to be initialized")
+	}
+}
+
 func TestNewStashPullPopper(t *testing.T) {
 	popper := NewStashPullPopper()
 	if popper == nil {
@@ -208,7 +219,7 @@ func TestNewCmd_Constructor(t *testing.T) {
 		cmd.remoteer == nil || cmd.rebaser == nil || cmd.stasher == nil ||
 		cmd.commitPusher == nil || cmd.addCommitPusher == nil || cmd.completer == nil ||
 		cmd.fetcher == nil || cmd.stashPullPopper == nil || cmd.resetCleaner == nil  ||
-        cmd.statuseer == nil || cmd.differ == nil {
+        cmd.statuseer == nil || cmd.differ == nil || cmd.versioneer == nil {
 		t.Error("Expected all command handlers to be initialized")
 	}
 }

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -163,6 +163,17 @@ func (h *Helper) ShowStatusHelp() {
 	})
 }
 
+// ShowVersionHelp shows help message for Version command.
+func (h *Helper) ShowVersionHelp() {
+	h.ShowCommandHelp(templates.HelpData{
+		Usage:       "ggc version",
+		Description: "Show current ggc version",
+		Examples: []string{
+			"ggc version           # Shows build time, latest commit and version number",
+		},
+	})
+}
+
 // ShowRebaseHelp shows help message for rebase command.
 func (h *Helper) ShowRebaseHelp() {
 	h.ShowCommandHelp(templates.HelpData{

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -34,6 +34,7 @@ var commands = []string{
 	"diff",
 	"diff unstaged",
 	"diff staged",
+	"version",
 	"clean files",
 	"clean dirs",
 	"clean-interactive",

--- a/cmd/templates/help.go
+++ b/cmd/templates/help.go
@@ -53,6 +53,7 @@ Main Commands:
   ggc remote add <n> <url>    Add remote
   ggc remote remove <n>       Remove remote
   ggc remote set-url <n> <url> Change remote URL
+  ggc version                 Show current ggc version
   ggc reset                   Reset and clean
   ggc reset-clean            Reset to HEAD and clean untracked files
   ggc stash                   Stash changes

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"runtime"
+	"os"
+	"os/exec"
+)
+
+// VersionGetter is a function type for getting version info
+type VersionGetter func() (version, commit, date string)
+
+var getVersionInfo VersionGetter
+
+// SetVersionGetter sets the version getter function
+func SetVersionGetter(getter VersionGetter) {
+	getVersionInfo = getter
+}
+
+// Versioneer handles status operations.
+type Versioneer struct {
+	outputWriter io.Writer
+	helper       *Helper
+	execCommand  func(string, ...string) *exec.Cmd
+}
+
+// NewVersioneer creates a new Versioneer instance.
+func NewVersioneer() *Versioneer {
+	return &Versioneer{
+		outputWriter: os.Stdout,
+		helper:       NewHelper(),
+		execCommand:  exec.Command,
+	}
+}
+
+// Version returns the ggc version with the given arguments.
+func (v *Versioneer) Version(args []string) {
+	if len(args) == 0 {
+		version, commit, date := "dev", "none", "unknown"
+		if getVersionInfo != nil {
+			version, commit, date = getVersionInfo()
+		}
+		_, _ = fmt.Fprintf(v.outputWriter, "ggc version %s\n", version)
+		_, _ = fmt.Fprintf(v.outputWriter, "commit: %s\n", commit)
+		_, _ = fmt.Fprintf(v.outputWriter, "built: %s\n", date)
+		_, _ = fmt.Fprintf(v.outputWriter, "os/arch: %s/%s\n", runtime.GOOS, runtime.GOARCH)
+	} else {
+		v.helper.ShowVersionHelp()
+		return
+	}
+}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,107 @@
+package cmd
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestVersioneer_Version(t *testing.T) {
+	cases := []struct {
+		name           string
+		args           []string
+		versionGetter  VersionGetter
+		expectedOutput []string
+	}{
+		{
+			name: "version no args with default values",
+			args: []string{},
+			versionGetter: nil,
+			expectedOutput: []string{
+				"ggc version dev",
+				"commit: none",
+				"built: unknown",
+				"os/arch:",
+			},
+		},
+		{
+			name: "version no args with custom version info",
+			args: []string{},
+			versionGetter: func() (version, commit, date string) {
+				return "v1.0.0", "abc123", "2024-01-01"
+			},
+			expectedOutput: []string{
+				"ggc version v1.0.0",
+				"commit: abc123",
+				"built: 2024-01-01",
+				"os/arch:",
+			},
+		},
+		{
+			name: "version with args shows help",
+			args: []string{"help"},
+			versionGetter: func() (version, commit, date string) {
+				return "v1.0.0", "abc123", "2024-01-01"
+			},
+			expectedOutput: []string{
+				"Usage:",
+			},
+		},
+		{
+			name: "version with multiple args shows help",
+			args: []string{"invalid", "args"},
+			versionGetter: nil,
+			expectedOutput: []string{
+				"Usage:",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			originalGetter := getVersionInfo
+			SetVersionGetter(tc.versionGetter)
+			defer SetVersionGetter(originalGetter)
+			
+			v := &Versioneer{
+				outputWriter: &buf,
+				helper:       NewHelper(),
+				execCommand:  exec.Command,
+			}
+			
+			v.helper.outputWriter = &buf
+			v.Version(tc.args)
+			
+			output := buf.String()
+			for _, expected := range tc.expectedOutput {
+				if !strings.Contains(output, expected) {
+					t.Errorf("expected output to contain %q, got %q", expected, output)
+				}
+			}
+		})
+	}
+}
+
+// Helper test to verify version getter functionality
+func TestSetVersionGetter(t *testing.T) {
+	originalGetter := getVersionInfo
+	defer SetVersionGetter(originalGetter)
+	
+	customGetter := func() (version, commit, date string) {
+		return "test-version", "test-commit", "test-date"
+	}
+	
+	SetVersionGetter(customGetter)
+	
+	if getVersionInfo == nil {
+		t.Error("expected getVersionInfo to be set")
+	}
+	
+	version, commit, date := getVersionInfo()
+	if version != "test-version" || commit != "test-commit" || date != "test-date" {
+		t.Errorf("expected version info (test-version, test-commit, test-date), got (%s, %s, %s)", 
+			version, commit, date)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -8,7 +8,19 @@ import (
 	"github.com/bmf-san/ggc/router"
 )
 
+var (
+	version string
+	commit  string
+	date    string
+)
+
+// GetVersionInfo returns the version information
+func GetVersionInfo() (string, string, string) {
+	return version, commit, date
+}
+
 func main() {
+	cmd.SetVersionGetter(GetVersionInfo)
 	c := cmd.NewCmd()
 	r := router.NewRouter(c)
 	r.Route(os.Args[1:])

--- a/router/router.go
+++ b/router/router.go
@@ -41,8 +41,10 @@ func (r *Router) Route(args []string) {
 		r.Executer.Reset(args[1:])
     case "diff":
 		r.Executer.Diff(args[1:])
-    case "status":
+	case "status":
 		r.Executer.Status(args[1:])
+	case "version":
+		r.Executer.Version(args[1:])
 	case "clean":
 		r.Executer.Clean(args[1:])
 	case "pull-rebase-push":

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -22,6 +22,8 @@ type mockExecuter struct {
 	pushArgs             []string
 	resetCalled          bool
 	resetArgs            []string
+	versionCalled        bool
+	versionArgs          []string
 	cleanCalled          bool
 	cleanArgs            []string
 	pullRebasePushCalled bool
@@ -50,6 +52,11 @@ func (m *mockExecuter) Log(args []string) {
 func (m *mockExecuter) Status(args []string) {
 	m.statusCalled = true
 	m.statusArgs = args
+}
+
+func (m *mockExecuter) Version(args []string) {
+	m.versionCalled = true
+	m.versionArgs = args
 }
 
 func (m *mockExecuter) Diff(args []string) {
@@ -190,6 +197,15 @@ func TestRouter(t *testing.T) {
 				}
 				if len(m.statusArgs) != 1 || m.statusArgs[0] != "short" {
 					t.Errorf("unexpected status args: got %v, expected [short]", m.statusArgs)
+				}
+			},
+		},
+		{
+			name: "version",
+			args: []string{"version"},
+			validate: func(t *testing.T, m *mockExecuter) {
+				if !m.versionCalled {
+					t.Error("Version should be called")
 				}
 			},
 		},

--- a/tools/completions/ggc.bash
+++ b/tools/completions/ggc.bash
@@ -6,7 +6,7 @@ _ggc()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    opts="add add-commit-push branch clean diff status clean-interactive commit commit-push-interactive complete fetch log pull pull-rebase-push push rebase remote reset reset-clean stash stash-pull-pop"
+    opts="add add-commit-push branch clean version diff status clean-interactive commit commit-push-interactive complete fetch log pull pull-rebase-push push rebase remote reset reset-clean stash stash-pull-pop"
 
     case ${prev} in
         branch)


### PR DESCRIPTION
Closes #33.
Adds version command invoked with `ggc version` with dynamic build information with the changes to the `Makefile` as suggested.

## Summary
- Add version variables and getter function in main.go
- Update Makefile with version injection via ldflags
- Implement Versioneer struct with Version() method
- Add version command to router with proper routing
- Add comprehensive tests with version_test.go
- Update help system and bash completions
- Add version command documentation