### PR TITLE
feat: upgrade to v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The Makefile will automatically install required tools like `golangci-lint` usin
 ### Global install with go install
 
 ```sh
-go install github.com/bmf-san/ggc/v4@latest
+go install github.com/bmf-san/ggc/v5@latest
 ```
 
 - The `ggc` binary will be installed to `$GOBIN` (usually `$HOME/go/bin`).
@@ -279,24 +279,24 @@ git/                     # Git operation wrappers
 ### Bash
 Add the following to your `~/.bash_profile` or `~/.bashrc`:
 ```bash
-if [ -f "$(go env GOPATH)/pkg/mod/github.com/bmf-san/ggc/v4@*/tools/completions/ggc.bash" ]; then
-  . "$(go env GOPATH)"/pkg/mod/github.com/bmf-san/ggc/v4@*/tools/completions/ggc.bash
+if [ -f "$(go env GOPATH)/pkg/mod/github.com/bmf-san/ggc/v5@*/tools/completions/ggc.bash" ]; then
+  . "$(go env GOPATH)"/pkg/mod/github.com/bmf-san/ggc/v5@*/tools/completions/ggc.bash
 fi
 ```
 
 ### Zsh
 Add the following to your `~/.zshrc`:
 ```zsh
-if [ -f "$(go env GOPATH)/pkg/mod/github.com/bmf-san/ggc/v4@*/tools/completions/ggc.zsh" ]; then
-  . "$(go env GOPATH)"/pkg/mod/github.com/bmf-san/ggc/v4@*/tools/completions/ggc.zsh
+if [ -f "$(go env GOPATH)/pkg/mod/github.com/bmf-san/ggc/v5@*/tools/completions/ggc.zsh" ]; then
+  . "$(go env GOPATH)"/pkg/mod/github.com/bmf-san/ggc/v5@*/tools/completions/ggc.zsh
 fi
 ```
 
 ### Fish
 Add the following to your `~/.config/fish/config.fish`:
 ```fish
-if test -f (go env GOPATH)/pkg/mod/github.com/bmf-san/ggc/v4@*/tools/completions/ggc.fish
-    source (go env GOPATH)/pkg/mod/github.com/bmf-san/ggc/v4@*/tools/completions/ggc.fish
+if test -f (go env GOPATH)/pkg/mod/github.com/bmf-san/ggc/v5@*/tools/completions/ggc.fish
+    source (go env GOPATH)/pkg/mod/github.com/bmf-san/ggc/v5@*/tools/completions/ggc.fish
 end
 ```
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/git"
 )
 
 // Adder provides functionality for the add command.

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/git"
 )
 
 func TestAdder_Add_NoArgs_PrintsUsage(t *testing.T) {

--- a/cmd/branch.go
+++ b/cmd/branch.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/git"
 )
 
 // Brancher provides functionality for the branch command.

--- a/cmd/branch_test.go
+++ b/cmd/branch_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/git"
 )
 
 // mockBranchGitClient is a mock implementation of git.Clienter for branch tests

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/git"
 )
 
 // Cleaner provides functionality for the clean command.

--- a/cmd/clean_test.go
+++ b/cmd/clean_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/git"
 )
 
 // mockGitClient for clean_test

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -8,7 +8,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/git"
 )
 
 // Executer is an interface for executing commands.

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/git"
 )
 
 // mockGitClient is a mock of git.Client.

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/git"
 )
 
 // Committer provides functionality for the commit command.

--- a/cmd/commit_test.go
+++ b/cmd/commit_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/git"
 )
 
 // mockGitClient for commit_test

--- a/cmd/complete.go
+++ b/cmd/complete.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/git"
 )
 
 // Completer handles dynamic completion for subcommands/args

--- a/cmd/complete_test.go
+++ b/cmd/complete_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/git"
 )
 
 // mockCompleteGitClient is a mock implementation for complete tests

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -9,8 +9,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/bmf-san/ggc/v4/config"
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/config"
+	"github.com/bmf-san/ggc/v5/git"
 )
 
 // Configureer handles config operations.

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bmf-san/ggc/v4/internal/testutil"
+	"github.com/bmf-san/ggc/v5/internal/testutil"
 )
 
 // Mock config manager for testing

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/git"
 )
 
 // Differ handles git diff operations.

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/git"
 )
 
 // Fetcher handles git fetch operations.

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/bmf-san/ggc/v4/cmd/templates"
+	"github.com/bmf-san/ggc/v5/cmd/templates"
 )
 
 // Helper provides help message functionality.

