### PR TITLE
Add CI, CodeQL, and Dependabot status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 [![GitHub license](https://img.shields.io/github/license/bmf-san/ggc)](https://github.com/bmf-san/ggc/blob/main/LICENSE)
 [![Go Reference](https://pkg.go.dev/badge/github.com/bmf-san/ggc.svg)](https://pkg.go.dev/github.com/bmf-san/ggc)
 [![Sourcegraph](https://sourcegraph.com/github.com/bmf-san/ggc/-/badge.svg)](https://sourcegraph.com/github.com/bmf-san/ggc?badge)
+[![CI](https://github.com/bmf-san/ggc/actions/workflows/ci.yml/badge.svg)](https://github.com/bmf-san/ggc/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/bmf-san/ggc/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/bmf-san/ggc/actions/workflows/github-code-scanning/codeql)
+[![Dependabot Updates](https://github.com/bmf-san/ggc/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/bmf-san/ggc/actions/workflows/dependabot/dependabot-updates)
 
 
 A Go Git CLI.


### PR DESCRIPTION
## Description of Changes
Added three status badges to the top of the `README.md` file:
- ✅ CI status (GitHub Actions)
- 🔒 CodeQL analysis
- 📦 Dependabot updates
These badges help contributors and users quickly understand the current build, security, and dependency status of the project.

## Related Issue
N/A

## Checklist
- [ x] I have read the [CONTRIBUTING.md](https://github.com/ggc-dev/ggc/blob/main/CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ x] I have updated the documentation (if required)
- [ ] Code is formatted with `make fmt`
- [ ] Code passes linter checks via `make lint`
- [ ] All tests are passing

## Screenshots (if appropriate)
<img width="1467" height="543" alt="change_in_readme" src="https://github.com/user-attachments/assets/355a83b0-6456-4213-a91e-11ee5923d652" />

## Additional Context
Happy to adjust the position or style of the badges, or add more if needed. Let me know if you'd like to include things like Go version, license, or coverage badges.
