### PR TITLE
feat(cmd): add keybindings config

### DIFF
--- a/cmd/keybinding_parser.go
+++ b/cmd/keybinding_parser.go
@@ -1,0 +1,98 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+)
+
+// KeyBindingParseResult contains the result of parsing a key binding
+type KeyBindingParseResult struct {
+	ControlCode byte
+	IsValid     bool
+}
+
+// parseKeyBindingInternal parses a key binding string and returns the control code and validity
+func parseKeyBindingInternal(keyStr string) (KeyBindingParseResult, error) {
+	s := strings.TrimSpace(keyStr)
+	if s == "" {
+		return KeyBindingParseResult{}, fmt.Errorf("empty key binding")
+	}
+
+	// Normalize to lowercase for comparison
+	sLower := strings.ToLower(s)
+
+	// Try different format parsers
+	if result, err := parseCtrlFormat(s, sLower, keyStr); err == nil {
+		return result, nil
+	}
+	if result, err := parseCaretFormat(s, keyStr); err == nil {
+		return result, nil
+	}
+	if result, err := parseEmacsFormat(s, sLower, keyStr); err == nil {
+		return result, nil
+	}
+
+	return KeyBindingParseResult{}, fmt.Errorf("unsupported key binding format: %s (supported: 'ctrl+w', '^w', 'C-w')", keyStr)
+}
+
+// parseCtrlFormat handles "ctrl+<key>" format (case-insensitive)
+func parseCtrlFormat(s, sLower, keyStr string) (KeyBindingParseResult, error) {
+	if !strings.HasPrefix(sLower, "ctrl+") || len(s) != len("ctrl+")+1 {
+		return KeyBindingParseResult{}, fmt.Errorf("not ctrl format")
+	}
+
+	c := rune(sLower[len(sLower)-1])
+	code := keyBindingCtrlCode(c)
+	if code == 0 {
+		return KeyBindingParseResult{}, fmt.Errorf("unsupported ctrl key: %s", keyStr)
+	}
+	return KeyBindingParseResult{ControlCode: code, IsValid: true}, nil
+}
+
+// parseCaretFormat handles "^<key>" format (caret notation)
+func parseCaretFormat(s, keyStr string) (KeyBindingParseResult, error) {
+	if !strings.HasPrefix(s, "^") || len(s) != 2 {
+		return KeyBindingParseResult{}, fmt.Errorf("not caret format")
+	}
+
+	c := rune(strings.ToLower(s)[1])
+	code := keyBindingCtrlCode(c)
+	if code == 0 {
+		return KeyBindingParseResult{}, fmt.Errorf("unsupported caret key: %s", keyStr)
+	}
+	return KeyBindingParseResult{ControlCode: code, IsValid: true}, nil
+}
+
+// parseEmacsFormat handles "c-<key>" or "C-<key>" format (emacs notation)
+func parseEmacsFormat(s, sLower, keyStr string) (KeyBindingParseResult, error) {
+	if !strings.HasPrefix(sLower, "c-") || len(s) != 3 {
+		return KeyBindingParseResult{}, fmt.Errorf("not emacs format")
+	}
+
+	c := rune(sLower[2])
+	code := keyBindingCtrlCode(c)
+	if code == 0 {
+		return KeyBindingParseResult{}, fmt.Errorf("unsupported emacs key: %s", keyStr)
+	}
+	return KeyBindingParseResult{ControlCode: code, IsValid: true}, nil
+}
+
+// validateKeyBindingInternal validates a key binding string without returning the control code
+func validateKeyBindingInternal(keyStr string) error {
+	_, err := parseKeyBindingInternal(keyStr)
+	return err
+}
+
+// keyBindingCtrlCode converts a letter to its control byte (e.g., 'a' => 1).
+// Handles both uppercase and lowercase letters for compatibility.
+func keyBindingCtrlCode(r rune) byte {
+	// Handle lowercase letters a-z
+	if r >= 'a' && r <= 'z' {
+		return byte(r-'a') + 1
+	}
+	// Handle uppercase letters A-Z
+	if r >= 'A' && r <= 'Z' {
+		return byte(r-'A') + 1
+	}
+	return 0
+}

