### PR TITLE
chore: remove unused error variables from git/errors.go

### DIFF
--- a/git/errors.go
+++ b/git/errors.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"errors"
 	"fmt"
 )
 
@@ -27,10 +26,3 @@ func NewError(op string, command string, err error) error {
 		Err:     err,
 	}
 }
-
-var (
-	// ErrCleanFiles is returned when cleaning files fails.
-	ErrCleanFiles = errors.New("failed to clean files")
-	// ErrCleanDirs is returned when cleaning directories fails.
-	ErrCleanDirs = errors.New("failed to clean directories")
-)


### PR DESCRIPTION
## Description of Changes
This PR removes two unused error variables `ErrCleanFiles` and `ErrCleanDirs` from `git/errors.go`. These variables were originally introduced as part of earlier error-handling improvements but are no longer referenced anywhere in the codebase. This cleanup improves code readability and maintainability by removing dead code.

## Related Issue
Closes #76.

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/ggc-dev/ggc/blob/main/CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated the documentation (if required)
- [x] Code is formatted with `make fmt`
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing

## Additional Context
These error variables were added in #17 but have remained unused since then. Removing them aligns with the current error-handling approach and avoids confusion for future contributors.
