### PR TITLE
feat: add native Zsh completion script

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,8 +240,8 @@ fi
 ### Zsh
 Add the following to your `~/.zshrc`:
 ```zsh
-if [ -f "$(go env GOPATH)/pkg/mod/github.com/bmf-san/ggc@*/tools/completions/ggc.bash" ]; then
-  . "$(go env GOPATH)"/pkg/mod/github.com/bmf-san/ggc@*/tools/completions/ggc.bash
+if [ -f "$(go env GOPATH)/pkg/mod/github.com/bmf-san/ggc@*/tools/completions/ggc.zsh" ]; then
+  . "$(go env GOPATH)"/pkg/mod/github.com/bmf-san/ggc@*/tools/completions/ggc.zsh
 fi
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -232,36 +232,69 @@ setup_shell_completion() {
     local current_shell
     current_shell=$(basename "$SHELL" 2>/dev/null || echo "unknown")
 
-	local completion_line
-	completion_line=$(cat <<-'EOF'
-	# ggc completion loader
-	load_ggc_completion() {
-		local gopath completion_file
-		gopath=$(go env GOPATH 2>/dev/null)
-		if [ -z "$gopath" ]; then
-			return 1
-		fi
+    local bash_completion_line
+    bash_completion_line=$(cat <<-'EOF'
+# ggc completion loader
+load_ggc_completion() {
+	local gopath completion_file
+	gopath=$(go env GOPATH 2>/dev/null)
+	if [ -z "$gopath" ]; then
+		return 1
+	fi
 
-		for completion_file in "$gopath"/pkg/mod/github.com/bmf-san/ggc@*/tools/completions/ggc.bash; do
-			if [ -f "$completion_file" ]; then
-				source "$completion_file"
-				return 0
-			fi
-		done
-
-		completion_file=$(find "$gopath/pkg/mod/github.com/bmf-san" -name "ggc.bash" -path "*/tools/completions/*" 2>/dev/null | head -1)
-		if [ -n "$completion_file" ] && [ -f "$completion_file" ]; then
+	for completion_file in "$gopath"/pkg/mod/github.com/bmf-san/ggc@*/tools/completions/ggc.bash; do
+		if [ -f "$completion_file" ]; then
 			source "$completion_file"
 			return 0
 		fi
+	done
 
-		return 1
-	}
-
-	# Load completion if go is available
-	if command -v go >/dev/null 2>&1; then
-		load_ggc_completion
+	completion_file=$(find "$gopath/pkg/mod/github.com/bmf-san" -name "ggc.bash" -path "*/tools/completions/*" 2>/dev/null | head -1)
+	if [ -n "$completion_file" ] && [ -f "$completion_file" ]; then
+		source "$completion_file"
+		return 0
 	fi
+
+	return 1
+}
+
+# Load completion if go is available
+if command -v go >/dev/null 2>&1; then
+	load_ggc_completion
+fi
+EOF
+)
+
+    local zsh_completion_line
+    zsh_completion_line=$(cat <<-'EOF'
+# ggc completion loader for zsh
+load_ggc_completion() {
+	local gopath completion_file
+	gopath=$(go env GOPATH 2>/dev/null)
+	if [ -z "$gopath" ]; then
+		return 1
+	fi
+
+	for completion_file in "$gopath"/pkg/mod/github.com/bmf-san/ggc@*/tools/completions/ggc.zsh; do
+		if [ -f "$completion_file" ]; then
+			source "$completion_file"
+			return 0
+		fi
+	done
+
+	completion_file=$(find "$gopath/pkg/mod/github.com/bmf-san" -name "ggc.zsh" -path "*/tools/completions/*" 2>/dev/null | head -1)
+	if [ -n "$completion_file" ] && [ -f "$completion_file" ]; then
+		source "$completion_file"
+		return 0
+	fi
+
+	return 1
+}
+
+# Load completion if go is available
+if command -v go >/dev/null 2>&1; then
+	load_ggc_completion
+fi
 EOF
 )
     
@@ -279,7 +312,7 @@ EOF
             if [ -f "$bash_profile" ]; then
                 if ! grep -q "load_ggc_completion" "$bash_profile"; then
                     echo "" >> "$bash_profile"
-                    echo "$completion_line" >> "$bash_profile"
+                    echo "$bash_completion_line" >> "$bash_profile"
                     print_success "Added ggc completion to $bash_profile"
                     print_info "Restart your terminal or run 'source $bash_profile' to enable completion"
                 else
@@ -287,7 +320,7 @@ EOF
                 fi
             else
                 print_warning "Could not find $bash_profile. Please add the following manually:"
-                echo "$completion_line"
+                echo "$bash_completion_line"
             fi
             ;;
         zsh)
@@ -295,7 +328,7 @@ EOF
             if [ -f "$zsh_profile" ]; then
                 if ! grep -q "load_ggc_completion" "$zsh_profile"; then
                     echo "" >> "$zsh_profile"
-                    echo "$completion_line" >> "$zsh_profile"
+                    echo "$zsh_completion_line" >> "$zsh_profile"
                     print_success "Added ggc completion to $zsh_profile"
                     print_info "Restart your terminal or run 'source $zsh_profile' to enable completion"
                 else
@@ -303,7 +336,7 @@ EOF
                 fi
             else
                 print_warning "Could not find $zsh_profile. Please add the following manually:"
-                echo "$completion_line"
+                echo "$zsh_completion_line"
             fi
             ;;
         fish)
@@ -313,13 +346,8 @@ EOF
             ;;
         *)
             print_info "Shell completion setup for $current_shell not automated."
-            print_info "To enable shell completion, add the following to your shell profile:"
-            echo ""
-            echo "For Bash (~/.bashrc or ~/.bash_profile):"
-            echo "$completion_line"
-            echo ""
-            echo "For Zsh (~/.zshrc):"
-            echo "$completion_line"
+            print_info "To enable shell completion, run this ggc command and add the output to your shell profile:"
+            echo "ggc completion $current_shell"
             ;;
     esac
 }

--- a/tools/completions/ggc.zsh
+++ b/tools/completions/ggc.zsh
@@ -1,0 +1,259 @@
+#compdef ggc
+
+_ggc() {
+    local context state line
+    typeset -A opt_args
+
+    _arguments -C \
+        '1: :_ggc_commands' \
+        '*::arg:->args'
+
+    case $state in
+        args)
+            case $line[1] in
+                branch)
+                    _ggc_branch
+                    ;;
+                commit)
+                    _ggc_commit
+                    ;;
+                push)
+                    _ggc_push
+                    ;;
+                pull)
+                    _ggc_pull
+                    ;;
+                hook)
+                    _ggc_hook
+                    ;;
+                status)
+                    _ggc_status
+                    ;;
+                diff)
+                    _ggc_diff
+                    ;;
+                log)
+                    _ggc_log
+                    ;;
+                clean)
+                    _ggc_clean
+                    ;;
+                complete)
+                    _ggc_complete
+                    ;;
+                remote)
+                    _ggc_remote
+                    ;;
+                fetch)
+                    _ggc_fetch
+                    ;;
+                tag)
+                    _ggc_tag
+                    ;;
+                config)
+                    _ggc_config
+                    ;;
+                add)
+                    _ggc_add
+                    ;;
+            esac
+            ;;
+    esac
+}
+
+_ggc_commands() {
+    local commands
+    commands=(
+        'add:Add files to staging area'
+        'branch:Branch operations'
+        'clean:Clean working directory'
+        'version:Show version information'
+        'config:Configuration management'
+        'hook:Git hook management'
+        'diff:Show differences'
+        'status:Show repository status'
+        'clean-interactive:Interactive clean'
+        'commit:Create commits'
+        'complete:Shell completion'
+        'tag:Tag management'
+        'fetch:Fetch from remote'
+        'log:Show commit history'
+        'pull:Pull from remote'
+        'push:Push to remote'
+        'rebase:Rebase commits'
+        'remote:Remote repository management'
+        'reset:Reset changes'
+        'stash:Stash changes'
+    )
+    _describe 'commands' commands
+}
+
+_ggc_branch() {
+    local subcommands
+    subcommands=(
+        'current:Show current branch'
+        'checkout:Switch to branch'
+        'checkout-remote:Checkout remote branch'
+        'delete:Delete branch'
+        'delete-merged:Delete merged branches'
+        'list-local:List local branches'
+        'list-remote:List remote branches'
+    )
+    
+    if [[ $CURRENT == 2 ]]; then
+        _describe 'branch subcommands' subcommands
+    elif [[ $words[2] == "checkout" && $CURRENT == 3 ]]; then
+        # Dynamic completion for branch checkout
+        local branches
+        branches=(${(f)"$(ggc __complete branch 2>/dev/null)"})
+        _describe 'branches' branches
+    fi
+}
+
+_ggc_commit() {
+    local subcommands
+    subcommands=(
+        'allow-empty:Allow empty commit'
+        'tmp:Create temporary commit'
+        'amend:Amend last commit'
+    )
+    
+    if [[ $CURRENT == 2 ]]; then
+        _describe 'commit subcommands' subcommands
+    elif [[ $words[2] == "amend" && $CURRENT == 3 ]]; then
+        local options
+        options=(
+            '--no-edit:Do not edit commit message'
+        )
+        _describe 'amend options' options
+    fi
+}
+
+_ggc_status() {
+    local options=(
+        'short:Show short status'
+    )
+    _describe 'status options' options
+}
+
+_ggc_push() {
+    local subcommands
+    subcommands=(
+        'current:Push current branch'
+        'force:Force push'
+    )
+    _describe 'push subcommands' subcommands
+}
+
+_ggc_diff() {
+    local subcommands
+    subcommands=(
+        'staged:Diff only staged changes'
+        'unstaged:Diff only unstaged changes'
+    )
+    _describe 'diff subcommands' subcommands
+}
+
+_ggc_pull() {
+    local subcommands
+    subcommands=(
+        'current:Pull current branch'
+        'rebase:Pull with rebase'
+    )
+    _describe 'pull subcommands' subcommands
+}
+
+_ggc_hook() {
+    local subcommands
+    subcommands=(
+        'list:List hooks'
+        'edit:Edit hook'
+        'install:Install hook'
+        'uninstall:Uninstall hook'
+        'enable:Enable hook'
+        'disable:Disable hook'
+    )
+    _describe 'hook subcommands' subcommands
+}
+
+_ggc_log() {
+    local subcommands
+    subcommands=(
+        'simple:Simple log format'
+        'graph:Graph log format'
+    )
+    _describe 'log subcommands' subcommands
+}
+
+_ggc_clean() {
+    local subcommands
+    subcommands=(
+        'files:Clean files'
+        'dirs:Clean directories'
+    )
+    _describe 'clean subcommands' subcommands
+}
+
+_ggc_complete() {
+    local subcommands
+    subcommands=(
+        'bash:Generate bash completion'
+        'zsh:Generate zsh completion'
+    )
+    _describe 'completion shells' subcommands
+}
+
+_ggc_remote() {
+    local subcommands
+    subcommands=(
+        'list:List remotes'
+        'add:Add remote'
+        'remove:Remove remote'
+        'set-url:Set remote URL'
+    )
+    _describe 'remote subcommands' subcommands
+}
+
+_ggc_fetch() {
+    local options
+    options=(
+        '--prune:Prune remote branches'
+    )
+    _describe 'fetch options' options
+}
+
+_ggc_tag() {
+    local subcommands
+    subcommands=(
+        'create:Create tag'
+        'delete:Delete tag'
+        'show:Show tag'
+        'list:List tags'
+        'annotated:Create annotated tag'
+        'push:Push tags'
+    )
+    _describe 'tag subcommands' subcommands
+}
+
+_ggc_config() {
+    local subcommands
+    subcommands=(
+        'list:List configuration'
+        'set:Set configuration value'
+        'get:Get configuration value'
+    )
+    _describe 'config subcommands' subcommands
+}
+
+_ggc_add() {
+    # Dynamic completion for add - get files from ggc
+    local files
+    files=(${(f)"$(ggc __complete files 2>/dev/null)"})
+    if [[ ${#files[@]} -gt 0 ]]; then
+        _describe 'files' files
+    else
+        _files
+    fi
+}
+
+compdef _ggc ggc


### PR DESCRIPTION
This PR adds a native Zsh shell completion script to `tools/completions`.

## Summary
- Adds a dedicated Zsh completion script at tools/completions/ggc.zsh
- Updates README.md to install script for zsh users
- Update install script to automatically install zsh completion for zsh users

## Related Issue
Closes #79.

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/ggc-dev/ggc/blob/main/CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated the documentation (if required)
- [x] Code is formatted with `make fmt`
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing

## Screenshots (if appropriate)
N/A

## Additional Context
This improves the user experience for `Zsh` users by providing native completion for `ggc` commands and subcommands. It replaces the need to rely on `Bash` compatibility mode, enabling context-aware and more reliable completions.