--- a/cmd/help_test.go
+++ b/cmd/help_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bmf-san/ggc/v4/cmd/templates"
+	"github.com/bmf-san/ggc/v5/cmd/templates"
 )
 
 func TestHelper_ShowHelp(t *testing.T) {

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/bmf-san/ggc/v4/config"
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/config"
+	"github.com/bmf-san/ggc/v5/git"
 )
 
 // Hooker handles git hook operations.

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/git"
 	"golang.org/x/term"
 )
 

--- a/cmd/interactive_test.go
+++ b/cmd/interactive_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bmf-san/ggc/v4/internal/testutil"
+	"github.com/bmf-san/ggc/v5/internal/testutil"
 	"golang.org/x/term"
 )
 

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/git"
 )
 
 // Logger provides functionality for the log command.

--- a/cmd/log_test.go
+++ b/cmd/log_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/git"
 )
 
 type mockLogGitClient struct {

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/git"
 )
 
 // Puller provides functionality for the pull command.

--- a/cmd/pull_test.go
+++ b/cmd/pull_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/git"
 )
 
 type mockPullGitClient struct {

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/git"
 )
 
 // Pusher provides functionality for the push command.

--- a/cmd/push_test.go
+++ b/cmd/push_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/git"
 )
 
 type mockPushGitClient struct {

--- a/cmd/rebase.go
+++ b/cmd/rebase.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/git"
 )
 
 // Rebaser handles rebase operations.

--- a/cmd/remote.go
+++ b/cmd/remote.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/git"
 )
 
 // Remoteer provides functionality for the remote command.

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/git"
 )
 
 // Resetter handles reset operations.

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/git"
 )
 
 // Restoreer handles restore operations.

--- a/cmd/stash.go
+++ b/cmd/stash.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/git"
 )
 
 // Stasher handles stash operations.

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/git"
 )
 
 // Statuseer handles status operations.

--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/git"
 )
 
 // Tagger handles tagging operations.

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -8,8 +8,8 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/bmf-san/ggc/v4/config"
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/config"
+	"github.com/bmf-san/ggc/v5/git"
 )
 
 // VersionGetter is a function type for getting version info

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bmf-san/ggc/v4/internal/testutil"
+	"github.com/bmf-san/ggc/v5/internal/testutil"
 )
 
 func TestVersioneer_Version(t *testing.T) {

--- a/config/config.go
+++ b/config/config.go
@@ -11,7 +11,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/git"
 	"go.yaml.in/yaml/v3"
 )
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bmf-san/ggc/v4/internal/testutil"
+	"github.com/bmf-san/ggc/v5/internal/testutil"
 	"go.yaml.in/yaml/v3"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bmf-san/ggc/v4
+module github.com/bmf-san/ggc/v5
 
 go 1.25.0
 

