### PR TITLE
fix: reduce cyclomatic complexity in processCSIFinalByte function

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -538,17 +538,7 @@ func isWordMotionParam(params string) bool {
 
 // processCSIFinalByte processes the final byte of a CSI sequence
 func (h *KeyHandler) processCSIFinalByte(final byte, params string) {
-	isWord := false
-	if params != "" {
-		for _, p := range strings.Split(params, ";") {
-			if n, err := strconv.Atoi(p); err == nil {
-				if n == 3 || n == 5 || n == 9 {
-					isWord = true
-					break
-				}
-			}
-		}
-	}
+	isWord := isWordMotionParam(params)
 	switch final {
 	case 'C': // Right
 		if isWord {


### PR DESCRIPTION
## Description of Changes
This PR fixes a cyclomatic complexity lint error in the `processCSIFinalByte` function in `cmd/interactive.go`.

**Changes made:**
- Refactored `processCSIFinalByte` function to use the existing `isWordMotionParam` helper function
- Removed duplicate parameter parsing logic that was causing high cyclomatic complexity (11 > 10)
- Simplified the function while maintaining identical functionality
- Reduced code duplication by leveraging existing utility function

The function now has a cyclomatic complexity under the threshold while preserving all existing behavior for CSI sequence processing.

## Related Issue
This addresses the lint error that was preventing clean builds:
```
cmd/interactive.go:540:1: cyclomatic: function (*KeyHandler).processCSIFinalByte has cyclomatic complexity 11 (> max enabled 10) (revive)
```

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/bmf-san/ggc/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests (no new tests needed - refactoring existing functionality)
- [x] I have updated the documentation (no documentation changes required)
- [x] Code is formatted with `make fmt`
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing

## Screenshots (if appropriate)
Before:
```
make lint
cmd/interactive.go:540:1: cyclomatic: function (*KeyHandler).processCSIFinalByte has cyclomatic complexity 11 (> max enabled 10) (revive)
make: *** [lint] Error 1
```

After:
```
make lint
golangci-lint run --max-issues-per-linter=0 --max-same-issues=0
0 issues.
```

## Additional Context
This is a code quality improvement that maintains 100% backward compatibility. The refactoring leverages an existing helper function (`isWordMotionParam`) that was already performing the same parameter parsing logic, eliminating code duplication and reducing complexity.

The change affects terminal input handling for word movement detection in the interactive UI, but the behavior remains identical from a user perspective.
