### PR TITLE
fix: ensure version info in build, add fast build commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 APP_NAME=ggc
 OUT?=coverage.out
 
-.PHONY: install-tools deps build run test lint clean cover test-cover test-and-lint
+.PHONY: install-tools deps build build-fast run run-fast test lint clean cover test-cover test-and-lint fmt
 
 # Install required tools
 install-tools:
@@ -18,10 +18,23 @@ deps: install-tools
 	go mod tidy
 	@echo "Dependencies installed successfully"
 
+# Build variables
+VERSION := $(shell git describe --tags --always --dirty)
+COMMIT := $(shell git rev-parse --short HEAD)
+DATE := $(shell date -u '+%Y-%m-%d_%H:%M:%S')
+
+# Full build with version info
 build:
-	go build -o ggc
+	go build -ldflags="-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o $(APP_NAME)
+
+# Fast build for development (no version info, faster compilation)
+build-fast:
+	go build -o $(APP_NAME) main.go
 
 run: build
+	./$(APP_NAME)
+
+run-fast: build-fast
 	./$(APP_NAME)
 
 fmt:

--- a/README.md
+++ b/README.md
@@ -93,6 +93,18 @@ make cover
 
 # Run tests and lint
 make test-and-lint
+
+# Full build with version info (for releases)
+make build
+
+# Fast build for development (no version info, faster compilation)
+make build-fast
+
+# Build and run with version info
+make run
+
+# Fast build and run for development
+make run-fast
 ```
 
 The Makefile will automatically install required tools like `golangci-lint` using `go install`.


### PR DESCRIPTION
This PR fixes the bug when building `ggc` with `make build`, `ggc version` not showing the version, commit and date variables in it's output.

## Summary
- Add version, commit, and date variables to full build using ldflags
- Fix 'ggc version' command showing no info on regular build
- Add build-fast target for development without version overhead
- Add run-fast target for quick development cycles
- Update .PHONY targets and README documentation

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/ggc-dev/ggc/blob/main/CONTRIBUTING.md)
- [ ] I have added or updated tests
- [x] I have updated the documentation (if required)
- [ ] Code is formatted with `make fmt`
- [ ] Code passes linter checks via `make lint`
- [ ] All tests are passing

## Additional Information
The regular build now includes proper version information while `build-fast` and `run-fast` provides a quicker option for development iterations.