### PR TITLE
feat: Add installation check for install-tools in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,13 @@ OUT?=coverage.out
 
 # Install required tools
 install-tools:
-	@echo "Installing required tools..."
-	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.2.1
-	@echo "Tools installed successfully"
+	@if ! command -v golangci-lint &> /dev/null; then \
+		echo "Installing required tools..."; \
+		go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.2.1; \
+		echo "Tools installed successfully"; \
+	else \
+		echo "Tools already installed"; \
+	fi
 
 # Install dependencies and tools
 deps: install-tools


### PR DESCRIPTION
This PR focuses on speeding up running `make lint` for faster checks.

## Summary
- Speeds up running make lint to only go install when needed

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/ggc-dev/ggc/blob/main/CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated the documentation (if required)
- [x] Code is formatted with `make fmt`
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing

## Screenshots (if appropriate)
N/A

## Additional Context
This enhancement reduces the overhead of running `make lint` by optimizing the dependency installation process. Previously, dependencies were installed with `go install` every time `make lint` was invoked, which could be time-consuming especially if you have slow internet and `golangci-lint` was already installed.