### PR TITLE
chore(deps): Migrate to maintained go-yaml version

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ ggc is a Git tool written in Go, offering both traditional CLI commands and an i
 - Implemented using the Go standard library and:
     - [golang.org/x/term](https://pkg.go.dev/golang.org/x/term) – for terminal interaction
     - [golang.org/x/sys](https://pkg.go.dev/golang.org/x/sys) – for low-level OS interaction
-    - [gopkg.in/yaml.v3](https://pkg.go.dev/gopkg.in/yaml.v3) – for parsing `~/.ggcconfig.yaml`
+    - [go.yaml.in/yaml/v3](https://pkg.go.dev/go.yaml.in/yaml/v3) – for parsing `~/.ggcconfig.yaml`
 
 ## Supported Environments
 - OS: macOS (Apple Silicon/Intel) - Verified
 - Go version: 1.25 or later recommended
-- Dependencies: Go standard library, `golang.org/x/term`, `golang.org/x/sys`, `gopkg.in/yaml.v3`
+- Dependencies: Go standard library, `golang.org/x/term`, `golang.org/x/sys`, `go.yaml.in/yaml/v3`
 - Requirement: `git` command must be installed
 
 ## Installation

--- a/config/config.go
+++ b/config/config.go
@@ -9,7 +9,7 @@ import (
 	"reflect"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // Config represents the complete configuration structure

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // TestGetDefaultConfig tests the default configuration values

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/bmf-san/ggc/v4
 go 1.25.0
 
 require (
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/term v0.34.0
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require golang.org/x/sys v0.35.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
 golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/term v0.34.0 h1:O/2T7POpk0ZZ7MAzMeWFSg6S5IpWd/RXDlM9hgM3DR4=
 golang.org/x/term v0.34.0/go.mod h1:5jC53AEywhIVebHgPVeg0mj8OD3VO9OzclacVrqpaAw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Description of Changes
- Migrate YAML dependency from unmaintained gopkg.in/yaml.v3 to maintained go.yaml.in/yaml/v3.
- Update import paths in `config/config.go` and `config/config_test.go`.
- Ran `make deps`
- Update README.md to reflect the new module path.
- No functional changes intended; configuration parsing behavior remains the same.

## Related Issue
closes #149 

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/bmf-san/ggc/blob/main/CONTRIBUTING.md)
- [x] I have updated the documentation (if required)
- [x] Code is formatted with `make fmt`
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing

## Screenshots
N/A

## Additional Context
- Rationale: go.yaml.in/yaml/v3 is the actively maintained path for the YAML v3 module, reducing maintenance and supply-chain risk versus the legacy gopkg.in path.
- Scope: Mechanical migration only (imports, module files, docs); no logic changes.