--- a/install.sh
+++ b/install.sh
@@ -153,7 +153,7 @@ install_with_go() {
     fi
 
     print_info "Running go install..."
-    if ! go install github.com/bmf-san/ggc/v4@latest; then
+    if ! go install github.com/bmf-san/ggc/v5@latest; then
         print_error "go install failed"
         return 1
     fi
@@ -199,7 +199,7 @@ function __ggc_load_completion
     end
 
     # Look for completion file in go modules
-    for completion_file in "$gopath"/pkg/mod/github.com/bmf-san/ggc/v4@*/tools/completions/ggc.fish
+    for completion_file in "$gopath"/pkg/mod/github.com/bmf-san/ggc/v5@*/tools/completions/ggc.fish
         if test -f "$completion_file"
             source "$completion_file"
             return 0
@@ -242,7 +242,7 @@ load_ggc_completion() {
 		return 1
 	fi
 
-	for completion_file in "$gopath"/pkg/mod/github.com/bmf-san/ggc/v4@*/tools/completions/ggc.bash; do
+	for completion_file in "$gopath"/pkg/mod/github.com/bmf-san/ggc/v5@*/tools/completions/ggc.bash; do
 		if [ -f "$completion_file" ]; then
 			source "$completion_file"
 			return 0
@@ -275,7 +275,7 @@ load_ggc_completion() {
 		return 1
 	fi
 
-	for completion_file in "$gopath"/pkg/mod/github.com/bmf-san/ggc/v4@*/tools/completions/ggc.zsh; do
+	for completion_file in "$gopath"/pkg/mod/github.com/bmf-san/ggc/v5@*/tools/completions/ggc.zsh; do
 		if [ -f "$completion_file" ]; then
 			source "$completion_file"
 			return 0

--- a/internal/testutil/git_client.go
+++ b/internal/testutil/git_client.go
@@ -3,7 +3,7 @@
 package testutil
 
 import (
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/git"
 )
 
 // NewMockGitClient creates a new mock git client for testing

--- a/main.go
+++ b/main.go
@@ -4,10 +4,10 @@ package main
 import (
 	"os"
 
-	"github.com/bmf-san/ggc/v4/cmd"
-	"github.com/bmf-san/ggc/v4/config"
-	"github.com/bmf-san/ggc/v4/git"
-	"github.com/bmf-san/ggc/v4/router"
+	"github.com/bmf-san/ggc/v5/cmd"
+	"github.com/bmf-san/ggc/v5/config"
+	"github.com/bmf-san/ggc/v5/git"
+	"github.com/bmf-san/ggc/v5/router"
 )
 
 var (

--- a/main_test.go
+++ b/main_test.go
@@ -3,8 +3,8 @@ package main
 import (
 	"testing"
 
-	"github.com/bmf-san/ggc/v4/config"
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/config"
+	"github.com/bmf-san/ggc/v5/git"
 )
 
 func TestGetVersionInfo(t *testing.T) {

--- a/router/router.go
+++ b/router/router.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/bmf-san/ggc/v4/cmd"
-	"github.com/bmf-san/ggc/v4/config"
+	"github.com/bmf-san/ggc/v5/cmd"
+	"github.com/bmf-san/ggc/v5/config"
 )
 
 // Router represents the command router with config support.

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -3,8 +3,8 @@ package router
 import (
 	"testing"
 
-	"github.com/bmf-san/ggc/v4/config"
-	"github.com/bmf-san/ggc/v4/git"
+	"github.com/bmf-san/ggc/v5/config"
+	"github.com/bmf-san/ggc/v5/git"
 )
 
 type mockExecuter struct {


### PR DESCRIPTION
# Pull Request: Release v5

## Description of Changes
This Pull Request upgrades ggc from v4 to v5, updating all module paths, import statements, and documentation to reflect the new major version.

### Key Changes:
- **Module Path Update**: Changed from `github.com/bmf-san/ggc/v4` to `github.com/bmf-san/ggc/v5`
- **Import Statements**: Updated all Go files to use v5 import paths
- **Documentation**: Updated README.md with new installation commands and shell completion paths
- **Installation Script**: Updated install.sh to install v5 instead of v4
- **Dependencies**: Regenerated go.sum for v5 module compatibility

### Breaking Changes:
- Module path changed from v4 to v5
- Users need to update their import statements if using ggc as a library
- Installation command updated to: `go install github.com/bmf-san/ggc/v5@latest`

### Files Modified:
- **46 files changed** (64 insertions, 64 deletions)
- All Go files with import path updates
- README.md with updated installation and completion instructions
- install.sh with updated installation commands
- go.mod module path update
- go.sum regenerated

## Related Issue
This is a major version release to v5 as part of the project's version management strategy.

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/bmf-san/ggc/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests (all existing tests pass)
- [x] I have updated the documentation (README.md, install.sh updated)
- [x] Code is formatted with `make fmt`
- [x] Code passes linter checks via `make lint` (0 issues)
- [x] All tests are passing (all packages pass)

## Screenshots (if appropriate)
N/A - This is a version upgrade with no UI changes.

## Additional Context

### Version Upgrade Details:
- **Previous Version**: v4
- **New Version**: v5
- **Commit Hash**: 923ec9e

### Quality Assurance:
- ✅ **Build**: `go build ./...` - Success
- ✅ **Tests**: `make test` - All packages pass
- ✅ **Linting**: `make lint` - 0 issues
- ✅ **Module Integrity**: go.sum regenerated and verified

### Installation Verification:
New installation command:
```bash
go install github.com/bmf-san/ggc/v5@latest
```

New shell completion paths:
- Bash: `$(go env GOPATH)/pkg/mod/github.com/bmf-san/ggc/v5@*/tools/completions/ggc.bash`
- Zsh: `$(go env GOPATH)/pkg/mod/github.com/bmf-san/ggc/v5@*/tools/completions/ggc.zsh`
- Fish: `$(go env GOPATH)/pkg/mod/github.com/bmf-san/ggc/v5@*/tools/completions/ggc.fish`

### Migration Guide for Users:
1. **For CLI users**: Update installation command to use v5
2. **For library users**: Update import statements from `github.com/bmf-san/ggc/v4/*` to `github.com/bmf-san/ggc/v5/*`
3. **For shell completion users**: Update completion script paths to use v5

This release maintains full backward compatibility in terms of functionality while providing a clean v5 module path for future development.
