### PR TITLE
feat: implement user-defined command aliases via config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,29 @@ ggc
 | `status short` | Show concise status |
 | `version` | Show current ggc version |
 
+## Command Aliases
+
+Chain multiple `ggc` commands together with custom aliases you define. Here is the default aliases in your `~/.ggcconfig.yaml` file:
+```yaml
+aliases:
+    ac:
+        - add .
+        - commit tmp
+    br: branch
+    ci: commit
+    quick:
+        - status
+        - add .
+        - commit tmp
+    st: status
+    sync:
+        - pull current
+        - add .
+        - commit tmp
+        - push current
+```
+For example, running `ggc ac` will execute first `ggc add .` then `ggc commit tmp` and terminate.
+
 ## Directory Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ ggc
 
 ## Command Aliases
 
-Chain multiple `ggc` commands together with custom aliases you define. Here is the default aliases in your `~/.ggcconfig.yaml` file:
+Chain multiple `ggc` commands together with custom aliases you define. Here is an example of aliases in your `~/.ggcconfig.yaml` file:
 ```yaml
 aliases:
     ac:

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -24,11 +24,16 @@ type Executer interface {
 	Diff(args []string)
 	Config(args []string)
 	Hook(args []string)
+	Rebase(args []string)
+	Remote(args []string)
 	Version(args []string)
+	Stash(args []string)
+	Fetch(args []string)
 	Status(args []string)
 	Tag(args []string)
 	Clean(args []string)
 	Restore(args []string)
+	Add(args []string)
 	Interactive()
 }
 
@@ -99,6 +104,26 @@ func (c *Cmd) Branch(args []string) {
 	c.brancher.Branch(args)
 }
 
+// Remote executes the remote command with the given arguments.
+func (c *Cmd) Remote(args []string) {
+	c.remoteer.Remote(args)
+}
+
+// Rebase executes the rebase command with the given arguments.
+func (c *Cmd) Rebase(args []string) {
+	c.rebaser.Rebase(args)
+}
+
+// Stash executes the stash command with the given arguments.
+func (c *Cmd) Stash(args []string) {
+	c.stasher.Stash(args)
+}
+
+// Fetch executes the fetch command with the given arguments.
+func (c *Cmd) Fetch(args []string) {
+	c.fetcher.Fetch(args)
+}
+
 // Commit executes the commit command with the given arguments.
 func (c *Cmd) Commit(args []string) {
 	c.committer.Commit(args)
@@ -107,6 +132,11 @@ func (c *Cmd) Commit(args []string) {
 // Log executes the log command with the given arguments.
 func (c *Cmd) Log(args []string) {
 	c.logger.Log(args)
+}
+
+// Add executes the add command with the given arguments.
+func (c *Cmd) Add(args []string) {
+	c.adder.Add(args)
 }
 
 // Status executes the status command with the given arguments.

--- a/config/config.go
+++ b/config/config.go
@@ -156,14 +156,6 @@ func (c *Config) validateIntegrationTokens() error {
 }
 
 func (c *Config) validateAliases() error {
-	validCommands := map[string]bool{
-		"add": true, "branch": true, "clean": true, "commit": true, "config": true,
-		"diff": true, "fetch": true, "help": true, "hook": true, "interactive": true,
-		"log": true, "pull": true, "push": true, "rebase": true, "remote": true,
-		"reset": true, "restore": true, "stash": true, "status": true, "tag": true,
-		"version": true,
-	}
-
 	for name, value := range c.Aliases {
 		if strings.TrimSpace(name) == "" || strings.Contains(name, " ") {
 			return &ValidationError{"aliases." + name, name, "alias names must not contain spaces"}
@@ -174,9 +166,6 @@ func (c *Config) validateAliases() error {
 			// Simple alias validation
 			if strings.TrimSpace(v) == "" {
 				return &ValidationError{"aliases." + name, v, "alias command cannot be empty"}
-			}
-			if !validCommands[v] {
-				return &ValidationError{"aliases." + name, v, fmt.Sprintf("unknown command '%s'", v)}
 			}
 
 		case []interface{}:
@@ -198,13 +187,6 @@ func (c *Config) validateAliases() error {
 						Field:   fmt.Sprintf("aliases.%s[%d]", name, i),
 						Value:   cmdStr,
 						Message: "command in sequence cannot be empty",
-					}
-				}
-				if !validCommands[strings.Split(cmdStr, " ")[0]] {
-					return &ValidationError{
-						Field:   fmt.Sprintf("aliases.%s[%d]", name, i),
-						Value:   cmdStr,
-						Message: fmt.Sprintf("unknown command '%s'", cmdStr),
 					}
 				}
 			}
@@ -346,15 +328,6 @@ func getDefaultConfig() *Config {
 	config.Behavior.ConfirmDestructive = "simple"
 	config.Behavior.AutoFetch = true
 	config.Behavior.StashBeforeSwitch = true
-
-	// Default simple aliases
-	config.Aliases["st"] = "status"
-	config.Aliases["br"] = "branch"
-	config.Aliases["ci"] = "commit"
-
-	config.Aliases["ac"] = []interface{}{"add .", "commit tmp"}
-	config.Aliases["sync"] = []interface{}{"pull current", "add .", "commit tmp", "push current"}
-	config.Aliases["quick"] = []interface{}{"status", "add .", "commit tmp"}
 
 	config.Integration.Github.DefaultRemote = "origin"
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -48,19 +48,6 @@ func TestGetDefaultConfig(t *testing.T) {
 		t.Error("Expected stash-before-switch to be true")
 	}
 
-	// Test default aliases
-	expectedAliases := map[string]string{
-		"st": "status",
-		"br": "branch",
-		"ci": "commit",
-	}
-	for alias, command := range expectedAliases {
-		if config.Aliases[alias] != command {
-			t.Errorf("Expected alias '%s' to be '%s', got '%s'", alias, command, config.Aliases[alias])
-		}
-	}
-
-	// Test integration defaults
 	if config.Integration.Github.DefaultRemote != "origin" {
 		t.Errorf("Expected default remote to be 'origin', got %s", config.Integration.Github.DefaultRemote)
 	}
@@ -248,7 +235,6 @@ func TestGetValueByPath(t *testing.T) {
 		{"default.editor", "vim"},
 		{"ui.color", true},
 		{"behavior.auto-push", false},
-		{"aliases.st", "status"},
 		{"integration.github.default-remote", "origin"},
 	}
 
@@ -861,22 +847,6 @@ func TestConfig_validateAliases(t *testing.T) {
 			},
 			wantError: true,
 			errorMsg:  "alias names must not contain spaces",
-		},
-		{
-			name: "invalid command in simple alias",
-			aliases: map[string]interface{}{
-				"bad": "nonexistent",
-			},
-			wantError: true,
-			errorMsg:  "unknown command 'nonexistent'",
-		},
-		{
-			name: "invalid command in sequence alias",
-			aliases: map[string]interface{}{
-				"bad": []interface{}{"add", "nonexistent", "push"},
-			},
-			wantError: true,
-			errorMsg:  "unknown command 'nonexistent'",
 		},
 		{
 			name: "empty sequence alias",

--- a/main.go
+++ b/main.go
@@ -20,9 +20,10 @@ func GetVersionInfo() (string, string) {
 }
 
 func main() {
-	config.NewConfigManager().LoadConfig()
+	cm := config.NewConfigManager()
+	cm.LoadConfig()
 	cmd.SetVersionGetter(GetVersionInfo)
 	c := cmd.NewCmd()
-	r := router.NewRouter(c)
+	r := router.NewRouter(c, cm)
 	r.Route(os.Args[1:])
 }

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -2,6 +2,8 @@ package router
 
 import (
 	"testing"
+
+	"github.com/bmf-san/ggc/config"
 )
 
 type mockExecuter struct {
@@ -34,6 +36,16 @@ type mockExecuter struct {
 	hookerArgs        []string
 	restoreCalled     bool
 	restoreArgs       []string
+	addCalled         bool
+	addArgs           []string
+	remoteCalled      bool
+	remoteArgs        []string
+	rebaseCalled      bool
+	rebaseArgs        []string
+	stashCalled       bool
+	stashArgs         []string
+	fetchCalled       bool
+	fetchArgs         []string
 	interactiveCalled bool
 }
 
@@ -79,6 +91,31 @@ func (m *mockExecuter) Version(args []string) {
 func (m *mockExecuter) Diff(args []string) {
 	m.diffCalled = true
 	m.diffArgs = args
+}
+
+func (m *mockExecuter) Add(args []string) {
+	m.addCalled = true
+	m.addArgs = args
+}
+
+func (m *mockExecuter) Remote(args []string) {
+	m.remoteCalled = true
+	m.remoteArgs = args
+}
+
+func (m *mockExecuter) Rebase(args []string) {
+	m.rebaseCalled = true
+	m.rebaseArgs = args
+}
+
+func (m *mockExecuter) Stash(args []string) {
+	m.stashCalled = true
+	m.stashArgs = args
+}
+
+func (m *mockExecuter) Fetch(args []string) {
+	m.fetchCalled = true
+	m.fetchArgs = args
 }
 
 func (m *mockExecuter) Restore(args []string) {
@@ -359,6 +396,54 @@ func TestRouter(t *testing.T) {
 			},
 		},
 		{
+			name: "add",
+			args: []string{"add", "."},
+			validate: func(t *testing.T, m *mockExecuter) {
+				if !m.addCalled {
+					t.Error("Add should be called")
+				}
+				if len(m.addArgs) != 1 || m.addArgs[0] != "." {
+					t.Errorf("unexpected add args: got %v", m.addArgs)
+				}
+			},
+		},
+		{
+			name: "remote",
+			args: []string{"remote"},
+			validate: func(t *testing.T, m *mockExecuter) {
+				if !m.remoteCalled {
+					t.Error("remote should be called")
+				}
+			},
+		},
+		{
+			name: "rebase",
+			args: []string{"rebase"},
+			validate: func(t *testing.T, m *mockExecuter) {
+				if !m.rebaseCalled {
+					t.Error("Rebase should be called")
+				}
+			},
+		},
+		{
+			name: "stash",
+			args: []string{"stash"},
+			validate: func(t *testing.T, m *mockExecuter) {
+				if !m.stashCalled {
+					t.Error("stash should be called")
+				}
+			},
+		},
+		{
+			name: "fetch",
+			args: []string{"fetch"},
+			validate: func(t *testing.T, m *mockExecuter) {
+				if !m.fetchCalled {
+					t.Error("fetch should be called")
+				}
+			},
+		},
+		{
 			name: "unknown",
 			args: []string{"unknown"},
 			validate: func(t *testing.T, m *mockExecuter) {
@@ -381,7 +466,7 @@ func TestRouter(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			m := &mockExecuter{}
-			r := NewRouter(m)
+			r := NewRouter(m, config.NewConfigManager())
 			r.Route(tc.args)
 			tc.validate(t, m)
 		})


### PR DESCRIPTION
This PR implements user-defined command aliases using the `~/.ggcconfig` file.

## Summary
- Added support for defining aliases in ~/.ggcconfig.yaml
- Aliases can map to a single command (e.g., `st: status`) or a sequence of commands (e.g., `acp: ["add", "commit", "push"]`)
- Implemented alias parsing and execution in router
- Commands from aliases run sequentially and stop on failure
- Updated config validation and tests to support mixed alias types
- Extended `config` command to display alias configuration in readable format

## Related Issue
Closes #64.

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/ggc-dev/ggc/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests
- [x] I have updated the documentation (if required)
- [x] Code is formatted with `make fmt`
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing

## Additional Context
Aliases are able to be run depending on user's configuration file in `~/.ggcconfig.yaml`. As an example:
```yaml
aliases:
    ac:
        - add .
        - commit tmp
    br: branch
    ci: commit
    quick:
        - status
        - add .
        - commit tmp
    st: status
    sync:
        - pull current
        - add .
        - commit tmp
        - push current
```
This is the default config and has `ggc ac`, `ggc ci` and others, which will execute commands sequentially in order based on the list.