### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Test
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: macos-latest


### PR DESCRIPTION
Potential fix for [https://github.com/bmf-san/ggc/security/code-scanning/1](https://github.com/bmf-san/ggc/security/code-scanning/1)

To address the issue, we will add a `permissions` block at the root level of the workflow. This block will explicitly define the minimal set of permissions required for the workflow to execute properly. Based on the tasks in the workflow:
1. The `contents: read` permission is required for actions like `actions/checkout` to fetch the repository content.
2. The `contents: write` permission is not needed, as no step modifies the repository contents.
3. The `pull-requests: write` permission is unnecessary unless interacting directly with pull requests, which this workflow does not do.

The `permissions` will be set to `contents: read`, which adheres to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
