### PR TITLE
refactor: remove "commit tmp" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,6 @@ ggc
 | `commit amend <message>` | Amend previous commit |
 | `commit amend --no-edit` | Amend without editing message |
 | `commit allow-empty` | Create an empty commit |
-| `commit tmp` | Create temporary commit |
 | `diff staged` | Show staged changes |
 | `diff unstaged` | Show unstaged changes |
 | `fetch --prune` | Fetch and prune remotes |

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -18,7 +18,6 @@ type mockGitClient struct {
 	logSimpleCalled         bool
 	logGraphCalled          bool
 	commitAllowEmptyCalled  bool
-	commitTmpCalled         bool
 	resetHardAndCleanCalled bool
 	cleanFilesCalled        bool
 	cleanDirsCalled         bool
@@ -65,11 +64,6 @@ func (m *mockGitClient) LogGraph() error {
 
 func (m *mockGitClient) CommitAllowEmpty() error {
 	m.commitAllowEmptyCalled = true
-	return nil
-}
-
-func (m *mockGitClient) CommitTmp() error {
-	m.commitTmpCalled = true
 	return nil
 }
 
@@ -228,13 +222,6 @@ func TestCmd_Commit(t *testing.T) {
 			args: []string{"allow-empty"},
 			wantCalled: func(mc *mockGitClient) bool {
 				return mc.commitAllowEmptyCalled
-			},
-		},
-		{
-			name: "tmp",
-			args: []string{"tmp"},
-			wantCalled: func(mc *mockGitClient) bool {
-				return mc.commitTmpCalled
 			},
 		},
 	}

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -48,10 +48,6 @@ func (c *Committer) Commit(args []string) {
 		if err := c.gitClient.CommitAllowEmpty(); err != nil {
 			_, _ = fmt.Fprintf(c.outputWriter, "Error: %v\n", err)
 		}
-	case "tmp":
-		if err := c.gitClient.CommitTmp(); err != nil {
-			_, _ = fmt.Fprintf(c.outputWriter, "Error: %v\n", err)
-		}
 	case "amend":
 		var cmd *exec.Cmd
 

--- a/cmd/commit_test.go
+++ b/cmd/commit_test.go
@@ -14,17 +14,11 @@ import (
 type mockCommitGitClient struct {
 	git.Clienter
 	commitAllowEmptyCalled bool
-	commitTmpCalled        bool
 	err                    error
 }
 
 func (m *mockCommitGitClient) CommitAllowEmpty() error {
 	m.commitAllowEmptyCalled = true
-	return m.err
-}
-
-func (m *mockCommitGitClient) CommitTmp() error {
-	m.commitTmpCalled = true
 	return m.err
 }
 
@@ -41,22 +35,6 @@ func TestCommitter_Commit_AllowEmpty(t *testing.T) {
 	c.Commit([]string{"allow-empty"})
 	if !mockClient.commitAllowEmptyCalled {
 		t.Error("CommitAllowEmpty should be called")
-	}
-}
-
-func TestCommitter_Commit_Tmp(t *testing.T) {
-	mockClient := &mockCommitGitClient{}
-	var buf bytes.Buffer
-	c := &Committer{
-		gitClient:    mockClient,
-		outputWriter: &buf,
-		helper:       NewHelper(),
-		execCommand:  exec.Command,
-	}
-	c.helper.outputWriter = &buf
-	c.Commit([]string{"tmp"})
-	if !mockClient.commitTmpCalled {
-		t.Error("CommitTmp should be called")
 	}
 }
 
@@ -215,23 +193,6 @@ func TestCommitter_Commit_Amend_Error(t *testing.T) {
 	output := buf.String()
 	if !strings.Contains(output, "Error:") {
 		t.Errorf("Expected error message, got: %s", output)
-	}
-}
-
-func TestCommitter_Commit_Tmp_Error(t *testing.T) {
-	var buf bytes.Buffer
-	c := &Committer{
-		gitClient:    &mockCommitGitClient{err: errors.New("tmp commit failed")},
-		outputWriter: &buf,
-		helper:       NewHelper(),
-		execCommand:  exec.Command,
-	}
-	c.helper.outputWriter = &buf
-	c.Commit([]string{"tmp"})
-
-	output := buf.String()
-	if output != "Error: tmp commit failed\n" {
-		t.Errorf("Expected tmp error message, got: %q", output)
 	}
 }
 

--- a/cmd/complete_test.go
+++ b/cmd/complete_test.go
@@ -28,7 +28,6 @@ func (m *mockCompleteGitClient) GetBranchName() (string, error)            { ret
 func (m *mockCompleteGitClient) ListRemoteBranches() ([]string, error)     { return nil, nil }
 func (m *mockCompleteGitClient) AddFiles(_ []string) error                 { return nil }
 func (m *mockCompleteGitClient) CommitAllowEmpty() error                   { return nil }
-func (m *mockCompleteGitClient) CommitTmp() error                          { return nil }
 func (m *mockCompleteGitClient) Commit(_ string) error                     { return nil }
 func (m *mockCompleteGitClient) Push(_ bool) error                         { return nil }
 func (m *mockCompleteGitClient) Pull(_ bool) error                         { return nil }

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -88,7 +88,6 @@ func (h *Helper) ShowCommitHelp() {
 			"ggc commit amend <message>    # Amend to previous commit",
 			"ggc commit amend --no-edit    # Amend without editing commit message",
 			"ggc commit allow-empty        # Create empty commit",
-			"ggc commit tmp                # Create temporary commit",
 		},
 	})
 }

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -71,7 +71,6 @@ var commands = []CommandInfo{
 	{"log graph", "Show log with graph"},
 	{"commit <message>", "Create commit with a message"},
 	{"commit allow-empty", "Create an empty commit"},
-	{"commit tmp", "Create a temporary commit"},
 	{"commit amend <message>", "Amend a previous commit"},
 	{"fetch --prune", "Fetch and clean stale references"},
 	{"tag list", "List all tags"},

--- a/cmd/restore_test.go
+++ b/cmd/restore_test.go
@@ -221,10 +221,6 @@ func (m *MockGitClient) CommitAllowEmpty() error {
 	return nil
 }
 
-func (m *MockGitClient) CommitTmp() error {
-	return nil
-}
-
 func (m *MockGitClient) ResetHardAndClean() error {
 	return nil
 }

--- a/cmd/templates/help.go
+++ b/cmd/templates/help.go
@@ -40,7 +40,6 @@ Main Commands:
   ggc commit amend <message>  Amend to previous commit
   ggc commit amend --no-edit  Amend without editing commit message
   ggc commit allow-empty      Create empty commit
-  ggc commit tmp              Temporary commit
   ggc complete <shell>        Generate shell completion script (bash|zsh)
   ggc fetch --prune          Fetch and remove stale remote-tracking branches
   ggc diff                    Show changes between commits, commit and working tree

--- a/git/commit.go
+++ b/git/commit.go
@@ -15,14 +15,3 @@ func (c *Client) CommitAllowEmpty() error {
 	}
 	return nil
 }
-
-// CommitTmp commits with a temporary message.
-func (c *Client) CommitTmp() error {
-	cmd := c.execCommand("git", "commit", "-m", "tmp")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return NewError("commit tmp", "git commit -m 'tmp'", err)
-	}
-	return nil
-}

