### PR TITLE
feat: Migrate to Go module v4 and update import paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The Makefile will automatically install required tools like `golangci-lint` usin
 ### Global install with go install
 
 ```sh
-go install github.com/bmf-san/ggc@latest
+go install github.com/bmf-san/ggc/v3@latest
 ```
 
 - The `ggc` binary will be installed to `$GOBIN` (usually `$HOME/go/bin`).
@@ -271,24 +271,24 @@ git/                     # Git operation wrappers
 ### Bash
 Add the following to your `~/.bash_profile` or `~/.bashrc`:
 ```bash
-if [ -f "$(go env GOPATH)/pkg/mod/github.com/bmf-san/ggc@*/tools/completions/ggc.bash" ]; then
-  . "$(go env GOPATH)"/pkg/mod/github.com/bmf-san/ggc@*/tools/completions/ggc.bash
+if [ -f "$(go env GOPATH)/pkg/mod/github.com/bmf-san/ggc/v3@*/tools/completions/ggc.bash" ]; then
+  . "$(go env GOPATH)"/pkg/mod/github.com/bmf-san/ggc/v3@*/tools/completions/ggc.bash
 fi
 ```
 
 ### Zsh
 Add the following to your `~/.zshrc`:
 ```zsh
-if [ -f "$(go env GOPATH)/pkg/mod/github.com/bmf-san/ggc@*/tools/completions/ggc.zsh" ]; then
-  . "$(go env GOPATH)"/pkg/mod/github.com/bmf-san/ggc@*/tools/completions/ggc.zsh
+if [ -f "$(go env GOPATH)/pkg/mod/github.com/bmf-san/ggc/v3@*/tools/completions/ggc.zsh" ]; then
+  . "$(go env GOPATH)"/pkg/mod/github.com/bmf-san/ggc/v3@*/tools/completions/ggc.zsh
 fi
 ```
 
 ### Fish
 Add the following to your `~/.config/fish/config.fish`:
 ```fish
-if test -f (go env GOPATH)/pkg/mod/github.com/bmf-san/ggc@*/tools/completions/ggc.fish
-    source (go env GOPATH)/pkg/mod/github.com/bmf-san/ggc@*/tools/completions/ggc.fish
+if test -f (go env GOPATH)/pkg/mod/github.com/bmf-san/ggc/v3@*/tools/completions/ggc.fish
+    source (go env GOPATH)/pkg/mod/github.com/bmf-san/ggc/v3@*/tools/completions/ggc.fish
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The Makefile will automatically install required tools like `golangci-lint` usin
 ### Global install with go install
 
 ```sh
-go install github.com/bmf-san/ggc/v3@latest
+go install github.com/bmf-san/ggc/v4@latest
 ```
 
 - The `ggc` binary will be installed to `$GOBIN` (usually `$HOME/go/bin`).
@@ -271,24 +271,24 @@ git/                     # Git operation wrappers
 ### Bash
 Add the following to your `~/.bash_profile` or `~/.bashrc`:
 ```bash
-if [ -f "$(go env GOPATH)/pkg/mod/github.com/bmf-san/ggc/v3@*/tools/completions/ggc.bash" ]; then
-  . "$(go env GOPATH)"/pkg/mod/github.com/bmf-san/ggc/v3@*/tools/completions/ggc.bash
+if [ -f "$(go env GOPATH)/pkg/mod/github.com/bmf-san/ggc/v4@*/tools/completions/ggc.bash" ]; then
+  . "$(go env GOPATH)"/pkg/mod/github.com/bmf-san/ggc/v4@*/tools/completions/ggc.bash
 fi
 ```
 
 ### Zsh
 Add the following to your `~/.zshrc`:
 ```zsh
