### PR TITLE
fix: handle help request before git operations in status command

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -67,14 +67,6 @@ func (s *Statuseer) getUpstreamStatus(branch string) string {
 
 // Status executes git status with the given arguments.
 func (s *Statuseer) Status(args []string) {
-	branch, err := s.gitClient.GetCurrentBranch()
-	if err != nil {
-		_, _ = fmt.Fprintf(s.outputWriter, "Error getting current branch: %v\n", err)
-		return
-	}
-
-	upstreamStatus := s.getUpstreamStatus(branch)
-
 	var cmd *exec.Cmd
 	if len(args) == 0 {
 		// Add '-c color.status=always' to ensure colour showing up in 'less'
@@ -88,6 +80,13 @@ func (s *Statuseer) Status(args []string) {
 			return
 		}
 	}
+
+	branch, err := s.gitClient.GetCurrentBranch()
+	if err != nil {
+		_, _ = fmt.Fprintf(s.outputWriter, "Error getting current branch: %v\n", err)
+		return
+	}
+	upstreamStatus := s.getUpstreamStatus(branch)
 
 	if _, err := exec.LookPath("less"); err != nil {
 		// Fallback: If 'less' is not available, direct output to outputWriter

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -119,8 +119,7 @@ func TestStatuseer_Status(t *testing.T) {
 		{
 			name: "status no args",
 			args: []string{},
-			expectedCmds: []string{"git rev-parse --abbrev-ref main@{upstream}", "git rev-list --left-right --count main...On branch main\nChanges not staged for commit:\n  modified:   modified_file.go\n\nUntracked files:\n  untracked_file.go",
-				"git -c color.status=always status"},
+			expectedCmds: []string{"git -c color.status=always status", "git rev-parse --abbrev-ref main@{upstream}", "git rev-list --left-right --count main...On branch main\nChanges not staged for commit:\n  modified:   modified_file.go\n\nUntracked files:\n  untracked_file.go"},
 			mockOutput:     []byte("On branch main\nChanges not staged for commit:\n  modified:   modified_file.go\n\nUntracked files:\n  untracked_file.go\n"),
 			mockError:      nil,
 			expectedOutput: "On branch main",
@@ -128,8 +127,7 @@ func TestStatuseer_Status(t *testing.T) {
 		{
 			name: "status short",
 			args: []string{"short"},
-			expectedCmds: []string{"git rev-parse --abbrev-ref main@{upstream}", "git rev-list --left-right --count main...M  modified_file.go\n?? untracked_file.go",
-				"git -c color.status=always status --short"},
+			expectedCmds: []string{"git -c color.status=always status --short", "git rev-parse --abbrev-ref main@{upstream}", "git rev-list --left-right --count main...M  modified_file.go\n?? untracked_file.go"},
 			mockOutput:     []byte("M  modified_file.go\n?? untracked_file.go\n"),
 			mockError:      nil,
 			expectedOutput: "M  modified_file.go",


### PR DESCRIPTION
## Description of Changes
This PR fixes the bug in #85 where running `ggc status help` would fail only if you were not in a git directory due to logic structure in `cmd/status.go`.

## Related Issue
Closes #85.

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/ggc-dev/ggc/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests
- [ ] I have updated the documentation (if required)
- [x] Code is formatted with `make fmt`
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing

## Screenshots (if appropriate)
N/A