--- a/git/commit_test.go
+++ b/git/commit_test.go
@@ -21,19 +21,3 @@ func TestClient_CommitAllowEmpty(t *testing.T) {
 		t.Errorf("got %v, want %v", gotArgs, want)
 	}
 }
-
-func TestClient_CommitTmp(t *testing.T) {
-	var gotArgs []string
-	client := &Client{
-		execCommand: func(name string, args ...string) *exec.Cmd {
-			gotArgs = append([]string{name}, args...)
-			return exec.Command("echo")
-		},
-	}
-
-	_ = client.CommitTmp()
-	want := []string{"git", "commit", "-m", "tmp"}
-	if !reflect.DeepEqual(gotArgs, want) {
-		t.Errorf("got %v, want %v", gotArgs, want)
-	}
-}

--- a/git/git.go
+++ b/git/git.go
@@ -23,7 +23,6 @@ type Clienter interface {
 	LogSimple() error
 	LogGraph() error
 	CommitAllowEmpty() error
-	CommitTmp() error
 	ResetHardAndClean() error
 	CleanFiles() error
 	CleanDirs() error

--- a/git/mock.go
+++ b/git/mock.go
@@ -12,7 +12,6 @@ type MockClient struct {
 	CleanFilesFunc         func() error
 	CleanDirsFunc          func() error
 	CommitAllowEmptyFunc   func() error
-	CommitTmpFunc          func() error
 	FetchPruneFunc         func() error
 	LogSimpleFunc          func() error
 	LogGraphFunc           func() error
@@ -58,11 +57,6 @@ func (m *MockClient) CleanDirs() error {
 // CommitAllowEmpty is a mock of CommitAllowEmpty.
 func (m *MockClient) CommitAllowEmpty() error {
 	return m.CommitAllowEmptyFunc()
-}
-
-// CommitTmp is a mock of CommitTmp.
-func (m *MockClient) CommitTmp() error {
-	return m.CommitTmpFunc()
 }
 
 // FetchPrune is a mock of FetchPrune.

--- a/tools/completions/ggc.bash
+++ b/tools/completions/ggc.bash
@@ -16,7 +16,7 @@ _ggc()
             return 0
             ;;
         commit)
-            subopts="allow-empty tmp amend"
+            subopts="allow-empty amend"
             COMPREPLY=( $(compgen -W "${subopts}" -- ${cur}) )
             return 0
             ;;

--- a/tools/completions/ggc.fish
+++ b/tools/completions/ggc.fish
@@ -17,7 +17,7 @@ complete -c ggc -f -n "__fish_seen_subcommand_from branch" -a "current checkout 
 complete -c ggc -f -n "__fish_seen_subcommand_from branch; and __fish_seen_subcommand_from checkout" -a "(__ggc_complete_branches)"
 
 # Commit subcommands
-complete -c ggc -f -n "__fish_seen_subcommand_from commit" -a "allow-empty tmp amend"
+complete -c ggc -f -n "__fish_seen_subcommand_from commit" -a "allow-empty amend"
 
 # Push subcommands
 complete -c ggc -f -n "__fish_seen_subcommand_from push" -a "current force"

--- a/tools/completions/ggc.zsh
+++ b/tools/completions/ggc.zsh
@@ -103,7 +103,7 @@ _ggc_branch() {
         'list-local:List local branches'
         'list-remote:List remote branches'
     )
-    
+
     if [[ $CURRENT == 2 ]]; then
         _describe 'branch subcommands' subcommands
     elif [[ $words[2] == "checkout" && $CURRENT == 3 ]]; then
@@ -118,10 +118,9 @@ _ggc_commit() {
     local subcommands
     subcommands=(
         'allow-empty:Allow empty commit'
-        'tmp:Create temporary commit'
         'amend:Amend last commit'
     )
-    
+
     if [[ $CURRENT == 2 ]]; then
         _describe 'commit subcommands' subcommands
     elif [[ $words[2] == "amend" && $CURRENT == 3 ]]; then


### PR DESCRIPTION
## Description of Changes
removed "commit tmp" command from codebase, command completion setting files and README

## Related Issue
close #119 

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/bmf-san/ggc/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests
- [x] I have updated the documentation (if required)
- [x] Code is formatted with `make fmt`
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing

## Screenshots (if appropriate)
none

## Additional Context
none
