### PR TITLE
removed waitForContinue from cmd_test.go and cmd.go and removed bufio…

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2,7 +2,6 @@
 package cmd
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 	"os"
@@ -191,8 +190,6 @@ func (c *Cmd) Interactive() {
 
 		c.Route(args[1:]) // Skip "ggc" in args
 
-		// Wait to check results after command execution
-		c.waitForContinue()
 	}
 }
 
@@ -251,10 +248,4 @@ func (c *Cmd) Route(args []string) {
 	default:
 		c.Help()
 	}
-}
-
-func (c *Cmd) waitForContinue() {
-	fmt.Println("\nPress Enter to continue...")
-	reader := bufio.NewReader(os.Stdin)
-	_, _ = reader.ReadString('\n')
 }

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -423,23 +423,6 @@ func TestCmd_Route(t *testing.T) {
 	}
 }
 
-func TestCmd_waitForContinue(t *testing.T) {
-	// waitForContinue reads from standard input, making direct testing difficult
-	// However, verify the function exists (and doesn't panic)
-	cmd := &Cmd{}
-
-	// Indirectly verify that the function exists
-	// Don't actually call it since it requires standard input
-	defer func() {
-		if r := recover(); r != nil {
-			t.Errorf("waitForContinue should not panic when defined, got panic: %v", r)
-		}
-	}()
-
-	// Use type assertion to verify the function is defined
-	_ = cmd.waitForContinue
-}
-
 // Test some behavior of Interactive by mocking InteractiveUI
 func TestCmd_Interactive_Existence(t *testing.T) {
 	// Interactive is a complex interactive function, making complete testing difficult


### PR DESCRIPTION
… import from cmd.go

## Description of Changes
Removed waitForContinue from cmd.go and cmd_test.go
Removed bufio import from cmd.go, no longer used

## Related Issue
close #103 

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/ggc-dev/ggc/blob/main/CONTRIBUTING.md)
- [] I have added or updated tests
- [x] I have updated the documentation (if required)
- [x] Code is formatted with `make fmt`
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing

## Additional Context
I ran make tests on Ubuntu and it led to all the test files being marked as modified even though nothing changed. So I just pushed the two files I changed. 