--- a/cmd/keybinding_parser_test.go
+++ b/cmd/keybinding_parser_test.go
@@ -1,0 +1,162 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantCode    byte
+		wantValid   bool
+		expectError bool
+	}{
+		// Valid ctrl+ format
+		{"ctrl+a lowercase", "ctrl+a", 1, true, false},
+		{"ctrl+z lowercase", "ctrl+z", 26, true, false},
+		{"CTRL+A uppercase", "CTRL+A", 1, true, false},
+		{"Ctrl+W mixed case", "Ctrl+W", 23, true, false},
+		{"ctrl+w with spaces", "  ctrl+w  ", 23, true, false},
+
+		// Valid caret notation
+		{"^a caret", "^a", 1, true, false},
+		{"^Z caret uppercase", "^Z", 26, true, false},
+		{"^w caret", "^w", 23, true, false},
+
+		// Valid emacs notation
+		{"C-a emacs", "C-a", 1, true, false},
+		{"c-a emacs lowercase", "c-a", 1, true, false},
+		{"C-W emacs uppercase", "C-W", 23, true, false},
+		{"c-z emacs", "c-z", 26, true, false},
+
+		// Invalid inputs
+		{"empty string", "", 0, false, true},
+		{"whitespace only", "   ", 0, false, true},
+		{"ctrl+ too short", "ctrl+", 0, false, true},
+		{"ctrl+ too long", "ctrl+ab", 0, false, true},
+		{"ctrl+ invalid char", "ctrl+1", 0, false, true},
+		{"ctrl+ invalid char @", "ctrl+@", 0, false, true},
+		{"caret too short", "^", 0, false, true},
+		{"caret too long", "^ab", 0, false, true},
+		{"caret invalid char", "^1", 0, false, true},
+		{"emacs too short", "c-", 0, false, true},
+		{"emacs too long", "c-ab", 0, false, true},
+		{"emacs invalid char", "c-1", 0, false, true},
+		{"unsupported format", "alt+a", 0, false, true},
+		{"random string", "hello", 0, false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseKeyBindingInternal(tt.input)
+
+			// Check error expectation
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("parseKeyBindingInternal(%q) expected error, got nil", tt.input)
+				}
+				return
+			}
+
+			// Check no error when not expected
+			if err != nil {
+				t.Errorf("parseKeyBindingInternal(%q) unexpected error: %v", tt.input, err)
+				return
+			}
+
+			// Check validity
+			if result.IsValid != tt.wantValid {
+				t.Errorf("parseKeyBindingInternal(%q).IsValid = %v, want %v", tt.input, result.IsValid, tt.wantValid)
+			}
+
+			// Check control code
+			if result.ControlCode != tt.wantCode {
+				t.Errorf("parseKeyBindingInternal(%q).ControlCode = %d, want %d", tt.input, result.ControlCode, tt.wantCode)
+			}
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expectError bool
+	}{
+		// Valid cases
+		{"valid ctrl+w", "ctrl+w", false},
+		{"valid ^w", "^w", false},
+		{"valid C-w", "C-w", false},
+		{"valid c-w", "c-w", false},
+
+		// Invalid cases
+		{"empty", "", true},
+		{"invalid format", "alt+w", true},
+		{"invalid char", "ctrl+1", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateKeyBindingInternal(tt.input)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("validateKeyBindingInternal(%q) expected error, got nil", tt.input)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("validateKeyBindingInternal(%q) unexpected error: %v", tt.input, err)
+				}
+			}
+		})
+	}
+}
+
+func TestCtrlCode(t *testing.T) {
+	tests := []struct {
+		name string
+		char rune
+		want byte
+	}{
+		{"lowercase a", 'a', 1},
+		{"lowercase z", 'z', 26},
+		{"lowercase w", 'w', 23},
+		{"uppercase A", 'A', 1},
+		{"uppercase Z", 'Z', 26},
+		{"uppercase W", 'W', 23},
+		{"invalid digit", '1', 0},
+		{"invalid symbol", '@', 0},
+		{"invalid space", ' ', 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := keyBindingCtrlCode(tt.char)
+			if got != tt.want {
+				t.Errorf("keyBindingCtrlCode(%q) = %d, want %d", tt.char, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseSynonyms(t *testing.T) {
+	// Test that all synonymous formats produce the same control code
+	want := byte(23) // ctrl+w = 23
+	synonyms := []string{"ctrl+w", "^w", "C-w", "c-w", "CTRL+W", "Ctrl+W"}
+
+	for _, input := range synonyms {
+		t.Run(input, func(t *testing.T) {
+			result, err := parseKeyBindingInternal(input)
+			if err != nil {
+				t.Fatalf("parseKeyBindingInternal(%q) error: %v", input, err)
+			}
+			if result.ControlCode != want {
+				t.Errorf("parseKeyBindingInternal(%q) = %d, want %d", input, result.ControlCode, want)
+			}
+			if !result.IsValid {
+				t.Errorf("parseKeyBindingInternal(%q).IsValid = false, want true", input)
+			}
+		})
+	}
+}

--- a/cmd/keybinding_resolver_test.go
+++ b/cmd/keybinding_resolver_test.go
@@ -15,9 +15,7 @@ func TestKeyBindingResolverLayering(t *testing.T) {
 	cfg.Interactive.Darwin.Keybindings = map[string]interface{}{
 		"move_down": "Ctrl+J",
 	}
-	cfg.Interactive.Terminals = map[string]struct {
-		Keybindings map[string]interface{} `yaml:"keybindings,omitempty"`
-	}{
+	cfg.Interactive.Terminals = map[string]config.KeybindingsConfig{
 		"wezterm": {
 			Keybindings: map[string]interface{}{
 				"move_to_end": "Ctrl+L",
@@ -112,9 +110,7 @@ func TestKeyBindingResolverLayerPrecedence(t *testing.T) {
 	cfg.Interactive.Darwin.Keybindings = map[string]interface{}{
 		"move_up": []interface{}{"Ctrl+S"},
 	}
-	cfg.Interactive.Terminals = map[string]struct {
-		Keybindings map[string]interface{} `yaml:"keybindings,omitempty"`
-	}{
+	cfg.Interactive.Terminals = map[string]config.KeybindingsConfig{
 		"wezterm": {Keybindings: map[string]interface{}{"move_up": "Ctrl+T"}},
 	}
 

--- a/cmd/keybindings.go
+++ b/cmd/keybindings.go
@@ -302,11 +302,6 @@ func hasPrefixFold(s, prefix string) bool {
 	return strings.HasPrefix(strings.ToLower(s), strings.ToLower(prefix))
 }
 
-// hasPrefixFold checks whether s has the given prefix, case-insensitively.
-func hasPrefixFold(s, prefix string) bool {
-	return strings.HasPrefix(strings.ToLower(s), strings.ToLower(prefix))
-}
-
 // ParseKeyBinding parses a key binding string and returns the corresponding
 // single-byte control code. Supports multiple formats:
 // - "ctrl+w", "CTRL+W", "Ctrl+w" (standard format)

--- a/cmd/keybindings.go
+++ b/cmd/keybindings.go
@@ -283,21 +283,18 @@ func (km *KeyBindingMap) MatchesKeyStroke(action string, input KeyStroke) bool {
 	return false
 }
 
-// ctrl converts a lowercase letter to its control byte (e.g., 'a' => 1).
+// ctrl converts a letter to its control byte (e.g., 'a' => 1).
+// Handles both uppercase and lowercase letters.
 func ctrl(r rune) byte {
-	// Only letters a-z are expected here; ensure predictable conversion.
+	// Handle lowercase letters a-z
 	if r >= 'a' && r <= 'z' {
 		return byte(r-'a') + 1
 	}
+	// Handle uppercase letters A-Z
 	if r >= 'A' && r <= 'Z' {
 		return byte(r-'A') + 1
 	}
 	return 0
-}
-
-// hasPrefixFold checks whether s has the given prefix, case-insensitively.
-func hasPrefixFold(s, prefix string) bool {
-	return strings.HasPrefix(strings.ToLower(s), strings.ToLower(prefix))
 }
 
 // ParseKeyBinding parses a key binding string and returns the corresponding
@@ -306,45 +303,11 @@ func hasPrefixFold(s, prefix string) bool {
 // - "^w", "^W" (caret notation)
 // - "c-w", "C-w", "C-W" (emacs notation)
 func ParseKeyBinding(keyStr string) (byte, error) { //nolint:revive // parsing multiple legacy formats
-	s := strings.TrimSpace(keyStr)
-	if s == "" {
-		return 0, fmt.Errorf("empty key binding")
+	result, err := parseKeyBindingInternal(keyStr)
+	if err != nil {
+		return 0, err
 	}
-
-	// Normalize to lowercase for comparison
-	sLower := strings.ToLower(s)
-
-	// Handle "ctrl+<key>" format (case-insensitive)
-	if strings.HasPrefix(sLower, "ctrl+") && len(s) == len("ctrl+")+1 {
-		c := rune(sLower[len(sLower)-1])
-		code := ctrl(c)
-		if code == 0 {
-			return 0, fmt.Errorf("unsupported ctrl key: %s", keyStr)
-		}
-		return code, nil
-	}
-
-	// Handle "^<key>" format (caret notation)
-	if strings.HasPrefix(s, "^") && len(s) == 2 {
-		c := rune(strings.ToLower(s)[1])
-		code := ctrl(c)
-		if code == 0 {
-			return 0, fmt.Errorf("unsupported caret key: %s", keyStr)
-		}
-		return code, nil
-	}
-
-	// Handle "c-<key>" or "C-<key>" format (emacs notation)
-	if hasPrefixFold(s, "c-") && len(s) == 3 {
-		c := rune(sLower[2])
-		code := ctrl(c)
-		if code == 0 {
-			return 0, fmt.Errorf("unsupported emacs key: %s", keyStr)
-		}
-		return code, nil
-	}
-
-	return 0, fmt.Errorf("unsupported key binding format: %s (supported: 'ctrl+w', '^w', 'C-w')", keyStr)
+	return result.ControlCode, nil
 }
 
 // ParseKeyStroke parses a single key binding string and returns a KeyStroke
@@ -380,7 +343,7 @@ func ParseKeyStroke(keyStr string) (KeyStroke, error) { //nolint:revive // parsi
 	}
 
 	// Handle "c-<key>" or "C-<key>" format (emacs notation)
-	if hasPrefixFold(s, "c-") && len(s) == 3 {
+	if strings.HasPrefix(strings.ToLower(s), "c-") && len(s) == 3 {
 		c := rune(sLower[2])
 		if c >= 'a' && c <= 'z' {
 			return NewCtrlKeyStroke(c), nil
@@ -422,7 +385,7 @@ func ParseKeyStroke(keyStr string) (KeyStroke, error) { //nolint:revive // parsi
 	}
 
 	// Handle "M-<key>" format (emacs meta notation)
-	if hasPrefixFold(s, "m-") && len(s) >= 3 {
+	if strings.HasPrefix(strings.ToLower(s), "m-") && len(s) >= 3 {
 		keyPart := strings.ToLower(s[2:])
 
 		// Handle special keys

--- a/cmd/keybindings_layers_test.go
+++ b/cmd/keybindings_layers_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/bmf-san/ggc/v5/config"
@@ -231,9 +232,7 @@ func TestKeyBindingValidation(t *testing.T) {
 
 // Helper function to check if a string contains a substring
 func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
-		(len(s) > len(substr) && contains(s[1:], substr)) ||
-		(len(s) >= len(substr) && s[:len(substr)] == substr))
+	return strings.Contains(s, substr)
 }
 
 // keyBindingMapsEqual compares two KeyBindingMaps for equality

--- a/cmd/keybindings_layers_test.go
+++ b/cmd/keybindings_layers_test.go
@@ -48,17 +48,17 @@ func TestKeyBindingResolution(t *testing.T) {
 			config: func() *config.Config {
 				cfg := &config.Config{}
 				cfg.Interactive.Keybindings.DeleteWord = "ctrl+o"
-				cfg.Interactive.Keybindings.MoveUp = "ctrl+k"
+				cfg.Interactive.Keybindings.MoveUp = "ctrl+l"
 				cfg.Interactive.Keybindings.MoveDown = "ctrl+j"
 				return cfg
 			}(),
 			expected: &KeyBindingMap{
 				DeleteWord:      []KeyStroke{NewCtrlKeyStroke('o')}, // overridden
 				ClearLine:       []KeyStroke{NewCtrlKeyStroke('u')}, // default
-				DeleteToEnd:     []KeyStroke{NewCtrlKeyStroke('k')}, // default (NOTE: conflict with MoveUp!)
+				DeleteToEnd:     []KeyStroke{NewCtrlKeyStroke('k')}, // default
 				MoveToBeginning: []KeyStroke{NewCtrlKeyStroke('a')}, // default
 				MoveToEnd:       []KeyStroke{NewCtrlKeyStroke('e')}, // default
-				MoveUp:          []KeyStroke{NewCtrlKeyStroke('k')}, // overridden (NOTE: conflict with DeleteToEnd!)
+				MoveUp:          []KeyStroke{NewCtrlKeyStroke('l')}, // overridden
 				MoveDown:        []KeyStroke{NewCtrlKeyStroke('j')}, // overridden
 			},
 		},
@@ -93,14 +93,14 @@ func TestKeyBindingConflictDetection(t *testing.T) {
 			expectConflicts: false,
 		},
 		{
-			name: "conflict detected but no error (warns only)",
+			name: "conflict detected returns error",
 			config: func() *config.Config {
 				cfg := &config.Config{}
 				cfg.Interactive.Keybindings.DeleteWord = "ctrl+k"
 				cfg.Interactive.Keybindings.DeleteToEnd = "ctrl+k"
 				return cfg
 			}(),
-			expectError:     false, // warnings only, no errors
+			expectError:     true,
 			expectConflicts: true,
 		},
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1212,9 +1212,7 @@ func TestManagerSaveWithKeybindingOverrides(t *testing.T) {
 	cm.config.Interactive.Darwin.Keybindings = map[string]interface{}{
 		"move_down": "Ctrl+J",
 	}
-	cm.config.Interactive.Terminals = map[string]struct {
-		Keybindings map[string]interface{} `yaml:"keybindings,omitempty"`
-	}{
+	cm.config.Interactive.Terminals = map[string]KeybindingsConfig{
 		"wezterm": {Keybindings: map[string]interface{}{"move_to_end": "Ctrl+L"}},
 	}
 


### PR DESCRIPTION
this one is designed to be landed after #189... the diff will not render correctly until that's merged.

## Description of Changes
- hook keybinding validation into config.Config.Validate, covering profile selection plus global, context, platform, and terminal overrides so invalid entries surface during config load/save.
  - mirror the interactive resolver’s parsing rules locally via parseKeyBinding, allowing caret and Emacs notations while avoiding circular imports and providing consistent error messages.
  - expand manager load/save tests to exercise keybinding overrides (including array inputs) and confirm failed validation blocks writes; add regression coverage in config/config_test.go.
  - note the newly supported formats in cmd/keybindings_layers_test.go to keep resolver tests aligned with the config surface.

## Related Issue
partially resolves 157

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/bmf-san/ggc/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests
- [x] Code is formatted with `make fmt`
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing

## Screenshots (if appropriate)
N/A

## Additional Context
tests: go test ./config, go test ./cmd. Builds on feature/157-keybindings-core; no runtime wiring yet.
