### PR TITLE
feat: Improve command search to support substring matching

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -160,7 +160,7 @@ func (ui *UI) Run() []string {
 		// Filtering
 		filtered := []CommandInfo{}
 		for _, cmd := range commands {
-			if strings.HasPrefix(cmd.Command, input) {
+			if strings.Contains(cmd.Command, input) {
 				filtered = append(filtered, cmd)
 			}
 		}


### PR DESCRIPTION
## Description of Changes
This PR improves the command search functionality in interactive mode by changing the search behavior from prefix matching to substring matching. This makes it easier for users to find commands without knowing their exact prefix.

For example:
- Users can now find "branch current" by typing "current"
- "checkout" will match both "branch checkout" and "branch checkout-remote"
- Commands can be found by any part of their name, not just the beginning

## Related Issue
No related issue.　

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/ggc-dev/ggc/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests
- [x] I have updated the documentation (if required)
- [x] Code is formatted with `make fmt`
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing

## Screenshots (if appropriate)
N/A

## Additional Context
I made a mistake by changing it at https://github.com/bmf-san/ggc/pull/105/files#diff-cefeef33d3b3acb225d70677153c782ac6f3b6bddc44a367c666e1063ceb955dR163
