### PR TITLE
fix: update version.go, fix err codes and update to work with ldflags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ go.work.sum
 
 # ggc
 ggc
+
+# Compiled binaries from goreleaser
+dist/

--- a/.go_releaser.yml
+++ b/.go_releaser.yml
@@ -9,7 +9,7 @@ builds:
       - amd64
       - arm64
     ldflags:
-      - -s -w -X main.version={{.Version}}
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}}
 
 archives:
   - format: tar.gz

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,12 @@ deps: install-tools
 	go mod tidy
 	@echo "Dependencies installed successfully"
 
+VERSION := $(shell git describe --tags --always --dirty)
+COMMIT := $(shell git rev-parse --short HEAD)
+
+# Full build with version info
 build:
-	go build -o $(APP_NAME) main.go
+	go build -ldflags="-X main.version=${VERSION} -X main.commit=${COMMIT}" -o $(APP_NAME)
 
 run: build
 	./$(APP_NAME)

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ chmod +x install.sh
 The script will:
 - Detect your operating system and architecture
 - Download the appropriate binary for your system
-- Install using `go install`, manual install fallback
+- Install using `git`, manual `go install` fallback
 - Verify the installation
 
 ### Build with make
@@ -112,6 +112,9 @@ go install github.com/bmf-san/ggc@latest
 - The `ggc` binary will be installed to `$GOBIN` (usually `$HOME/go/bin`).
 - If `$GOBIN` is in your `PATH`, you can use `ggc` from anywhere.
 - If not, add it to your `PATH`:
+
+> [!NOTE]
+> When using `go install`, you may get limited version info due to `ldflags` not working with `go install`. It is recommended to build with make build or use the install script or binaries.
 
 ```sh
 export PATH=$PATH:$(go env GOBIN)

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -14,8 +14,8 @@ func TestVersioneer_Version(t *testing.T) {
 		expectedOutput []string
 	}{
 		{
-			name:          "version no args with default values",
-			args:          []string{},
+			name: "version no args with default values",
+			args: []string{},
 			expectedOutput: []string{
 				"ggc version",
 				"commit:",
@@ -41,8 +41,8 @@ func TestVersioneer_Version(t *testing.T) {
 			},
 		},
 		{
-			name:          "version with multiple args shows help",
-			args:          []string{"invalid", "args"},
+			name: "version with multiple args shows help",
+			args: []string{"invalid", "args"},
 			expectedOutput: []string{
 				"Usage:",
 			},

--- a/config/config.go
+++ b/config/config.go
@@ -15,9 +15,9 @@ import (
 // Config represents the complete configuration structure
 type Config struct {
 	Meta struct {
-		Version    string `yaml:"version"`
-		Commit     string `yaml:"commit"`
-		CreatedAt  string `yaml:"created-at"`
+		Version       string `yaml:"version"`
+		Commit        string `yaml:"commit"`
+		CreatedAt     string `yaml:"created-at"`
 		ConfigVersion string `yaml:"config-version"`
 	} `yaml:"meta"`
 
@@ -66,27 +66,25 @@ func NewConfigManager() *Manager {
 }
 
 func getGitVersion() string {
-    cmd := exec.Command("git", "describe", "--tags", "--always", "--dirty")
-    output, err := cmd.Output()
-    if err != nil {
-		fmt.Println(err)
-        return "dev"
-    }
-    return strings.TrimSpace(string(output))
+	cmd := exec.Command("git", "describe", "--tags", "--always", "--dirty")
+	output, err := cmd.Output()
+	if err != nil {
+		return "dev"
+	}
+	return strings.TrimSpace(string(output))
 }
 
 func getGitCommit() string {
-    cmd := exec.Command("git", "rev-parse", "--short", "HEAD")
-    output, err := cmd.Output()
-    if err != nil {
-		fmt.Println(err)
-        return "unknown"
-    }
-    return strings.TrimSpace(string(output))
+	cmd := exec.Command("git", "rev-parse", "--short", "HEAD")
+	output, err := cmd.Output()
+	if err != nil {
+		return "unknown"
+	}
+	return strings.TrimSpace(string(output))
 }
 
 func (c *Config) updateMeta() {
-	version, commit  := getGitVersion(), getGitCommit()
+	version, commit := getGitVersion(), getGitCommit()
 
 	c.Meta.Version = version
 	c.Meta.Commit = commit

--- a/main.go
+++ b/main.go
@@ -9,8 +9,19 @@ import (
 	"github.com/bmf-san/ggc/router"
 )
 
+var (
+	version string
+	commit  string
+)
+
+// GetVersionInfo returns the version information
+func GetVersionInfo() (string, string) {
+	return version, commit
+}
+
 func main() {
 	config.NewConfigManager().LoadConfig()
+	cmd.SetVersionGetter(GetVersionInfo)
 	c := cmd.NewCmd()
 	r := router.NewRouter(c)
 	r.Route(os.Args[1:])


### PR DESCRIPTION
## Description of Changes
Fixes the bug where `ggc version` isn't showing enough information even after the updates. 

## Reproduction
Compile the `ggc` file,  inside the `ggc` directory, there is a valid `.git` folder, so it should not error. If you compile with `goreleaser build --snapshot --clean` then `mv ggc ~/` and `cd ~/ && ./ggc version` then the version returns:
```bash
exit status 128
exit status 128
exit status 128
exit status 128
exit status 128
exit status 128
ggc version dev
commit: unknown
built: 2025-07-14_18:49:43
config version: 1.0
os/arch: darwin/arm64
``` 

To fix this, I added allowing `ldflags` as versioning too, added it to the `goreleaser` yml file and allowed falling back if needed to `git rev-parse`'ing as a backup. It still uses the `~/.ggcconfig.yaml` file but can run from anywhere. 

Note that however, installing with:
```bash
go install github.com/bmf-san/ggc@latest
```
does **NOT** compile with `ldflags` and will therefore return limited version info. This solution combines both my first and second idea and fixes the bug with `exit status 128` showing.

## Related Issue
Closes #68.

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/ggc-dev/ggc/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests
- [x] I have updated the documentation (if required)
- [x] Code is formatted with `make fmt`
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing
