### PR TITLE
fix(cmd/restore): prevent panic on short refs in isCommitLike

### DIFF
--- a/cmd/branch_test.go
+++ b/cmd/branch_test.go
@@ -63,6 +63,8 @@ func (m *mockBranchGitClient) RestoreFromCommit(string, ...string) error {
 	return nil
 }
 
+func (m *mockBranchGitClient) RevParseVerify(string) bool { return false }
+
 func TestBrancher_Branch_Current(t *testing.T) {
 	var buf bytes.Buffer
 	mockClient := &mockBranchGitClient{

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -82,6 +82,8 @@ func (m *mockGitClient) CleanDirs() error {
 	return nil
 }
 
+func (m *mockGitClient) RevParseVerify(string) bool { return false }
+
 func (m *mockGitClient) GetBranchName() (string, error) {
 	return "main", nil
 }

--- a/cmd/complete_test.go
+++ b/cmd/complete_test.go
@@ -43,6 +43,7 @@ func (m *mockCompleteGitClient) RestoreAllStaged() error                   { ret
 func (m *mockCompleteGitClient) RestoreStaged(...string) error             { return nil }
 func (m *mockCompleteGitClient) RestoreWorkingDir(...string) error         { return nil }
 func (m *mockCompleteGitClient) RestoreFromCommit(string, ...string) error { return nil }
+func (m *mockCompleteGitClient) RevParseVerify(string) bool                { return false }
 
 func TestCompleter_Complete_Branch(t *testing.T) {
 	// Capture stdout

--- a/cmd/restore_test.go
+++ b/cmd/restore_test.go
@@ -185,6 +185,8 @@ func (m *MockGitClient) RestoreFromCommit(commit string, paths ...string) error 
 	return cmd.Run()
 }
 
+func (m *MockGitClient) RevParseVerify(string) bool { return false }
+
 func (m *MockGitClient) GetCurrentBranch() (string, error) {
 	return "main", nil
 }
@@ -288,6 +290,16 @@ func TestRestoreer_Restore_CommitLikeBoundary(t *testing.T) {
 			name:     "non-hex string not treated as commit",
 			args:     []string{"deadbeeg", "file.txt"},
 			expected: "git restore deadbeeg file.txt",
+		},
+		{
+			name:     "HEADERS not treated as commit",
+			args:     []string{"HEADERS", "file.txt"},
+			expected: "git restore HEADERS file.txt",
+		},
+		{
+			name:     "HEAD@{1} treated as commit",
+			args:     []string{"HEAD@{1}", "file.txt"},
+			expected: "git restore --source HEAD@{1} file.txt",
 		},
 	}
 

--- a/git/git.go
+++ b/git/git.go
@@ -18,6 +18,7 @@ type Clienter interface {
 	ListLocalBranches() ([]string, error)
 	ListRemoteBranches() ([]string, error)
 	CheckoutNewBranch(name string) error
+	RevParseVerify(ref string) bool
 	Push(force bool) error
 	Pull(rebase bool) error
 	LogSimple() error
@@ -83,4 +84,14 @@ func (c *Client) GetCurrentBranch() (string, error) {
 	}
 	branch := strings.TrimSpace(string(out))
 	return branch, nil
+}
+
+// RevParseVerify checks whether the given ref resolves to a valid object.
+// It runs: git rev-parse --verify --quiet <ref>
+func (c *Client) RevParseVerify(ref string) bool {
+	cmd := c.execCommand("git", "rev-parse", "--verify", "--quiet", ref)
+	if err := cmd.Run(); err != nil {
+		return false
+	}
+	return true
 }

--- a/git/mock.go
+++ b/git/mock.go
@@ -9,6 +9,7 @@ type MockClient struct {
 	ListLocalBranchesFunc  func() ([]string, error)
 	ListRemoteBranchesFunc func() ([]string, error)
 	CheckoutNewBranchFunc  func(name string) error
+	RevParseVerifyFunc     func(ref string) bool
 	CleanFilesFunc         func() error
 	CleanDirsFunc          func() error
 	CommitAllowEmptyFunc   func() error
@@ -42,6 +43,14 @@ func (m *MockClient) ListRemoteBranches() ([]string, error) {
 // CheckoutNewBranch is a mock of CheckoutNewBranch.
 func (m *MockClient) CheckoutNewBranch(name string) error {
 	return m.CheckoutNewBranchFunc(name)
+}
+
+// RevParseVerify is a mock of RevParseVerify.
+func (m *MockClient) RevParseVerify(ref string) bool {
+	if m.RevParseVerifyFunc != nil {
+		return m.RevParseVerifyFunc(ref)
+	}
+	return false
 }
 
 // CleanFiles is a mock of CleanFiles.


### PR DESCRIPTION
## Description of Changes
- Guard commit-like detection with Git:
    - Prefer git rev-parse --verify --quiet <ref> to classify commit-ish.
- Tighten heuristics as a safe fallback:
    - HEAD variants: match HEAD, HEAD^, HEAD~, HEAD@{...} only.
    - Refs: accept refs/... and common origin/....
    - Hex SHAs: accept 7–64 hex chars (SHA-1/256) without panicking.
- Remove unsafe fixed-index slicing that caused slice-bounds panics.
- Update git client:
    - Add RevParseVerify(ref string) bool to git.Clienter and implement in client.
    - Update test mocks to satisfy the new interface.
- Add/extend boundary tests:
    - Short non-commit strings treated as file paths.
    - HEAD/HEAD~1/HEAD@{1}, refs/heads/main, origin/main treated as commit-like.
    - 7- and 64-char hex recognized; non-hex rejected.
    - Negative case: HEADERS treated as a path (not commit-ish).

## Related Issue
closes #139 

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/bmf-san/ggc/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests
- [x] Code is formatted with `make fmt`
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing

## Screenshots (if appropriate)
- Not applicable. This change prevents a runtime panic and is covered by unit tests.

## Additional Context
- Reproduction on main HEAD:
    - Command: ggc restore re file1.txt
    - Result: panic: runtime error: slice bounds out of range [:4] with length 2
    - Root cause: isCommitLike previously sliced s[:4]/s[:7]/s[:8] without length checks.
- Fix summary:
    - Use rev-parse --verify to authoritatively identify commit-ish and avoid false positives (e.g., HEADERS).
    - Keep strict, safe heuristics as a fallback to avoid panics and support offline cases.
    - Maintain intended routing: legitimate refs/SHAs use --source; short non-commit strings are treated as file paths.