### PR TITLE
fix: add linting to the PR template and keep command format in README consistent

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,7 @@ Example: close #123
 - [ ] I have added or updated tests
 - [ ] I have updated the documentation (if required)
 - [ ] Code is formatted with `make fmt`
+- [ ] Code passes linter checks via `make lint`
 - [ ] All tests are passing
 
 ## Screenshots (if appropriate)

--- a/README.md
+++ b/README.md
@@ -188,16 +188,16 @@ ggc
 - `reset` - Reset and clean
   - `reset-clean` - Reset to HEAD and clean untracked files and directories
 
-- `ggc tag` - List all tags
-    - `ggc tag list` - List all tags (sorted)
-        - `ggc tag list v1.*` - List tags matching pattern
-    - `ggc tag create v1.0.0` - Create tag
-        - `ggc tag create v1.0.0 abc123` - Tag specific commit
-    - `ggc tag annotated v1.0.0 'Release notes'` - Create annotated tag
-    - `ggc tag delete v1.0.0` - Delete tag
-    - `ggc tag push` - Push all tags to origin
-        - `ggc tag push v1.0.0` - Push specific tag
-    - `ggc tag show v1.0.0` - Show tag information
+- `tag` - List all tags
+    - `tag list` - List all tags (sorted)
+        - `tag list v1.*` - List tags matching pattern
+    - `tag create v1.0.0` - Create tag
+        - `tag create v1.0.0 abc123` - Tag specific commit
+    - `tag annotated v1.0.0 'Release notes'` - Create annotated tag
+    - `tag delete v1.0.0` - Delete tag
+    - `tag push` - Push all tags to origin
+        - `tag push v1.0.0` - Push specific tag
+    - `tag show v1.0.0` - Show tag information
 
 - `stash` - Stash changes
   - `stash` - Stash current changes


### PR DESCRIPTION
## Description of Changes
This PR fixes the command format to be consistent in the README and adds linting to the PR template checklist.

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/ggc-dev/ggc/blob/main/CONTRIBUTING.md)
- [ ] I have added or updated tests
- [x] I have updated the documentation (if required)
- [ ] Code is formatted with `make fmt`
- [ ] All tests are passing