### PR TITLE
refactor: use NewError for consistent error handling in git package

### DIFF
--- a/git/pull.go
+++ b/git/pull.go
@@ -1,6 +1,11 @@
 // Package git provides a high-level interface to git commands.
 package git
 
+import (
+	"fmt"
+	"strings"
+)
+
 // Pull pulls from a remote.
 func (c *Client) Pull(rebase bool) error {
 	args := []string{"pull"}
@@ -8,5 +13,8 @@ func (c *Client) Pull(rebase bool) error {
 		args = append(args, "--rebase")
 	}
 	cmd := c.execCommand("git", args...)
-	return cmd.Run()
+	if err := cmd.Run(); err != nil {
+		return NewError("pull", fmt.Sprintf("git %s", strings.Join(args, " ")), err)
+	}
+	return nil
 }

--- a/git/push.go
+++ b/git/push.go
@@ -1,16 +1,24 @@
 // Package git provides a high-level interface to git commands.
 package git
 
+import (
+	"fmt"
+	"strings"
+)
+
 // Push pushes to a remote.
 func (c *Client) Push(force bool) error {
 	branch, err := c.GetCurrentBranch()
 	if err != nil {
-		return err
+		return NewError("push", "get current branch", err)
 	}
 	args := []string{"push", "origin", branch}
 	if force {
 		args = append(args, "--force-with-lease")
 	}
 	cmd := c.execCommand("git", args...)
-	return cmd.Run()
+	if err := cmd.Run(); err != nil {
+		return NewError("push", fmt.Sprintf("git %s", strings.Join(args, " ")), err)
+	}
+	return nil
 }

--- a/git/reset.go
+++ b/git/reset.go
@@ -5,11 +5,14 @@ package git
 func (c *Client) ResetHardAndClean() error {
 	branch, err := c.GetCurrentBranch()
 	if err != nil {
-		return err
+		return NewError("reset hard and clean", "get current branch", err)
 	}
 	cmd := c.execCommand("git", "reset", "--hard", "origin/"+branch)
 	if err := cmd.Run(); err != nil {
-		return err
+		return NewError("reset hard and clean", "git reset --hard origin/"+branch, err)
 	}
-	return c.CleanDirs()
+	if err := c.CleanDirs(); err != nil {
+		return NewError("reset hard and clean", "clean directories", err)
+	}
+	return nil
 }


### PR DESCRIPTION
## Description of Changes
- Replaces raw error in `git/pull.go`, `git/push.go`, and `git/reset.go` with `NewError`

## Related Issue
Closes #76.

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/ggc-dev/ggc/blob/main/CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated the documentation (if required)
- [x] Code is formatted with `make fmt`
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing

## Additional Context
This change improves context in error messages, making debugging easier and aligning with the project's error-handling conventions introduced in PR #17.