### PR TITLE
feat: add support for `ggc restore` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,11 @@ ggc
 | `hook disable <hook>` | Disable a hook |
 | `hook uninstall <hook>` | Remove a hook |
 | `hook edit <hook>` | Edit a hook |
+| `restore <file>` | Restore file in working directory from index
+| `restore .` | Restore all files in working directory from index
+| `restore staged <file>` | Unstage file (restore from HEAD to index)
+| `restore staged .` | Unstage all files
+| `restore <commit> <file>` | Restore file from specific commit
 | `tag list` | List all tags |
 | `tag create <v>` | Create a tag |
 | `tag annotated <v> <msg>` | Create annotated tag |
@@ -271,6 +276,7 @@ Below are the Git commands that ggc wraps, along with links to their official do
 ### File Operations
 - [`git add`](https://git-scm.com/docs/git-add) - Add file contents to the index
 - [`git clean`](https://git-scm.com/docs/git-clean) - Remove untracked files from the working tree
+- [`git restore`](https://git-scm.com/docs/git-restore) - Restore files in the working tree
 
 ### Branch Operations
 - [`git branch`](https://git-scm.com/docs/git-branch) - List, create, or delete branches

--- a/cmd/branch_test.go
+++ b/cmd/branch_test.go
@@ -38,7 +38,28 @@ func (m *mockBranchGitClient) ListRemoteBranches() ([]string, error) {
 	return []string{"origin/main", "origin/feature/test"}, nil
 }
 
+// define other functions as nil except branch testing ones
 func (m *mockBranchGitClient) LogGraph() error {
+	return nil
+}
+
+func (m *mockBranchGitClient) RestoreAll() error {
+	return nil
+}
+
+func (m *mockBranchGitClient) RestoreAllStaged() error {
+	return nil
+}
+
+func (m *mockBranchGitClient) RestoreStaged(...string) error {
+	return nil
+}
+
+func (m *mockBranchGitClient) RestoreWorkingDir(...string) error {
+	return nil
+}
+
+func (m *mockBranchGitClient) RestoreFromCommit(string, ...string) error {
 	return nil
 }
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -28,6 +28,7 @@ type Executer interface {
 	Status(args []string)
 	Tag(args []string)
 	Clean(args []string)
+	Restore(args []string)
 	Interactive()
 }
 
@@ -54,6 +55,7 @@ type Cmd struct {
 	versioneer   *Versioneer
 	completer    *Completer
 	differ       *Differ
+	restoreer    *Restoreer
 	fetcher      *Fetcher
 }
 
@@ -82,6 +84,7 @@ func NewCmd() *Cmd {
 		versioneer:   NewVersioneer(),
 		completer:    NewCompleter(),
 		differ:       NewDiffer(),
+		restoreer:    NewRestoreer(),
 		fetcher:      NewFetcher(),
 	}
 }
@@ -129,6 +132,11 @@ func (c *Cmd) Tag(args []string) {
 // Diff executes the diff command with the given arguments.
 func (c *Cmd) Diff(args []string) {
 	c.differ.Diff(args)
+}
+
+// Restore executes the restore command with the given arguments.
+func (c *Cmd) Restore(args []string) {
+	c.restoreer.Restore(args)
 }
 
 // Version executes the version command with the given arguments.
@@ -238,6 +246,8 @@ func (c *Cmd) Route(args []string) {
 		c.fetcher.Fetch(args[1:])
 	case "diff":
 		c.differ.Diff(args[1:])
+	case "restore":
+		c.restoreer.Restore(args[1:])
 	default:
 		c.Help()
 	}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -100,6 +100,26 @@ func (m *mockGitClient) CheckoutNewBranch(_ string) error {
 	return nil
 }
 
+func (m *mockGitClient) RestoreAll() error {
+	return nil
+}
+
+func (m *mockGitClient) RestoreAllStaged() error {
+	return nil
+}
+
+func (m *mockGitClient) RestoreStaged(...string) error {
+	return nil
+}
+
+func (m *mockGitClient) RestoreWorkingDir(...string) error {
+	return nil
+}
+
+func (m *mockGitClient) RestoreFromCommit(string, ...string) error {
+	return nil
+}
+
 type mockCmdGitClient struct {
 	git.Clienter
 	pullCalled bool

--- a/cmd/complete_test.go
+++ b/cmd/complete_test.go
@@ -21,24 +21,29 @@ func (m *mockCompleteGitClient) ListLocalBranches() ([]string, error) {
 	return []string{"main", "feature/test"}, nil
 }
 
-// Implement other required methods to satisfy git.Clienter interface
-func (m *mockCompleteGitClient) GetCurrentBranch() (string, error)     { return "main", nil }
-func (m *mockCompleteGitClient) GetGitStatus() (string, error)         { return "", nil }
-func (m *mockCompleteGitClient) GetBranchName() (string, error)        { return "main", nil }
-func (m *mockCompleteGitClient) ListRemoteBranches() ([]string, error) { return nil, nil }
-func (m *mockCompleteGitClient) AddFiles(_ []string) error             { return nil }
-func (m *mockCompleteGitClient) CommitAllowEmpty() error               { return nil }
-func (m *mockCompleteGitClient) CommitTmp() error                      { return nil }
-func (m *mockCompleteGitClient) Commit(_ string) error                 { return nil }
-func (m *mockCompleteGitClient) Push(_ bool) error                     { return nil }
-func (m *mockCompleteGitClient) Pull(_ bool) error                     { return nil }
-func (m *mockCompleteGitClient) LogSimple() error                      { return nil }
-func (m *mockCompleteGitClient) LogGraph() error                       { return nil }
-func (m *mockCompleteGitClient) ResetHardAndClean() error              { return nil }
-func (m *mockCompleteGitClient) CleanFiles() error                     { return nil }
-func (m *mockCompleteGitClient) CleanDirs() error                      { return nil }
-func (m *mockCompleteGitClient) CheckoutNewBranch(_ string) error      { return nil }
-func (m *mockCompleteGitClient) FetchPrune() error                     { return nil }
+// Implement other required methods to satisfy git Clienter interface
+func (m *mockCompleteGitClient) GetCurrentBranch() (string, error)         { return "main", nil }
+func (m *mockCompleteGitClient) GetGitStatus() (string, error)             { return "", nil }
+func (m *mockCompleteGitClient) GetBranchName() (string, error)            { return "main", nil }
+func (m *mockCompleteGitClient) ListRemoteBranches() ([]string, error)     { return nil, nil }
+func (m *mockCompleteGitClient) AddFiles(_ []string) error                 { return nil }
+func (m *mockCompleteGitClient) CommitAllowEmpty() error                   { return nil }
+func (m *mockCompleteGitClient) CommitTmp() error                          { return nil }
+func (m *mockCompleteGitClient) Commit(_ string) error                     { return nil }
+func (m *mockCompleteGitClient) Push(_ bool) error                         { return nil }
+func (m *mockCompleteGitClient) Pull(_ bool) error                         { return nil }
+func (m *mockCompleteGitClient) LogSimple() error                          { return nil }
+func (m *mockCompleteGitClient) LogGraph() error                           { return nil }
+func (m *mockCompleteGitClient) ResetHardAndClean() error                  { return nil }
+func (m *mockCompleteGitClient) CleanFiles() error                         { return nil }
+func (m *mockCompleteGitClient) CleanDirs() error                          { return nil }
+func (m *mockCompleteGitClient) CheckoutNewBranch(_ string) error          { return nil }
+func (m *mockCompleteGitClient) FetchPrune() error                         { return nil }
+func (m *mockCompleteGitClient) RestoreAll() error                         { return nil }
+func (m *mockCompleteGitClient) RestoreAllStaged() error                   { return nil }
+func (m *mockCompleteGitClient) RestoreStaged(...string) error             { return nil }
+func (m *mockCompleteGitClient) RestoreWorkingDir(...string) error         { return nil }
+func (m *mockCompleteGitClient) RestoreFromCommit(string, ...string) error { return nil }
 
 func TestCompleter_Complete_Branch(t *testing.T) {
 	// Capture stdout

--- a/cmd/constructor_test.go
+++ b/cmd/constructor_test.go
@@ -159,6 +159,17 @@ func TestNewStatuseer(t *testing.T) {
 	}
 }
 
+func TestNewRestoreer(t *testing.T) {
+	restoreer := NewRestoreer()
+	if restoreer == nil {
+		t.Fatal("Expected Restoreer, got nil")
+	}
+	// Basic field checks
+	if restoreer.outputWriter == nil || restoreer.helper == nil || restoreer.execCommand == nil {
+		t.Error("Expected all fields to be initialized")
+	}
+}
+
 func TestNewTagger(t *testing.T) {
 	tagger := NewTagger()
 	if tagger == nil {
@@ -197,7 +208,7 @@ func TestNewCmd_Constructor(t *testing.T) {
 		cmd.remoteer == nil || cmd.rebaser == nil || cmd.stasher == nil ||
 		cmd.completer == nil || cmd.fetcher == nil || cmd.statuseer == nil ||
 		cmd.differ == nil || cmd.tagger == nil || cmd.versioneer == nil ||
-		cmd.configureer == nil || cmd.hooker == nil {
+		cmd.configureer == nil || cmd.hooker == nil || cmd.restoreer == nil {
 		t.Error("Expected all command handlers to be initialized")
 	}
 }

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -185,6 +185,21 @@ func (h *Helper) ShowConfigHelp() {
 	})
 }
 
+// ShowRestoreHelp shows help message for restore command.
+func (h *Helper) ShowRestoreHelp() {
+	h.ShowCommandHelp(templates.HelpData{
+		Usage:       "ggc restore [command]",
+		Description: "Restore working tree files",
+		Examples: []string{
+			"restore <file>                # Restore file in working directory from index",
+			"restore <commit> <file>       # Restore file from specific commit",
+			"restore .                     # Restore all files in working directory from index",
+			"restore staged <file>         # Unstage file (restore from HEAD to index)",
+			"restore staged .              # Unstage all files",
+		},
+	})
+}
+
 // ShowStatusHelp shows help message for status command.
 func (h *Helper) ShowStatusHelp() {
 	h.ShowCommandHelp(templates.HelpData{

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/bmf-san/ggc/git"
+	"io"
+	"os"
+	"os/exec"
+)
+
+// Restoreer handles restore operations.
+type Restoreer struct {
+	outputWriter io.Writer
+	helper       *Helper
+	execCommand  func(string, ...string) *exec.Cmd
+	gitClient    git.Clienter
+}
+
+// NewRestoreer creates a new Restoreer instance.
+func NewRestoreer() *Restoreer {
+	return &Restoreer{
+		outputWriter: os.Stdout,
+		helper:       NewHelper(),
+		execCommand:  exec.Command,
+		gitClient:    git.NewClient(),
+	}
+}
+
+// Restore executes git restore commands.
+func (r *Restoreer) Restore(args []string) {
+	if len(args) == 0 {
+		r.helper.ShowRestoreHelp()
+		return
+	}
+
+	switch args[0] {
+	case "staged":
+		if len(args) < 2 {
+			r.helper.ShowRestoreHelp()
+			return
+		}
+
+		paths := args[1:]
+		if err := r.gitClient.RestoreStaged(paths...); err != nil {
+			_, _ = fmt.Fprintf(r.outputWriter, "Error: %v\n", err)
+			return
+		}
+
+	default:
+		if len(args) >= 2 && isCommitLike(args[0]) {
+			// Handle : ggc restore <commit> <file>
+			commit := args[0]
+			paths := args[1:]
+			if err := r.gitClient.RestoreFromCommit(commit, paths...); err != nil {
+				_, _ = fmt.Fprintf(r.outputWriter, "Error: %v\n", err)
+				return
+			}
+		} else {
+			// Handle : ggc restore <file> or ggc restore .
+			if err := r.gitClient.RestoreWorkingDir(args...); err != nil {
+				_, _ = fmt.Fprintf(r.outputWriter, "Error: %v\n", err)
+				return
+			}
+		}
+	}
+}
+
+func isCommitLike(s string) bool {
+	if len(s) >= 7 && len(s) <= 40 {
+		for _, r := range s {
+			if (r < '0' || r > '9') && (r < 'a' || r > 'f') && (r < 'A' || r > 'F') {
+				return false
+			}
+		}
+		return true
+	}
+	return s == "HEAD" || s[:4] == "HEAD" || s[:8] == "refs/" || s[:7] == "origin/"
+}

--- a/cmd/restore_test.go
+++ b/cmd/restore_test.go
@@ -1,0 +1,258 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestRestoreer_Restore(t *testing.T) {
+	cases := []struct {
+		name           string
+		args           []string
+		expectedCmds   []string
+		mockOutput     []byte
+		mockError      error
+		expectedOutput string
+	}{
+		{
+			name:           "restore single file",
+			args:           []string{"file.txt"},
+			expectedCmds:   []string{"git restore file.txt"},
+			mockOutput:     []byte("Restored file.txt"),
+			mockError:      nil,
+			expectedOutput: "",
+		},
+		{
+			name:           "restore all files",
+			args:           []string{"."},
+			expectedCmds:   []string{"git restore ."},
+			mockOutput:     []byte("Restored all files"),
+			mockError:      nil,
+			expectedOutput: "",
+		},
+		{
+			name:           "restore multiple files",
+			args:           []string{"file1.txt", "file2.txt"},
+			expectedCmds:   []string{"git restore file1.txt file2.txt"},
+			mockOutput:     []byte("Restored files"),
+			mockError:      nil,
+			expectedOutput: "",
+		},
+		{
+			name:           "restore staged file",
+			args:           []string{"staged", "file.txt"},
+			expectedCmds:   []string{"git restore --staged file.txt"},
+			mockOutput:     []byte("Unstaged file.txt"),
+			mockError:      nil,
+			expectedOutput: "",
+		},
+		{
+			name:           "restore staged all files",
+			args:           []string{"staged", "."},
+			expectedCmds:   []string{"git restore --staged ."},
+			mockOutput:     []byte("Unstaged all files"),
+			mockError:      nil,
+			expectedOutput: "",
+		},
+		{
+			name:           "restore staged multiple files",
+			args:           []string{"staged", "file1.txt", "file2.txt"},
+			expectedCmds:   []string{"git restore --staged file1.txt file2.txt"},
+			mockOutput:     []byte("Unstaged files"),
+			mockError:      nil,
+			expectedOutput: "",
+		},
+		{
+			name:           "restore from commit",
+			args:           []string{"HEAD~1", "file.txt"},
+			expectedCmds:   []string{"git restore --source HEAD~1 file.txt"},
+			mockOutput:     []byte("Restored from commit"),
+			mockError:      nil,
+			expectedOutput: "",
+		},
+		{
+			name:           "restore from commit hash",
+			args:           []string{"abc123f", "file.txt"},
+			expectedCmds:   []string{"git restore --source abc123f file.txt"},
+			mockOutput:     []byte("Restored from commit"),
+			mockError:      nil,
+			expectedOutput: "",
+		},
+		{
+			name:           "restore file error",
+			args:           []string{"file.txt"},
+			expectedCmds:   []string{"git restore file.txt"},
+			mockOutput:     nil,
+			mockError:      errors.New("restore failed"),
+			expectedOutput: "Error:",
+		},
+		{
+			name:           "restore staged error",
+			args:           []string{"staged", "file.txt"},
+			expectedCmds:   []string{"git restore --staged file.txt"},
+			mockOutput:     nil,
+			mockError:      errors.New("staged restore failed"),
+			expectedOutput: "Error:",
+		},
+		{
+			name:           "restore from commit error",
+			args:           []string{"HEAD~1", "file.txt"},
+			expectedCmds:   []string{"git restore --source HEAD~1 file.txt"},
+			mockOutput:     nil,
+			mockError:      errors.New("commit restore failed"),
+			expectedOutput: "Error:",
+		},
+		{
+			name:           "no args",
+			args:           []string{},
+			expectedCmds:   nil,
+			mockOutput:     nil,
+			mockError:      nil,
+			expectedOutput: "Usage: ggc restore",
+		},
+		{
+			name:           "staged without file",
+			args:           []string{"staged"},
+			expectedCmds:   nil,
+			mockOutput:     nil,
+			mockError:      nil,
+			expectedOutput: "Usage: ggc restore",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			cmdIndex := 0
+
+			MockGitClient := &MockGitClient{
+				execCommand: func(_ string, args ...string) *exec.Cmd {
+					if cmdIndex < len(tc.expectedCmds) {
+						gotCmd := strings.Join(append([]string{"git"}, args...), " ")
+						if gotCmd != tc.expectedCmds[cmdIndex] {
+							t.Errorf("expected command %q, got %q", tc.expectedCmds[cmdIndex], gotCmd)
+						}
+					}
+					cmdIndex++
+					if tc.mockError != nil {
+						return exec.Command("false")
+					}
+					return exec.Command("echo", string(tc.mockOutput))
+				},
+			}
+
+			r := &Restoreer{
+				outputWriter: &buf,
+				helper:       NewHelper(),
+				execCommand:  MockGitClient.execCommand,
+				gitClient:    MockGitClient,
+			}
+			r.helper.outputWriter = &buf
+
+			r.Restore(tc.args)
+
+			output := buf.String()
+			if !strings.Contains(output, tc.expectedOutput) {
+				t.Errorf("expected output to contain %q, got %q", tc.expectedOutput, output)
+			}
+		})
+	}
+}
+
+// MockGitClient that uses execCommand for testing
+type MockGitClient struct {
+	execCommand func(string, ...string) *exec.Cmd
+}
+
+func (m *MockGitClient) RestoreWorkingDir(paths ...string) error {
+	args := append([]string{"restore"}, paths...)
+	cmd := m.execCommand("git", args...)
+	return cmd.Run()
+}
+
+func (m *MockGitClient) RestoreStaged(paths ...string) error {
+	args := append([]string{"restore", "--staged"}, paths...)
+	cmd := m.execCommand("git", args...)
+	return cmd.Run()
+}
+
+func (m *MockGitClient) RestoreFromCommit(commit string, paths ...string) error {
+	args := append([]string{"restore", "--source", commit}, paths...)
+	cmd := m.execCommand("git", args...)
+	return cmd.Run()
+}
+
+func (m *MockGitClient) GetCurrentBranch() (string, error) {
+	return "main", nil
+}
+
+func (m *MockGitClient) ListLocalBranches() ([]string, error) {
+	return []string{"main", "feature/test"}, nil
+}
+
+func (m *MockGitClient) ListRemoteBranches() ([]string, error) {
+	return []string{"origin/main", "origin/feature/test"}, nil
+}
+
+func (m *MockGitClient) Push(bool) error {
+	return nil
+}
+
+func (m *MockGitClient) Pull(bool) error {
+	return nil
+}
+
+func (m *MockGitClient) FetchPrune() error {
+	return nil
+}
+
+func (m *MockGitClient) LogSimple() error {
+	return nil
+}
+
+func (m *MockGitClient) LogGraph() error {
+	return nil
+}
+
+func (m *MockGitClient) CommitAllowEmpty() error {
+	return nil
+}
+
+func (m *MockGitClient) CommitTmp() error {
+	return nil
+}
+
+func (m *MockGitClient) ResetHardAndClean() error {
+	return nil
+}
+
+func (m *MockGitClient) CleanFiles() error {
+	return nil
+}
+
+func (m *MockGitClient) CleanDirs() error {
+	return nil
+}
+
+func (m *MockGitClient) GetBranchName() (string, error) {
+	return "main", nil
+}
+
+func (m *MockGitClient) GetGitStatus() (string, error) {
+	return "", nil
+}
+
+func (m *MockGitClient) CheckoutNewBranch(_ string) error {
+	return nil
+}
+
+func (m *MockGitClient) RestoreAll() error {
+	return nil
+}
+
+func (m *MockGitClient) RestoreAllStaged() error {
+	return nil
+}

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -117,17 +117,17 @@ func TestStatuseer_Status(t *testing.T) {
 		expectedOutput string
 	}{
 		{
-			name: "status no args",
-			args: []string{},
-			expectedCmds: []string{"git -c color.status=always status", "git rev-parse --abbrev-ref main@{upstream}", "git rev-list --left-right --count main...On branch main\nChanges not staged for commit:\n  modified:   modified_file.go\n\nUntracked files:\n  untracked_file.go"},
+			name:           "status no args",
+			args:           []string{},
+			expectedCmds:   []string{"git -c color.status=always status", "git rev-parse --abbrev-ref main@{upstream}", "git rev-list --left-right --count main...On branch main\nChanges not staged for commit:\n  modified:   modified_file.go\n\nUntracked files:\n  untracked_file.go"},
 			mockOutput:     []byte("On branch main\nChanges not staged for commit:\n  modified:   modified_file.go\n\nUntracked files:\n  untracked_file.go\n"),
 			mockError:      nil,
 			expectedOutput: "On branch main",
 		},
 		{
-			name: "status short",
-			args: []string{"short"},
-			expectedCmds: []string{"git -c color.status=always status --short", "git rev-parse --abbrev-ref main@{upstream}", "git rev-list --left-right --count main...M  modified_file.go\n?? untracked_file.go"},
+			name:           "status short",
+			args:           []string{"short"},
+			expectedCmds:   []string{"git -c color.status=always status --short", "git rev-parse --abbrev-ref main@{upstream}", "git rev-list --left-right --count main...M  modified_file.go\n?? untracked_file.go"},
 			mockOutput:     []byte("M  modified_file.go\n?? untracked_file.go\n"),
 			mockError:      nil,
 			expectedOutput: "M  modified_file.go",

--- a/cmd/templates/help.go
+++ b/cmd/templates/help.go
@@ -54,6 +54,11 @@ Main Commands:
   ggc remote add <n> <url>    Add remote
   ggc remote remove <n>       Remove remote
   ggc remote set-url <n> <url> Change remote URL
+  ggc restore <file>          Restore file in working directory from index
+  ggc restore .               Restore all files in working directory from index
+  ggc restore staged <file>   Unstage file (restore from HEAD to index)
+  ggc restore staged .        Unstage all files
+  ggc restore <commit> <file> Restore file from specific commit
   ggc version                 Show current ggc version
   ggc config                  Manage ggc configuration
   ggc hook                    Manage Git hooks

--- a/git/git.go
+++ b/git/git.go
@@ -29,6 +29,11 @@ type Clienter interface {
 	CleanDirs() error
 	GetGitStatus() (string, error)
 	GetBranchName() (string, error)
+	RestoreWorkingDir(paths ...string) error
+	RestoreStaged(paths ...string) error
+	RestoreFromCommit(commit string, paths ...string) error
+	RestoreAll() error
+	RestoreAllStaged() error
 }
 
 // NewClient creates a new Client.

--- a/git/restore.go
+++ b/git/restore.go
@@ -1,0 +1,59 @@
+// Package git provides a high-level interface to git commands.
+package git
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RestoreOptions holds options for git restore command
+type RestoreOptions struct {
+	Staged bool   //  (from HEAD to index)
+	Source string // (from specific commit)
+}
+
+// Restore runs `git restore` with optional paths and options.
+func (c *Client) Restore(paths []string, opts *RestoreOptions) error {
+	args := []string{"restore"}
+
+	if opts != nil {
+		if opts.Staged {
+			args = append(args, "--staged")
+		}
+		if opts.Source != "" {
+			args = append(args, "--source", opts.Source)
+		}
+	}
+
+	args = append(args, paths...)
+	cmd := c.execCommand("git", args...)
+	if err := cmd.Run(); err != nil {
+		return NewError("restore", fmt.Sprintf("git %s", strings.Join(args, " ")), err)
+	}
+	return nil
+}
+
+// RestoreWorkingDir restores files in working directory from index
+func (c *Client) RestoreWorkingDir(paths ...string) error {
+	return c.Restore(paths, nil)
+}
+
+// RestoreStaged unstages files (restores from HEAD to index)
+func (c *Client) RestoreStaged(paths ...string) error {
+	return c.Restore(paths, &RestoreOptions{Staged: true})
+}
+
+// RestoreFromCommit restores files from a specific commit
+func (c *Client) RestoreFromCommit(commit string, paths ...string) error {
+	return c.Restore(paths, &RestoreOptions{Source: commit})
+}
+
+// RestoreAll restores all files in working directory from index
+func (c *Client) RestoreAll() error {
+	return c.Restore([]string{"."}, nil)
+}
+
+// RestoreAllStaged unstages all files
+func (c *Client) RestoreAllStaged() error {
+	return c.Restore([]string{"."}, &RestoreOptions{Staged: true})
+}

--- a/git/restore_test.go
+++ b/git/restore_test.go
@@ -1,0 +1,247 @@
+package git
+
+import (
+	"os/exec"
+	"reflect"
+	"testing"
+)
+
+func TestClient_Restore(t *testing.T) {
+	cases := []struct {
+		name     string
+		paths    []string
+		opts     *RestoreOptions
+		wantArgs []string
+	}{
+		{
+			name:     "restore single file",
+			paths:    []string{"file.txt"},
+			opts:     nil,
+			wantArgs: []string{"git", "restore", "file.txt"},
+		},
+		{
+			name:     "restore multiple files",
+			paths:    []string{"file1.txt", "file2.txt"},
+			opts:     nil,
+			wantArgs: []string{"git", "restore", "file1.txt", "file2.txt"},
+		},
+		{
+			name:     "restore staged file",
+			paths:    []string{"file.txt"},
+			opts:     &RestoreOptions{Staged: true},
+			wantArgs: []string{"git", "restore", "--staged", "file.txt"},
+		},
+		{
+			name:     "restore from specific commit",
+			paths:    []string{"file.txt"},
+			opts:     &RestoreOptions{Source: "abc123"},
+			wantArgs: []string{"git", "restore", "--source", "abc123", "file.txt"},
+		},
+		{
+			name:     "restore staged from specific commit",
+			paths:    []string{"file.txt"},
+			opts:     &RestoreOptions{Staged: true, Source: "abc123"},
+			wantArgs: []string{"git", "restore", "--staged", "--source", "abc123", "file.txt"},
+		},
+		{
+			name:     "restore with empty source",
+			paths:    []string{"file.txt"},
+			opts:     &RestoreOptions{Source: ""},
+			wantArgs: []string{"git", "restore", "file.txt"},
+		},
+		{
+			name:     "restore all files",
+			paths:    []string{"."},
+			opts:     nil,
+			wantArgs: []string{"git", "restore", "."},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotArgs []string
+			client := &Client{
+				execCommand: func(name string, args ...string) *exec.Cmd {
+					gotArgs = append([]string{name}, args...)
+					return exec.Command("echo")
+				},
+			}
+
+			_ = client.Restore(tc.paths, tc.opts)
+
+			if !reflect.DeepEqual(gotArgs, tc.wantArgs) {
+				t.Errorf("got %v, want %v", gotArgs, tc.wantArgs)
+			}
+		})
+	}
+}
+
+func TestClient_RestoreWorkingDir(t *testing.T) {
+	cases := []struct {
+		name     string
+		paths    []string
+		wantArgs []string
+	}{
+		{
+			name:     "restore single file from working dir",
+			paths:    []string{"file.txt"},
+			wantArgs: []string{"git", "restore", "file.txt"},
+		},
+		{
+			name:     "restore multiple files from working dir",
+			paths:    []string{"file1.txt", "file2.txt", "dir/file3.txt"},
+			wantArgs: []string{"git", "restore", "file1.txt", "file2.txt", "dir/file3.txt"},
+		},
+		{
+			name:     "restore no files",
+			paths:    []string{},
+			wantArgs: []string{"git", "restore"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotArgs []string
+			client := &Client{
+				execCommand: func(name string, args ...string) *exec.Cmd {
+					gotArgs = append([]string{name}, args...)
+					return exec.Command("echo")
+				},
+			}
+
+			_ = client.RestoreWorkingDir(tc.paths...)
+
+			if !reflect.DeepEqual(gotArgs, tc.wantArgs) {
+				t.Errorf("got %v, want %v", gotArgs, tc.wantArgs)
+			}
+		})
+	}
+}
+
+func TestClient_RestoreStaged(t *testing.T) {
+	cases := []struct {
+		name     string
+		paths    []string
+		wantArgs []string
+	}{
+		{
+			name:     "unstage single file",
+			paths:    []string{"file.txt"},
+			wantArgs: []string{"git", "restore", "--staged", "file.txt"},
+		},
+		{
+			name:     "unstage multiple files",
+			paths:    []string{"file1.txt", "file2.txt"},
+			wantArgs: []string{"git", "restore", "--staged", "file1.txt", "file2.txt"},
+		},
+		{
+			name:     "unstage no files",
+			paths:    []string{},
+			wantArgs: []string{"git", "restore", "--staged"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotArgs []string
+			client := &Client{
+				execCommand: func(name string, args ...string) *exec.Cmd {
+					gotArgs = append([]string{name}, args...)
+					return exec.Command("echo")
+				},
+			}
+
+			_ = client.RestoreStaged(tc.paths...)
+
+			if !reflect.DeepEqual(gotArgs, tc.wantArgs) {
+				t.Errorf("got %v, want %v", gotArgs, tc.wantArgs)
+			}
+		})
+	}
+}
+
+func TestClient_RestoreFromCommit(t *testing.T) {
+	cases := []struct {
+		name     string
+		commit   string
+		paths    []string
+		wantArgs []string
+	}{
+		{
+			name:     "restore single file from commit",
+			commit:   "abc123",
+			paths:    []string{"file.txt"},
+			wantArgs: []string{"git", "restore", "--source", "abc123", "file.txt"},
+		},
+		{
+			name:     "restore multiple files from commit",
+			commit:   "def456",
+			paths:    []string{"file1.txt", "file2.txt"},
+			wantArgs: []string{"git", "restore", "--source", "def456", "file1.txt", "file2.txt"},
+		},
+		{
+			name:     "restore from HEAD",
+			commit:   "HEAD",
+			paths:    []string{"file.txt"},
+			wantArgs: []string{"git", "restore", "--source", "HEAD", "file.txt"},
+		},
+		{
+			name:     "restore from branch",
+			commit:   "feature/branch",
+			paths:    []string{"file.txt"},
+			wantArgs: []string{"git", "restore", "--source", "feature/branch", "file.txt"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotArgs []string
+			client := &Client{
+				execCommand: func(name string, args ...string) *exec.Cmd {
+					gotArgs = append([]string{name}, args...)
+					return exec.Command("echo")
+				},
+			}
+
+			_ = client.RestoreFromCommit(tc.commit, tc.paths...)
+
+			if !reflect.DeepEqual(gotArgs, tc.wantArgs) {
+				t.Errorf("got %v, want %v", gotArgs, tc.wantArgs)
+			}
+		})
+	}
+}
+
+func TestClient_RestoreAll(t *testing.T) {
+	var gotArgs []string
+	client := &Client{
+		execCommand: func(name string, args ...string) *exec.Cmd {
+			gotArgs = append([]string{name}, args...)
+			return exec.Command("echo")
+		},
+	}
+
+	_ = client.RestoreAll()
+
+	wantArgs := []string{"git", "restore", "."}
+	if !reflect.DeepEqual(gotArgs, wantArgs) {
+		t.Errorf("got %v, want %v", gotArgs, wantArgs)
+	}
+}
+
+func TestClient_RestoreAllStaged(t *testing.T) {
+	var gotArgs []string
+	client := &Client{
+		execCommand: func(name string, args ...string) *exec.Cmd {
+			gotArgs = append([]string{name}, args...)
+			return exec.Command("echo")
+		},
+	}
+
+	_ = client.RestoreAllStaged()
+
+	wantArgs := []string{"git", "restore", "--staged", "."}
+	if !reflect.DeepEqual(gotArgs, wantArgs) {
+		t.Errorf("got %v, want %v", gotArgs, wantArgs)
+	}
+}

--- a/router/router.go
+++ b/router/router.go
@@ -53,6 +53,8 @@ func (r *Router) Route(args []string) {
 		r.Executer.Version(args[1:])
 	case "clean":
 		r.Executer.Clean(args[1:])
+	case "restore":
+		r.Executer.Restore(args[1:])
 	default:
 		r.Executer.Help()
 	}

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -32,6 +32,8 @@ type mockExecuter struct {
 	configArgs        []string
 	hookerCalled      bool
 	hookerArgs        []string
+	restoreCalled     bool
+	restoreArgs       []string
 	interactiveCalled bool
 }
 
@@ -77,6 +79,11 @@ func (m *mockExecuter) Version(args []string) {
 func (m *mockExecuter) Diff(args []string) {
 	m.diffCalled = true
 	m.diffArgs = args
+}
+
+func (m *mockExecuter) Restore(args []string) {
+	m.restoreCalled = true
+	m.restoreArgs = args
 }
 
 func (m *mockExecuter) Tag(args []string) {
@@ -207,6 +214,24 @@ func TestRouter(t *testing.T) {
 			validate: func(t *testing.T, m *mockExecuter) {
 				if !m.hookerCalled {
 					t.Error("Hooker should be called")
+				}
+			},
+		},
+		{
+			name: "restore no args",
+			args: []string{"restore"},
+			validate: func(t *testing.T, m *mockExecuter) {
+				if !m.restoreCalled {
+					t.Error("restore should be called")
+				}
+			},
+		},
+		{
+			name: "restore all",
+			args: []string{"restore", "."},
+			validate: func(t *testing.T, m *mockExecuter) {
+				if !m.restoreCalled {
+					t.Error("restore should be called")
 				}
 			},
 		},

--- a/tools/completions/ggc.bash
+++ b/tools/completions/ggc.bash
@@ -7,7 +7,7 @@ _ggc()
     prev="${COMP_WORDS[COMP_CWORD-1]}"
 
 
-    opts="add branch clean version config hook diff status clean-interactive commit complete tag fetch log pull push rebase remote reset stash"
+    opts="add branch clean version config hook restore diff status clean-interactive commit complete tag fetch log pull push rebase remote reset stash"
 
     case ${prev} in
         branch)
@@ -72,6 +72,11 @@ _ggc()
             ;;
         config)
             subopts="list set get"
+            COMPREPLY=( $(compgen -W "${subopts}" -- ${cur}) )
+            return 0
+            ;;
+        restore)
+            subopts="staged"
             COMPREPLY=( $(compgen -W "${subopts}" -- ${cur}) )
             return 0
             ;;

--- a/tools/completions/ggc.fish
+++ b/tools/completions/ggc.fish
@@ -8,7 +8,7 @@ function __ggc_complete_files
 end
 
 # Main commands
-complete -c ggc -f -a "add branch clean version hook diff status clean-interactive commit complete tag fetch log pull push rebase remote reset stash"
+complete -c ggc -f -a "add branch clean version restore hook diff status clean-interactive commit complete tag fetch log pull push rebase remote reset stash"
 
 # Branch subcommands
 complete -c ggc -f -n "__fish_seen_subcommand_from branch" -a "current checkout checkout-remote delete delete-merged list-local list-remote"
@@ -48,6 +48,9 @@ complete -c ggc -f -n "__fish_seen_subcommand_from tag" -a "create delete show l
 
 # Hook subcommands
 complete -c ggc -f -n "__fish_seen_subcommand_from hook" -a "list edit install uninstall enable disable"
+
+# Restore subcommands
+complete -c ggc -f -n "__fish_seen_subcommand_from restore" -a "staged"
 
 # Add command with file completion
 complete -c ggc -f -n "__fish_seen_subcommand_from add" -a "(__ggc_complete_files)"

--- a/tools/completions/ggc.zsh
+++ b/tools/completions/ggc.zsh
@@ -32,6 +32,9 @@ _ggc() {
                 diff)
                     _ggc_diff
                     ;;
+                restore)
+                    _ggc_restore
+                    ;;
                 log)
                     _ggc_log
                     ;;
@@ -84,6 +87,7 @@ _ggc_commands() {
         'remote:Remote repository management'
         'reset:Reset changes'
         'stash:Stash changes'
+		'restore:Restore working tree files'
     )
     _describe 'commands' commands
 }
@@ -243,6 +247,14 @@ _ggc_config() {
         'get:Get configuration value'
     )
     _describe 'config subcommands' subcommands
+}
+
+_ggc_restore() {
+    local subcommands
+    subcommands=(
+        'staged:Restore staged files'
+    )
+    _describe 'restore subcommands' subcommands
 }
 
 _ggc_add() {


### PR DESCRIPTION
This PR adds support for the `ggc restore` command mentioned in a previous issue. 

## Summary
- Restoring files in the working directory from the index
- Unstaging files (restore from HEAD to index)
- Restoring files from specific commits
- Support for restoring all files or specific files
- Shell completions for bash, zsh, and fish
- Updated tests and added new tests as needed
- Updated documentation accordingly to reflect changes

## Related Issue
Closes #74.

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/ggc-dev/ggc/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests
- [x] I have updated the documentation (if required)
- [x] Code is formatted with `make fmt`
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing

## Screenshots (if appropriate)
N/A

## Additional Context
Commands added:
```
  ggc restore <file>          Restore file in working directory from index
  ggc restore .               Restore all files in working directory from index
  ggc restore staged <file>   Unstage file (restore from HEAD to index)
  ggc restore staged .        Unstage all files
  ggc restore <commit> <file> Restore file from specific commit
```
