### PR TITLE
feat: Add Basic Command Description to Interactive Mode

### DIFF
--- a/cmd/interactive_test.go
+++ b/cmd/interactive_test.go
@@ -56,3 +56,39 @@ func TestExtractPlaceholders(t *testing.T) {
 		})
 	}
 }
+
+func TestCommandDescriptions(t *testing.T) {
+	// Ensure that all commands have a description (catch in tests)
+	for _, cmd := range commands {
+		description := cmd.Description
+		if description == "" {
+			t.Errorf("Command '%s' has no description", cmd.Command)
+		}
+	}
+}
+
+func TestCommandDescriptionsContent(t *testing.T) {
+	// Test description content updated + showing correctly
+	expectedDescriptions := map[string]string{
+		"add <file>":       "Add a specific file to the index",
+		"status":           "Show working tree status",
+		"commit <message>": "Create commit with a message",
+		"quit":             "Exit interactive mode",
+	}
+
+	for cmdStr, expectedDesc := range expectedDescriptions {
+		found := false
+		for _, cmd := range commands {
+			if cmd.Command == cmdStr {
+				if cmd.Description != expectedDesc {
+					t.Errorf("Description for '%s' is '%s', expected '%s'", cmdStr, cmd.Description, expectedDesc)
+				}
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Command '%s' not found in commandList", cmdStr)
+		}
+	}
+}


### PR DESCRIPTION
This PR adds basic command descriptions when in interactive mode for better user experience and ease of use.

## Summary
- Adds functionality to cmd/interactive.go with a new CommandInfo struct
- Adds a description for each command
- Includes tests for ensuring descriptions work properly

## Related Issue
Closes #35.

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/ggc-dev/ggc/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests
- [x] I have updated the documentation (if required)
- [x] Code is formatted with `make fmt`
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing

## Additional Context
Used some of the code here #42, with required changes.

PS: sorry for the slowdown in PR's. I'm on vacation for the summer so it'll probably be a bit spotty for now 👍