### PR TITLE
fix(config): validate-before-write and atomic save with 0700/0600 perms; Windows safety

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ ggc
 
 # Compiled binaries from goreleaser
 dist/
+.DS_Store

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -223,6 +223,28 @@ func TestSave(t *testing.T) {
 	}
 }
 
+// TestSaveDoesNotWriteOnInvalidConfig ensures Save validates before writing
+// and does not leave a config file on disk when validation fails.
+func TestSaveDoesNotWriteOnInvalidConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "test-invalid-save.yaml")
+
+	cm := NewConfigManager()
+	cm.configPath = configPath
+
+	// Force an invalid editor so validation fails
+	cm.config.Default.Editor = "this-editor-should-not-exist-xyz"
+
+	err := cm.Save()
+	if err == nil {
+		t.Fatal("expected Save to fail validation, got nil error")
+	}
+
+	if _, statErr := os.Stat(configPath); !os.IsNotExist(statErr) {
+		t.Fatalf("expected no config file to be written, got statErr=%v", statErr)
+	}
+}
+
 // TestGetValueByPath tests getting values using dot notation
 func TestGetValueByPath(t *testing.T) {
 	cm := NewConfigManager()


### PR DESCRIPTION
## Description of Changes
- Validate-before-write: Prevents persisting invalid configs by validating prior to any write.
- Atomic-ish save: Write to a temp file, close it, then rename over the destination. On Windows, remove and replace.
failures.
- Secure permissions: Create config directory with 0700; ensure final file is 0600 on Unix.
- Test added: Ensures Save() does not write a file when validation fails (invalid editor).

## Related Issue
closes #145 

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/bmf-san/ggc/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests
- [x] Code is formatted with `make fmt`
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing

## Screenshots (if appropriate)
N/A

## Additional Context
N/A