-if [ -f "$(go env GOPATH)/pkg/mod/github.com/bmf-san/ggc/v3@*/tools/completions/ggc.zsh" ]; then
-  . "$(go env GOPATH)"/pkg/mod/github.com/bmf-san/ggc/v3@*/tools/completions/ggc.zsh
+if [ -f "$(go env GOPATH)/pkg/mod/github.com/bmf-san/ggc/v4@*/tools/completions/ggc.zsh" ]; then
+  . "$(go env GOPATH)"/pkg/mod/github.com/bmf-san/ggc/v4@*/tools/completions/ggc.zsh
 fi
 ```
 
 ### Fish
 Add the following to your `~/.config/fish/config.fish`:
 ```fish
-if test -f (go env GOPATH)/pkg/mod/github.com/bmf-san/ggc/v3@*/tools/completions/ggc.fish
-    source (go env GOPATH)/pkg/mod/github.com/bmf-san/ggc/v3@*/tools/completions/ggc.fish
+if test -f (go env GOPATH)/pkg/mod/github.com/bmf-san/ggc/v4@*/tools/completions/ggc.fish
+    source (go env GOPATH)/pkg/mod/github.com/bmf-san/ggc/v4@*/tools/completions/ggc.fish
 end
 ```
 

--- a/cmd/branch.go
+++ b/cmd/branch.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/bmf-san/ggc/git"
+	"github.com/bmf-san/ggc/v3/git"
 )
 
 // Brancher provides functionality for the branch command.

--- a/cmd/branch.go
+++ b/cmd/branch.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/bmf-san/ggc/v3/git"
+	"github.com/bmf-san/ggc/v4/git"
 )
 
 // Brancher provides functionality for the branch command.

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/bmf-san/ggc/v3/git"
+	"github.com/bmf-san/ggc/v4/git"
 )
 
 // Cleaner provides functionality for the clean command.

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/bmf-san/ggc/git"
+	"github.com/bmf-san/ggc/v3/git"
 )
 
 // Cleaner provides functionality for the clean command.

--- a/cmd/clean_test.go
+++ b/cmd/clean_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bmf-san/ggc/v3/git"
+	"github.com/bmf-san/ggc/v4/git"
 )
 
 // mockGitClient for clean_test

--- a/cmd/clean_test.go
+++ b/cmd/clean_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bmf-san/ggc/git"
+	"github.com/bmf-san/ggc/v3/git"
 )
 
 // mockGitClient for clean_test

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -9,7 +9,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/bmf-san/ggc/v3/git"
+	"github.com/bmf-san/ggc/v4/git"
 )
 
 // Executer is an interface for executing commands.

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -9,7 +9,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/bmf-san/ggc/git"
+	"github.com/bmf-san/ggc/v3/git"
 )
 
 // Executer is an interface for executing commands.

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/bmf-san/ggc/git"
+	"github.com/bmf-san/ggc/v3/git"
 )
 
 // mockGitClient is a mock of git.Client.

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/bmf-san/ggc/v3/git"
+	"github.com/bmf-san/ggc/v4/git"
 )
 
 // mockGitClient is a mock of git.Client.

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -8,7 +8,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/bmf-san/ggc/v3/git"
+	"github.com/bmf-san/ggc/v4/git"
 )
 
 // Committer provides functionality for the commit command.

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -8,7 +8,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/bmf-san/ggc/git"
+	"github.com/bmf-san/ggc/v3/git"
 )
 
 // Committer provides functionality for the commit command.

--- a/cmd/commit_test.go
+++ b/cmd/commit_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bmf-san/ggc/git"
+	"github.com/bmf-san/ggc/v3/git"
 )
 
 // mockGitClient for commit_test

--- a/cmd/commit_test.go
+++ b/cmd/commit_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bmf-san/ggc/v3/git"
+	"github.com/bmf-san/ggc/v4/git"
 )
 
 // mockGitClient for commit_test

--- a/cmd/complete.go
+++ b/cmd/complete.go
@@ -5,7 +5,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/bmf-san/ggc/git"
+	"github.com/bmf-san/ggc/v3/git"
 )
 
 // Completer handles dynamic completion for subcommands/args

--- a/cmd/complete.go
+++ b/cmd/complete.go
@@ -5,7 +5,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/bmf-san/ggc/v3/git"
+	"github.com/bmf-san/ggc/v4/git"
 )
 
 // Completer handles dynamic completion for subcommands/args

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/bmf-san/ggc/config"
+	"github.com/bmf-san/ggc/v3/config"
 )
 
 // Configureer handles config operations.

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/bmf-san/ggc/v3/config"
+	"github.com/bmf-san/ggc/v4/config"
 )
 
 // Configureer handles config operations.

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/bmf-san/ggc/v3/cmd/templates"
+	"github.com/bmf-san/ggc/v4/cmd/templates"
 )
 
 // Helper provides help message functionality.

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/bmf-san/ggc/cmd/templates"
+	"github.com/bmf-san/ggc/v3/cmd/templates"
 )
 
 // Helper provides help message functionality.

--- a/cmd/help_test.go
+++ b/cmd/help_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bmf-san/ggc/v3/cmd/templates"
+	"github.com/bmf-san/ggc/v4/cmd/templates"
 )
 
 func TestHelper_ShowHelp(t *testing.T) {

--- a/cmd/help_test.go
+++ b/cmd/help_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bmf-san/ggc/cmd/templates"
+	"github.com/bmf-san/ggc/v3/cmd/templates"
 )
 
 func TestHelper_ShowHelp(t *testing.T) {

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/bmf-san/ggc/v3/config"
+	"github.com/bmf-san/ggc/v4/config"
 )
 
 // Hooker handles git hook operations.

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/bmf-san/ggc/config"
+	"github.com/bmf-san/ggc/v3/config"
 )
 
 // Hooker handles git hook operations.

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/bmf-san/ggc/git"
+	"github.com/bmf-san/ggc/v3/git"
 )
 
 // Logger provides functionality for the log command.

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/bmf-san/ggc/v3/git"
+	"github.com/bmf-san/ggc/v4/git"
 )
 
 // Logger provides functionality for the log command.

--- a/cmd/log_test.go
+++ b/cmd/log_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bmf-san/ggc/git"
+	"github.com/bmf-san/ggc/v3/git"
 )
 
 type mockLogGitClient struct {

--- a/cmd/log_test.go
+++ b/cmd/log_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bmf-san/ggc/v3/git"
+	"github.com/bmf-san/ggc/v4/git"
 )
 
 type mockLogGitClient struct {

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/bmf-san/ggc/v3/git"
+	"github.com/bmf-san/ggc/v4/git"
 )
 
 // Puller provides functionality for the pull command.

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/bmf-san/ggc/git"
+	"github.com/bmf-san/ggc/v3/git"
 )
 
 // Puller provides functionality for the pull command.

--- a/cmd/pull_test.go
+++ b/cmd/pull_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/bmf-san/ggc/git"
+	"github.com/bmf-san/ggc/v3/git"
 )
 
 type mockPullGitClient struct {

--- a/cmd/pull_test.go
+++ b/cmd/pull_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/bmf-san/ggc/v3/git"
+	"github.com/bmf-san/ggc/v4/git"
 )
 
 type mockPullGitClient struct {

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/bmf-san/ggc/git"
+	"github.com/bmf-san/ggc/v3/git"
 )
 
 // Pusher provides functionality for the push command.

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/bmf-san/ggc/v3/git"
+	"github.com/bmf-san/ggc/v4/git"
 )
 
 // Pusher provides functionality for the push command.

--- a/cmd/push_test.go
+++ b/cmd/push_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/bmf-san/ggc/v3/git"
+	"github.com/bmf-san/ggc/v4/git"
 )
 
 type mockPushGitClient struct {

--- a/cmd/push_test.go
+++ b/cmd/push_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/bmf-san/ggc/git"
+	"github.com/bmf-san/ggc/v3/git"
 )
 
 type mockPushGitClient struct {

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/bmf-san/ggc/v3/git"
+	"github.com/bmf-san/ggc/v4/git"
 )
 
 // Resetter handles reset operations.

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/bmf-san/ggc/git"
+	"github.com/bmf-san/ggc/v3/git"
 )
 
 // Resetter handles reset operations.

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/bmf-san/ggc/v3/git"
+	"github.com/bmf-san/ggc/v4/git"
 )
 
 // Restoreer handles restore operations.

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -2,10 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/bmf-san/ggc/git"
 	"io"
 	"os"
 	"os/exec"
+
+	"github.com/bmf-san/ggc/v3/git"
 )
 
 // Restoreer handles restore operations.

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/bmf-san/ggc/git"
+	"github.com/bmf-san/ggc/v3/git"
 )
 
 // Statuseer handles status operations.

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/bmf-san/ggc/v3/git"
+	"github.com/bmf-san/ggc/v4/git"
 )
 
 // Statuseer handles status operations.

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -8,7 +8,7 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/bmf-san/ggc/config"
+	"github.com/bmf-san/ggc/v3/config"
 )
 
 // VersionGetter is a function type for getting version info

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -8,7 +8,7 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/bmf-san/ggc/v3/config"
+	"github.com/bmf-san/ggc/v4/config"
 )
 
 // VersionGetter is a function type for getting version info

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bmf-san/ggc/v3
+module github.com/bmf-san/ggc/v4
 
 go 1.25.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bmf-san/ggc
+module github.com/bmf-san/ggc/v3
 
 go 1.25.0
 

--- a/install.sh
+++ b/install.sh
@@ -44,14 +44,14 @@ get_latest_version() {
 
 detect_platform() {
     local os arch
-    
+
     case "$(uname -s)" in
         Linux*)   os="linux" ;;
         Darwin*)  os="darwin" ;;
         CYGWIN*|MINGW*|MSYS*) os="windows" ;;
         *)        os="unknown" ;;
     esac
-    
+
     case "$(uname -m)" in
         x86_64|amd64) arch="amd64" ;;
         arm64|aarch64) arch="arm64" ;;
@@ -59,37 +59,37 @@ detect_platform() {
         i386|i686) arch="386" ;;
         *) arch="unknown" ;;
     esac
-    
+
     echo "${os}_${arch}"
 }
 
 install_from_source() {
     print_info "Installing ggc from source (recommended for full version info)..."
-    
+
     if ! command_exists go; then
         print_error "Go is not installed. Please install Go first."
         return 1
     fi
-    
+
     if ! command_exists git; then
         print_error "Git is not installed. Please install Git first."
         return 1
     fi
-    
+
     local temp_dir
     temp_dir=$(mktemp -d)
-    
+
     print_info "Cloning repository to $temp_dir..."
     if ! git clone "$REPO_URL" "$temp_dir"; then
         print_error "Failed to clone repository"
         rm -rf "$temp_dir"
         return 1
     fi
-    
+
     cd "$temp_dir"
-    
+
     print_info "Building ggc with full version information..."
-    
+
     # Try to build with make first (preferred for version info)
     if [ -f "Makefile" ]; then
         print_info "Using Makefile for build (includes version information)..."
@@ -113,10 +113,10 @@ install_from_source() {
             return 1
         fi
     fi
-    
+
     # Create install directory
     mkdir -p "$INSTALL_DIR"
-    
+
     # Move binary to install directory
     if ! mv ggc "$INSTALL_DIR/$BINARY_NAME"; then
         print_error "Failed to move binary to install directory"
@@ -124,21 +124,21 @@ install_from_source() {
         rm -rf "$temp_dir"
         return 1
     fi
-    
+
     chmod +x "$INSTALL_DIR/$BINARY_NAME"
-    
+
     print_success "ggc installed successfully to $INSTALL_DIR/$BINARY_NAME"
     print_info "This installation includes full version and commit information"
-    
+
     # Check if install directory is in PATH
     if ! echo "$PATH" | grep -q "$INSTALL_DIR"; then
         print_warning "Install directory not in PATH. Adding it automatically..."
         add_to_path "$INSTALL_DIR"
     fi
-    
+
     cd ..
     rm -rf "$temp_dir"
-    
+
     return 0
 }
 
@@ -146,33 +146,33 @@ install_with_go() {
     print_warning "Installing ggc using 'go install' (fallback method)..."
     print_warning "Note: This method provides limited version information compared to source installation"
     print_warning "Version may show as development build."
-    
+
     if ! command_exists go; then
         print_error "Go is not installed. Please install Go first."
         return 1
     fi
-    
+
     print_info "Running go install..."
-    if ! go install github.com/bmf-san/ggc@latest; then
+    if ! go install github.com/bmf-san/ggc/v3@latest; then
         print_error "go install failed"
         return 1
     fi
-    
+
     local gobin
     gobin=$(go env GOBIN)
     if [ -z "$gobin" ]; then
         gobin="$(go env GOPATH)/bin"
     fi
-    
+
     if [ -f "$gobin/ggc" ]; then
         print_success "ggc installed successfully to $gobin/ggc"
         print_warning "This installation has limited version information due to go install limitations"
-        
+
         if ! echo "$PATH" | grep -q "$gobin"; then
             print_warning "Go bin directory not in PATH. Adding it automatically..."
             add_to_path "$gobin"
         fi
-        
+
         return 0
     else
         print_error "Installation failed - binary not found"
@@ -183,10 +183,10 @@ install_with_go() {
 create_fish_completion() {
     local fish_completions_dir="$HOME/.config/fish/completions"
     local fish_completion_file="$fish_completions_dir/ggc.fish"
-    
+
     # Create completions directory if it doesn't exist
     mkdir -p "$fish_completions_dir"
-    
+
     # Create the fish completion loader
     cat > "$fish_completion_file" << 'EOF'
 # Fish completion loader for ggc
@@ -197,22 +197,22 @@ function __ggc_load_completion
     if test -z "$gopath"
         return 1
     end
-    
+
     # Look for completion file in go modules
-    for completion_file in "$gopath"/pkg/mod/github.com/bmf-san/ggc@*/tools/completions/ggc.fish
+    for completion_file in "$gopath"/pkg/mod/github.com/bmf-san/ggc/v3@*/tools/completions/ggc.fish
         if test -f "$completion_file"
             source "$completion_file"
             return 0
         end
     end
-    
+
     # Fallback: find completion file
     set -l completion_file (find "$gopath/pkg/mod/github.com/bmf-san" -name "ggc.fish" -path "*/tools/completions/*" 2>/dev/null | head -1)
     if test -n "$completion_file"; and test -f "$completion_file"
         source "$completion_file"
         return 0
     end
-    
+
     return 1
 end
 
@@ -227,7 +227,7 @@ EOF
 
 setup_shell_completion() {
     print_info "Setting up shell completion..."
-    
+
     # better way to detect shell using basename
     local current_shell
     current_shell=$(basename "$SHELL" 2>/dev/null || echo "unknown")
@@ -242,7 +242,7 @@ load_ggc_completion() {
 		return 1
 	fi
 
-	for completion_file in "$gopath"/pkg/mod/github.com/bmf-san/ggc@*/tools/completions/ggc.bash; do
+	for completion_file in "$gopath"/pkg/mod/github.com/bmf-san/ggc/v3@*/tools/completions/ggc.bash; do
 		if [ -f "$completion_file" ]; then
 			source "$completion_file"
 			return 0
@@ -275,7 +275,7 @@ load_ggc_completion() {
 		return 1
 	fi
 
-	for completion_file in "$gopath"/pkg/mod/github.com/bmf-san/ggc@*/tools/completions/ggc.zsh; do
+	for completion_file in "$gopath"/pkg/mod/github.com/bmf-san/ggc/v3@*/tools/completions/ggc.zsh; do
 		if [ -f "$completion_file" ]; then
 			source "$completion_file"
 			return 0
@@ -297,7 +297,7 @@ if command -v go >/dev/null 2>&1; then
 fi
 EOF
 )
-    
+
     case "$current_shell" in
         bash)
             local bash_profile="$HOME/.bashrc"
@@ -308,7 +308,7 @@ EOF
                     bash_profile="$HOME/.bashrc"
                 fi
             fi
-            
+
             if [ -f "$bash_profile" ]; then
                 if ! grep -q "load_ggc_completion" "$bash_profile"; then
                     echo "" >> "$bash_profile"
@@ -354,12 +354,12 @@ EOF
 
 add_to_path() {
     local path_to_add="$1"
-    
+
     local current_shell
     current_shell=$(basename "$SHELL" 2>/dev/null || echo "unknown")
-    
+
     local path_line="export PATH=\$PATH:$path_to_add"
-    
+
     case "$current_shell" in
         bash)
             local bash_profile="$HOME/.bashrc"
@@ -370,7 +370,7 @@ add_to_path() {
                     bash_profile="$HOME/.bashrc"
                 fi
             fi
-            
+
             if [ -f "$bash_profile" ]; then
                 if ! grep -q "PATH.*$path_to_add" "$bash_profile"; then
 					{
@@ -410,7 +410,7 @@ add_to_path() {
         fish)
             local fish_config="$HOME/.config/fish/config.fish"
             local fish_path_line="set -gx PATH \$PATH $path_to_add"
-            
+
             if [ -f "$fish_config" ]; then
                 if ! grep -q "PATH.*$path_to_add" "$fish_config"; then
 					{
@@ -438,44 +438,44 @@ add_to_path() {
 
 check_dependencies() {
     local missing_deps=()
-    
+
     if ! command_exists go; then
         missing_deps+=("go")
     fi
-    
+
     if ! command_exists git; then
         missing_deps+=("git")
     fi
-    
+
     if [ ${#missing_deps[@]} -gt 0 ]; then
         print_error "Missing required dependencies: ${missing_deps[*]}"
         print_info "For source installation (recommended), you need both Go and Git"
         print_info "For fallback installation, you only need Go (but with limited version info)"
         return 1
     fi
-    
+
     return 0
 }
 
 main() {
     echo "ggc Installation Script"
     echo "======================="
-    
+
     print_info "Installation directory: $INSTALL_DIR"
-    
+
     installation_success=false
-    
+
     # Check if we have the basic requirements
     if command_exists go && command_exists git; then
         print_info "✅ Go and Git detected - proceeding with source installation"
         print_info "This will provide full version and commit information"
-        
+
         if install_from_source; then
             installation_success=true
         else
             print_warning "❌ Source installation failed"
             print_info "Falling back to 'go install' method..."
-            
+
             if install_with_go; then
                 installation_success=true
             fi
@@ -483,7 +483,7 @@ main() {
     elif command_exists go; then
         print_warning "⚠️  Git not found - source installation unavailable"
         print_info "Falling back to 'go install' method (limited version info)"
-        
+
         if install_with_go; then
             installation_success=true
         fi
@@ -493,11 +493,11 @@ main() {
         print_info "For best results, also install Git for source installation"
         exit 1
     fi
-    
+
     if [ "$installation_success" = true ]; then
         echo ""
         print_success "✅ Installation completed successfully!"
-        
+
         # Test the installation
         local installed_binary
         if [ -f "$INSTALL_DIR/$BINARY_NAME" ]; then
@@ -512,7 +512,7 @@ main() {
                 installed_binary="$gobin/ggc"
             fi
         fi
-        
+
         if [ -n "$installed_binary" ]; then
             print_info "Testing installation..."
             if "$installed_binary" version >/dev/null 2>&1; then
@@ -521,9 +521,9 @@ main() {
                 print_warning "⚠️  ggc installed but version command failed"
             fi
         fi
-        
+
         print_info "Run 'ggc --help' or just 'ggc' to get started"
-        
+
         echo ""
         setup_shell_completion
     else

--- a/install.sh
+++ b/install.sh
@@ -153,7 +153,7 @@ install_with_go() {
     fi
 
     print_info "Running go install..."
-    if ! go install github.com/bmf-san/ggc/v3@latest; then
+    if ! go install github.com/bmf-san/ggc/v4@latest; then
         print_error "go install failed"
         return 1
     fi
@@ -199,7 +199,7 @@ function __ggc_load_completion
     end
 
     # Look for completion file in go modules
-    for completion_file in "$gopath"/pkg/mod/github.com/bmf-san/ggc/v3@*/tools/completions/ggc.fish
+    for completion_file in "$gopath"/pkg/mod/github.com/bmf-san/ggc/v4@*/tools/completions/ggc.fish
         if test -f "$completion_file"
             source "$completion_file"
             return 0
@@ -242,7 +242,7 @@ load_ggc_completion() {
 		return 1
 	fi
 
-	for completion_file in "$gopath"/pkg/mod/github.com/bmf-san/ggc/v3@*/tools/completions/ggc.bash; do
+	for completion_file in "$gopath"/pkg/mod/github.com/bmf-san/ggc/v4@*/tools/completions/ggc.bash; do
 		if [ -f "$completion_file" ]; then
 			source "$completion_file"
 			return 0
@@ -275,7 +275,7 @@ load_ggc_completion() {
 		return 1
 	fi
 
-	for completion_file in "$gopath"/pkg/mod/github.com/bmf-san/ggc/v3@*/tools/completions/ggc.zsh; do
+	for completion_file in "$gopath"/pkg/mod/github.com/bmf-san/ggc/v4@*/tools/completions/ggc.zsh; do
 		if [ -f "$completion_file" ]; then
 			source "$completion_file"
 			return 0

--- a/main.go
+++ b/main.go
@@ -4,9 +4,9 @@ package main
 import (
 	"os"
 
-	"github.com/bmf-san/ggc/cmd"
-	"github.com/bmf-san/ggc/config"
-	"github.com/bmf-san/ggc/router"
+	"github.com/bmf-san/ggc/v3/cmd"
+	"github.com/bmf-san/ggc/v3/config"
+	"github.com/bmf-san/ggc/v3/router"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -4,9 +4,9 @@ package main
 import (
 	"os"
 
-	"github.com/bmf-san/ggc/v3/cmd"
-	"github.com/bmf-san/ggc/v3/config"
-	"github.com/bmf-san/ggc/v3/router"
+	"github.com/bmf-san/ggc/v4/cmd"
+	"github.com/bmf-san/ggc/v4/config"
+	"github.com/bmf-san/ggc/v4/router"
 )
 
 var (

--- a/router/router.go
+++ b/router/router.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/bmf-san/ggc/v3/cmd"
-	"github.com/bmf-san/ggc/v3/config"
+	"github.com/bmf-san/ggc/v4/cmd"
+	"github.com/bmf-san/ggc/v4/config"
 )
 
 // Router represents the command router with config support.

--- a/router/router.go
+++ b/router/router.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/bmf-san/ggc/cmd"
-	"github.com/bmf-san/ggc/config"
+	"github.com/bmf-san/ggc/v3/cmd"
+	"github.com/bmf-san/ggc/v3/config"
 )
 
 // Router represents the command router with config support.

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -3,7 +3,7 @@ package router
 import (
 	"testing"
 
-	"github.com/bmf-san/ggc/config"
+	"github.com/bmf-san/ggc/v3/config"
 )
 
 type mockExecuter struct {

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -3,7 +3,7 @@ package router
 import (
 	"testing"
 
-	"github.com/bmf-san/ggc/v3/config"
+	"github.com/bmf-san/ggc/v4/config"
 )
 
 type mockExecuter struct {


### PR DESCRIPTION
## Description of Changes
- Update Go module path to `github.com/bmf-san/ggc/v4` for v4 support
- Refactor all import paths to use `/v4`
- Clean up tags and release management 

## Related Issue
N/A

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/bmf-san/ggc/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests
- [x] I have updated the documentation (if required)
- [x] Code is formatted with `make fmt`
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing

## Screenshots (if appropriate)
<!-- Add screenshots to help explain your changes. -->

## Additional Context
- Follows Go module versioning rules for v4 and above
- Existing tags and releases have been cleaned up