### PR TITLE
fix: small syntax error in config_test.go

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -976,6 +976,7 @@ func stringifyValue(val any) string {
 	default:
 		return fmt.Sprintf("%v", v)
 	}
+}
 
 // TestManagerLoadConfig tests the LoadConfig method error paths
 func TestManagerLoadConfig(t *testing.T) {


### PR DESCRIPTION
## Description of Changes
fix the small syntax error due to missing closing brace `}` in `config_test.go` that was making tests fail.

## Related Issue
#118 

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/bmf-san/ggc/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests
- [ ] I have updated the documentation (if required)
- [x] Code is formatted with `make fmt`
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing