### PR TITLE
chore: replace reflect.DeepEqual with slices.Equal/EqualFunc

### DIFF
--- a/cmd/interactive_test.go
+++ b/cmd/interactive_test.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"bytes"
 	"fmt"
-	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -183,7 +183,7 @@ func TestExtractPlaceholders(t *testing.T) {
 			if len(tt.want) == 0 && len(got) == 0 {
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
+			if !slices.Equal(got, tt.want) {
 				t.Errorf("extractPlaceholders() = %v, want %v", got, tt.want)
 			}
 		})

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -391,7 +391,7 @@ func TestGetValueByPath(t *testing.T) {
 			continue
 		}
 
-		if !reflect.DeepEqual(value, tc.expected) {
+		if value != tc.expected {
 			t.Errorf("Expected value for path %s to be %v, got %v", tc.path, tc.expected, value)
 		}
 	}
@@ -445,7 +445,7 @@ func TestSetValueByPath(t *testing.T) {
 			continue
 		}
 
-		if !reflect.DeepEqual(actualValue, tc.expected) {
+		if actualValue != tc.expected {
 			t.Errorf("Expected value for path %s to be %v, got %v", tc.path, tc.expected, actualValue)
 		}
 	}

--- a/git/add_test.go
+++ b/git/add_test.go
@@ -2,7 +2,7 @@ package git
 
 import (
 	"os/exec"
-	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -54,7 +54,7 @@ func TestClient_Add(t *testing.T) {
 				return
 			}
 
-			if !tt.wantErr && !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+			if !tt.wantErr && !slices.Equal(gotArgs, tt.wantArgs) {
 				t.Errorf("Add() gotArgs = %v, want %v", gotArgs, tt.wantArgs)
 			}
 		})
@@ -76,7 +76,7 @@ func TestClient_AddInteractive(t *testing.T) {
 	}
 
 	wantArgs := []string{"git", "add", "-p"}
-	if !reflect.DeepEqual(gotArgs, wantArgs) {
+	if !slices.Equal(gotArgs, wantArgs) {
 		t.Errorf("AddInteractive() gotArgs = %v, want %v", gotArgs, wantArgs)
 	}
 }

--- a/git/branch_test.go
+++ b/git/branch_test.go
@@ -3,7 +3,7 @@ package git
 import (
 	"errors"
 	"os/exec"
-	"reflect"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -45,7 +45,7 @@ func TestClient_ListLocalBranches(t *testing.T) {
 				t.Errorf("ListLocalBranches() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
+			if !slices.Equal(got, tt.want) {
 				t.Errorf("ListLocalBranches() = %v, want %v", got, tt.want)
 			}
 		})
@@ -89,7 +89,7 @@ func TestClient_ListRemoteBranches(t *testing.T) {
 				t.Errorf("ListRemoteBranches() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
+			if !slices.Equal(got, tt.want) {
 				t.Errorf("ListRemoteBranches() = %v, want %v", got, tt.want)
 			}
 		})
@@ -228,7 +228,7 @@ func TestClient_SortBranches(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SortBranches error: %v", err)
 	}
-	if !reflect.DeepEqual(got, []string{"b1", "b2", "b3"}) {
+	if !slices.Equal(got, []string{"b1", "b2", "b3"}) {
 		t.Errorf("unexpected result: %v", got)
 	}
 }
@@ -244,7 +244,7 @@ func TestClient_BranchesContaining(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BranchesContaining error: %v", err)
 	}
-	if !reflect.DeepEqual(got, []string{"main", "feature", "bugfix"}) {
+	if !slices.Equal(got, []string{"main", "feature", "bugfix"}) {
 		t.Errorf("unexpected branches: %v", got)
 	}
 }
@@ -555,7 +555,7 @@ func TestClient_ListMergedBranches(t *testing.T) {
 				t.Errorf("ListMergedBranches() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
+			if !slices.Equal(got, tt.want) {
 				t.Errorf("ListMergedBranches() = %v, want %v", got, tt.want)
 			}
 		})

--- a/git/clean_test.go
+++ b/git/clean_test.go
@@ -3,7 +3,7 @@ package git
 import (
 	"errors"
 	"os/exec"
-	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -18,7 +18,7 @@ func TestClient_CleanFiles(t *testing.T) {
 
 	_ = client.CleanFiles()
 	want := []string{"git", "clean", "-fd"}
-	if !reflect.DeepEqual(gotArgs, want) {
+	if !slices.Equal(gotArgs, want) {
 		t.Errorf("got %v, want %v", gotArgs, want)
 	}
 }
@@ -34,7 +34,7 @@ func TestClient_CleanDirs(t *testing.T) {
 
 	_ = client.CleanDirs()
 	want := []string{"git", "clean", "-fdx"}
-	if !reflect.DeepEqual(gotArgs, want) {
+	if !slices.Equal(gotArgs, want) {
 		t.Errorf("got %v, want %v", gotArgs, want)
 	}
 }
@@ -186,7 +186,7 @@ func TestClient_CleanFilesForce(t *testing.T) {
 
 			if tt.wantArgs == nil && gotArgs != nil {
 				t.Errorf("CleanFilesForce() should not execute command for empty files, but got: %v", gotArgs)
-			} else if tt.wantArgs != nil && !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+			} else if tt.wantArgs != nil && !slices.Equal(gotArgs, tt.wantArgs) {
 				t.Errorf("CleanFilesForce() gotArgs = %v, want %v", gotArgs, tt.wantArgs)
 			}
 		})

--- a/git/commit_test.go
+++ b/git/commit_test.go
@@ -3,7 +3,7 @@ package git
 import (
 	"errors"
 	"os/exec"
-	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -18,7 +18,7 @@ func TestClient_CommitAllowEmpty(t *testing.T) {
 
 	_ = client.CommitAllowEmpty()
 	want := []string{"git", "commit", "--allow-empty", "-m", "empty commit"}
-	if !reflect.DeepEqual(gotArgs, want) {
+	if !slices.Equal(gotArgs, want) {
 		t.Errorf("got %v, want %v", gotArgs, want)
 	}
 }

--- a/git/diff_test.go
+++ b/git/diff_test.go
@@ -2,7 +2,7 @@ package git
 
 import (
 	"os/exec"
-	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -23,7 +23,7 @@ func TestClient_Diff(t *testing.T) {
 	}
 
 	wantArgs := []string{"git", "diff"}
-	if !reflect.DeepEqual(gotArgs, wantArgs) {
+	if !slices.Equal(gotArgs, wantArgs) {
 		t.Errorf("Diff() gotArgs = %v, want %v", gotArgs, wantArgs)
 	}
 
@@ -49,7 +49,7 @@ func TestClient_DiffStaged(t *testing.T) {
 	}
 
 	wantArgs := []string{"git", "diff", "--staged"}
-	if !reflect.DeepEqual(gotArgs, wantArgs) {
+	if !slices.Equal(gotArgs, wantArgs) {
 		t.Errorf("DiffStaged() gotArgs = %v, want %v", gotArgs, wantArgs)
 	}
 
@@ -75,7 +75,7 @@ func TestClient_DiffHead(t *testing.T) {
 	}
 
 	wantArgs := []string{"git", "diff", "HEAD"}
-	if !reflect.DeepEqual(gotArgs, wantArgs) {
+	if !slices.Equal(gotArgs, wantArgs) {
 		t.Errorf("DiffHead() gotArgs = %v, want %v", gotArgs, wantArgs)
 	}
 

--- a/git/fetch_test.go
+++ b/git/fetch_test.go
@@ -2,7 +2,7 @@ package git
 
 import (
 	"os/exec"
-	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -39,7 +39,7 @@ func TestClient_Fetch(t *testing.T) {
 				t.Errorf("Fetch() error = %v", err)
 			}
 
-			if !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+			if !slices.Equal(gotArgs, tt.wantArgs) {
 				t.Errorf("Fetch() gotArgs = %v, want %v", gotArgs, tt.wantArgs)
 			}
 		})

--- a/git/ls-files_test.go
+++ b/git/ls-files_test.go
@@ -2,7 +2,7 @@ package git
 
 import (
 	"os/exec"
-	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -23,7 +23,7 @@ func TestClient_ListFiles(t *testing.T) {
 	}
 
 	wantArgs := []string{"git", "ls-files"}
-	if !reflect.DeepEqual(gotArgs, wantArgs) {
+	if !slices.Equal(gotArgs, wantArgs) {
 		t.Errorf("ListFiles() gotArgs = %v, want %v", gotArgs, wantArgs)
 	}
 

--- a/git/pull_test.go
+++ b/git/pull_test.go
@@ -2,7 +2,7 @@ package git
 
 import (
 	"os/exec"
-	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -34,7 +34,7 @@ func TestClient_Pull(t *testing.T) {
 				},
 			}
 			_ = client.Pull(tc.rebase)
-			if !reflect.DeepEqual(gotArgs, tc.wantArgs) {
+			if !slices.Equal(gotArgs, tc.wantArgs) {
 				t.Errorf("got %v, want %v", gotArgs, tc.wantArgs)
 			}
 		})

--- a/git/push_test.go
+++ b/git/push_test.go
@@ -2,7 +2,7 @@ package git
 
 import (
 	"os/exec"
-	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -38,7 +38,7 @@ func TestClient_Push(t *testing.T) {
 			}
 
 			_ = client.Push(tc.force)
-			if !reflect.DeepEqual(gotArgs, tc.wantArgs) {
+			if !slices.Equal(gotArgs, tc.wantArgs) {
 				t.Errorf("got %v, want %v", gotArgs, tc.wantArgs)
 			}
 		})

--- a/git/rebase_test.go
+++ b/git/rebase_test.go
@@ -2,7 +2,7 @@ package git
 
 import (
 	"os/exec"
-	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -45,7 +45,7 @@ func TestClient_LogOneline(t *testing.T) {
 				t.Errorf("LogOneline() error = %v", err)
 			}
 
-			if !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+			if !slices.Equal(gotArgs, tt.wantArgs) {
 				t.Errorf("LogOneline() gotArgs = %v, want %v", gotArgs, tt.wantArgs)
 			}
 
@@ -94,7 +94,7 @@ func TestClient_RebaseInteractive(t *testing.T) {
 				t.Errorf("RebaseInteractive() error = %v", err)
 			}
 
-			if !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+			if !slices.Equal(gotArgs, tt.wantArgs) {
 				t.Errorf("RebaseInteractive() gotArgs = %v, want %v", gotArgs, tt.wantArgs)
 			}
 		})
@@ -154,7 +154,7 @@ func TestClient_GetUpstreamBranch(t *testing.T) {
 				t.Errorf("GetUpstreamBranch() error = %v", err)
 			}
 
-			if !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+			if !slices.Equal(gotArgs, tt.wantArgs) {
 				t.Errorf("GetUpstreamBranch() gotArgs = %v, want %v", gotArgs, tt.wantArgs)
 			}
 
@@ -203,7 +203,7 @@ func TestClient_Rebase(t *testing.T) {
 				t.Errorf("Rebase() error = %v", err)
 			}
 
-			if !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+			if !slices.Equal(gotArgs, tt.wantArgs) {
 				t.Errorf("Rebase() gotArgs = %v, want %v", gotArgs, tt.wantArgs)
 			}
 		})
@@ -236,7 +236,7 @@ func TestClient_RebaseContinue(t *testing.T) {
 				t.Errorf("RebaseContinue() error = %v", err)
 			}
 
-			if !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+			if !slices.Equal(gotArgs, tt.wantArgs) {
 				t.Errorf("RebaseContinue() gotArgs = %v, want %v", gotArgs, tt.wantArgs)
 			}
 		})
@@ -269,7 +269,7 @@ func TestClient_RebaseAbort(t *testing.T) {
 				t.Errorf("RebaseAbort() error = %v", err)
 			}
 
-			if !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+			if !slices.Equal(gotArgs, tt.wantArgs) {
 				t.Errorf("RebaseAbort() gotArgs = %v, want %v", gotArgs, tt.wantArgs)
 			}
 		})
@@ -302,7 +302,7 @@ func TestClient_RebaseSkip(t *testing.T) {
 				t.Errorf("RebaseSkip() error = %v", err)
 			}
 
-			if !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+			if !slices.Equal(gotArgs, tt.wantArgs) {
 				t.Errorf("RebaseSkip() gotArgs = %v, want %v", gotArgs, tt.wantArgs)
 			}
 		})

--- a/git/remote_test.go
+++ b/git/remote_test.go
@@ -2,7 +2,7 @@ package git
 
 import (
 	"os/exec"
-	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -21,7 +21,7 @@ func TestClient_RemoteList(t *testing.T) {
 	}
 
 	wantArgs := []string{"git", "remote", "-v"}
-	if !reflect.DeepEqual(gotArgs, wantArgs) {
+	if !slices.Equal(gotArgs, wantArgs) {
 		t.Errorf("RemoteList() gotArgs = %v, want %v", gotArgs, wantArgs)
 	}
 }
@@ -41,7 +41,7 @@ func TestClient_RemoteAdd(t *testing.T) {
 	}
 
 	wantArgs := []string{"git", "remote", "add", "origin", "https://github.com/user/repo.git"}
-	if !reflect.DeepEqual(gotArgs, wantArgs) {
+	if !slices.Equal(gotArgs, wantArgs) {
 		t.Errorf("RemoteAdd() gotArgs = %v, want %v", gotArgs, wantArgs)
 	}
 }
@@ -61,7 +61,7 @@ func TestClient_RemoteRemove(t *testing.T) {
 	}
 
 	wantArgs := []string{"git", "remote", "remove", "origin"}
-	if !reflect.DeepEqual(gotArgs, wantArgs) {
+	if !slices.Equal(gotArgs, wantArgs) {
 		t.Errorf("RemoteRemove() gotArgs = %v, want %v", gotArgs, wantArgs)
 	}
 }
@@ -81,7 +81,7 @@ func TestClient_RemoteSetURL(t *testing.T) {
 	}
 
 	wantArgs := []string{"git", "remote", "set-url", "origin", "https://github.com/user/new-repo.git"}
-	if !reflect.DeepEqual(gotArgs, wantArgs) {
+	if !slices.Equal(gotArgs, wantArgs) {
 		t.Errorf("RemoteSetURL() gotArgs = %v, want %v", gotArgs, wantArgs)
 	}
 }

--- a/git/reset_test.go
+++ b/git/reset_test.go
@@ -3,7 +3,7 @@ package git
 import (
 	"errors"
 	"os/exec"
-	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -24,7 +24,9 @@ func TestClient_ResetHardAndClean(t *testing.T) {
 		{"git", "reset", "--hard", "origin/main"},
 		{"git", "clean", "-fdx"},
 	}
-	if !reflect.DeepEqual(gotArgs, want) {
+	if !slices.EqualFunc(gotArgs, want, func(a, b []string) bool {
+		return slices.Equal(a, b)
+	}) {
 		t.Errorf("got %v, want %v", gotArgs, want)
 	}
 }

--- a/git/restore_test.go
+++ b/git/restore_test.go
@@ -2,7 +2,7 @@ package git
 
 import (
 	"os/exec"
-	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -69,7 +69,7 @@ func TestClient_Restore(t *testing.T) {
 
 			_ = client.Restore(tc.paths, tc.opts)
 
-			if !reflect.DeepEqual(gotArgs, tc.wantArgs) {
+			if !slices.Equal(gotArgs, tc.wantArgs) {
 				t.Errorf("got %v, want %v", gotArgs, tc.wantArgs)
 			}
 		})
@@ -111,7 +111,7 @@ func TestClient_RestoreWorkingDir(t *testing.T) {
 
 			_ = client.RestoreWorkingDir(tc.paths...)
 
-			if !reflect.DeepEqual(gotArgs, tc.wantArgs) {
+			if !slices.Equal(gotArgs, tc.wantArgs) {
 				t.Errorf("got %v, want %v", gotArgs, tc.wantArgs)
 			}
 		})
@@ -153,7 +153,7 @@ func TestClient_RestoreStaged(t *testing.T) {
 
 			_ = client.RestoreStaged(tc.paths...)
 
-			if !reflect.DeepEqual(gotArgs, tc.wantArgs) {
+			if !slices.Equal(gotArgs, tc.wantArgs) {
 				t.Errorf("got %v, want %v", gotArgs, tc.wantArgs)
 			}
 		})
@@ -205,7 +205,7 @@ func TestClient_RestoreFromCommit(t *testing.T) {
 
 			_ = client.RestoreFromCommit(tc.commit, tc.paths...)
 
-			if !reflect.DeepEqual(gotArgs, tc.wantArgs) {
+			if !slices.Equal(gotArgs, tc.wantArgs) {
 				t.Errorf("got %v, want %v", gotArgs, tc.wantArgs)
 			}
 		})
@@ -224,7 +224,7 @@ func TestClient_RestoreAll(t *testing.T) {
 	_ = client.RestoreAll()
 
 	wantArgs := []string{"git", "restore", "."}
-	if !reflect.DeepEqual(gotArgs, wantArgs) {
+	if !slices.Equal(gotArgs, wantArgs) {
 		t.Errorf("got %v, want %v", gotArgs, wantArgs)
 	}
 }
@@ -241,7 +241,7 @@ func TestClient_RestoreAllStaged(t *testing.T) {
 	_ = client.RestoreAllStaged()
 
 	wantArgs := []string{"git", "restore", "--staged", "."}
-	if !reflect.DeepEqual(gotArgs, wantArgs) {
+	if !slices.Equal(gotArgs, wantArgs) {
 		t.Errorf("got %v, want %v", gotArgs, wantArgs)
 	}
 }

--- a/git/rev-list_test.go
+++ b/git/rev-list_test.go
@@ -2,7 +2,7 @@ package git
 
 import (
 	"os/exec"
-	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -45,7 +45,7 @@ func TestClient_GetAheadBehindCount(t *testing.T) {
 				t.Errorf("GetAheadBehindCount() error = %v", err)
 			}
 
-			if !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+			if !slices.Equal(gotArgs, tt.wantArgs) {
 				t.Errorf("GetAheadBehindCount() gotArgs = %v, want %v", gotArgs, tt.wantArgs)
 			}
 
@@ -92,7 +92,7 @@ func TestClient_GetTagCommit(t *testing.T) {
 				t.Errorf("GetTagCommit() error = %v", err)
 			}
 
-			if !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+			if !slices.Equal(gotArgs, tt.wantArgs) {
 				t.Errorf("GetTagCommit() gotArgs = %v, want %v", gotArgs, tt.wantArgs)
 			}
 

--- a/git/rev-parse_test.go
+++ b/git/rev-parse_test.go
@@ -3,7 +3,7 @@ package git
 import (
 	"errors"
 	"os/exec"
-	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -219,7 +219,7 @@ func TestClient_GetUpstreamBranchName(t *testing.T) {
 				t.Errorf("GetUpstreamBranchName() error = %v", err)
 			}
 
-			if !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+			if !slices.Equal(gotArgs, tt.wantArgs) {
 				t.Errorf("GetUpstreamBranchName() gotArgs = %v, want %v", gotArgs, tt.wantArgs)
 			}
 

--- a/git/stash_test.go
+++ b/git/stash_test.go
@@ -2,7 +2,7 @@ package git
 
 import (
 	"os/exec"
-	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -21,7 +21,7 @@ func TestClient_Stash(t *testing.T) {
 	}
 
 	wantArgs := []string{"git", "stash"}
-	if !reflect.DeepEqual(gotArgs, wantArgs) {
+	if !slices.Equal(gotArgs, wantArgs) {
 		t.Errorf("Stash() gotArgs = %v, want %v", gotArgs, wantArgs)
 	}
 }
@@ -43,7 +43,7 @@ func TestClient_StashList(t *testing.T) {
 	}
 
 	wantArgs := []string{"git", "stash", "list"}
-	if !reflect.DeepEqual(gotArgs, wantArgs) {
+	if !slices.Equal(gotArgs, wantArgs) {
 		t.Errorf("StashList() gotArgs = %v, want %v", gotArgs, wantArgs)
 	}
 
@@ -85,7 +85,7 @@ func TestClient_StashShow(t *testing.T) {
 				t.Errorf("StashShow() error = %v", err)
 			}
 
-			if !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+			if !slices.Equal(gotArgs, tt.wantArgs) {
 				t.Errorf("StashShow() gotArgs = %v, want %v", gotArgs, tt.wantArgs)
 			}
 		})
@@ -125,7 +125,7 @@ func TestClient_StashApply(t *testing.T) {
 				t.Errorf("StashApply() error = %v", err)
 			}
 
-			if !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+			if !slices.Equal(gotArgs, tt.wantArgs) {
 				t.Errorf("StashApply() gotArgs = %v, want %v", gotArgs, tt.wantArgs)
 			}
 		})
@@ -165,7 +165,7 @@ func TestClient_StashPop(t *testing.T) {
 				t.Errorf("StashPop() error = %v", err)
 			}
 
-			if !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+			if !slices.Equal(gotArgs, tt.wantArgs) {
 				t.Errorf("StashPop() gotArgs = %v, want %v", gotArgs, tt.wantArgs)
 			}
 		})
@@ -205,7 +205,7 @@ func TestClient_StashDrop(t *testing.T) {
 				t.Errorf("StashDrop() error = %v", err)
 			}
 
-			if !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+			if !slices.Equal(gotArgs, tt.wantArgs) {
 				t.Errorf("StashDrop() gotArgs = %v, want %v", gotArgs, tt.wantArgs)
 			}
 		})
@@ -227,7 +227,7 @@ func TestClient_StashClear(t *testing.T) {
 	}
 
 	wantArgs := []string{"git", "stash", "clear"}
-	if !reflect.DeepEqual(gotArgs, wantArgs) {
+	if !slices.Equal(gotArgs, wantArgs) {
 		t.Errorf("StashClear() gotArgs = %v, want %v", gotArgs, wantArgs)
 	}
 }

--- a/git/status_test.go
+++ b/git/status_test.go
@@ -2,7 +2,7 @@ package git
 
 import (
 	"os/exec"
-	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -23,7 +23,7 @@ func TestClient_Status(t *testing.T) {
 	}
 
 	wantArgs := []string{"git", "status"}
-	if !reflect.DeepEqual(gotArgs, wantArgs) {
+	if !slices.Equal(gotArgs, wantArgs) {
 		t.Errorf("Status() gotArgs = %v, want %v", gotArgs, wantArgs)
 	}
 
@@ -49,7 +49,7 @@ func TestClient_StatusShort(t *testing.T) {
 	}
 
 	wantArgs := []string{"git", "status", "--short"}
-	if !reflect.DeepEqual(gotArgs, wantArgs) {
+	if !slices.Equal(gotArgs, wantArgs) {
 		t.Errorf("StatusShort() gotArgs = %v, want %v", gotArgs, wantArgs)
 	}
 
@@ -75,7 +75,7 @@ func TestClient_StatusWithColor(t *testing.T) {
 	}
 
 	wantArgs := []string{"git", "-c", "color.status=always", "status"}
-	if !reflect.DeepEqual(gotArgs, wantArgs) {
+	if !slices.Equal(gotArgs, wantArgs) {
 		t.Errorf("StatusWithColor() gotArgs = %v, want %v", gotArgs, wantArgs)
 	}
 
@@ -101,7 +101,7 @@ func TestClient_StatusShortWithColor(t *testing.T) {
 	}
 
 	wantArgs := []string{"git", "-c", "color.status=always", "status", "--short"}
-	if !reflect.DeepEqual(gotArgs, wantArgs) {
+	if !slices.Equal(gotArgs, wantArgs) {
 		t.Errorf("StatusShortWithColor() gotArgs = %v, want %v", gotArgs, wantArgs)
 	}
 

--- a/git/tag_test.go
+++ b/git/tag_test.go
@@ -2,7 +2,7 @@ package git
 
 import (
 	"os/exec"
-	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -44,7 +44,7 @@ func TestClient_TagList(t *testing.T) {
 				t.Errorf("TagList() error = %v", err)
 			}
 
-			if !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+			if !slices.Equal(gotArgs, tt.wantArgs) {
 				t.Errorf("TagList() gotArgs = %v, want %v", gotArgs, tt.wantArgs)
 			}
 		})
@@ -87,7 +87,7 @@ func TestClient_TagCreate(t *testing.T) {
 				t.Errorf("TagCreate() error = %v", err)
 			}
 
-			if !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+			if !slices.Equal(gotArgs, tt.wantArgs) {
 				t.Errorf("TagCreate() gotArgs = %v, want %v", gotArgs, tt.wantArgs)
 			}
 		})
@@ -130,7 +130,7 @@ func TestClient_TagCreateAnnotated(t *testing.T) {
 				t.Errorf("TagCreateAnnotated() error = %v", err)
 			}
 
-			if !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+			if !slices.Equal(gotArgs, tt.wantArgs) {
 				t.Errorf("TagCreateAnnotated() gotArgs = %v, want %v", gotArgs, tt.wantArgs)
 			}
 		})
@@ -179,7 +179,7 @@ func TestClient_TagDelete(t *testing.T) {
 			// Check the last call for the pattern
 			if len(tt.tagNames) > 0 {
 				expectedLastArgs := []string{"git", "tag", "-d", tt.tagNames[len(tt.tagNames)-1]}
-				if !reflect.DeepEqual(lastArgs, expectedLastArgs) {
+				if !slices.Equal(lastArgs, expectedLastArgs) {
 					t.Errorf("TagDelete() lastArgs = %v, want %v", lastArgs, expectedLastArgs)
 				}
 			}
@@ -202,7 +202,7 @@ func TestClient_TagPush(t *testing.T) {
 	}
 
 	wantArgs := []string{"git", "push", "origin", "v1.0.0"}
-	if !reflect.DeepEqual(gotArgs, wantArgs) {
+	if !slices.Equal(gotArgs, wantArgs) {
 		t.Errorf("TagPush() gotArgs = %v, want %v", gotArgs, wantArgs)
 	}
 }
@@ -222,7 +222,7 @@ func TestClient_TagPushAll(t *testing.T) {
 	}
 
 	wantArgs := []string{"git", "push", "origin", "--tags"}
-	if !reflect.DeepEqual(gotArgs, wantArgs) {
+	if !slices.Equal(gotArgs, wantArgs) {
 		t.Errorf("TagPushAll() gotArgs = %v, want %v", gotArgs, wantArgs)
 	}
 }
@@ -242,7 +242,7 @@ func TestClient_TagShow(t *testing.T) {
 	}
 
 	wantArgs := []string{"git", "show", "v1.0.0"}
-	if !reflect.DeepEqual(gotArgs, wantArgs) {
+	if !slices.Equal(gotArgs, wantArgs) {
 		t.Errorf("TagShow() gotArgs = %v, want %v", gotArgs, wantArgs)
 	}
 }
@@ -264,7 +264,7 @@ func TestClient_GetLatestTag(t *testing.T) {
 	}
 
 	wantArgs := []string{"git", "describe", "--tags", "--abbrev=0"}
-	if !reflect.DeepEqual(gotArgs, wantArgs) {
+	if !slices.Equal(gotArgs, wantArgs) {
 		t.Errorf("GetLatestTag() gotArgs = %v, want %v", gotArgs, wantArgs)
 	}
 
@@ -320,7 +320,7 @@ func TestClient_TagExists(t *testing.T) {
 			result := client.TagExists(tt.tagName)
 
 			wantArgs := []string{"git", "tag", "-l", tt.tagName}
-			if !reflect.DeepEqual(gotArgs, wantArgs) {
+			if !slices.Equal(gotArgs, wantArgs) {
 				t.Errorf("TagExists() gotArgs = %v, want %v", gotArgs, wantArgs)
 			}
 


### PR DESCRIPTION
  ## Description of Changes

  - nice easy win - replaced slice comparisons that previously used reflect.DeepEqual with slices.Equal or slices.EqualFunc, covering the git, cmd, router, and config test packages.
  - simplified scalar comparisons in config/config_test.go to use direct equality where reflection was unnecessary.

  ## Related Issue
  closes #203

  ## Checklist

  - [x] I have read the CONTRIBUTING.md (https://github.com/bmf-san/ggc/blob/main/CONTRIBUTING.md)
  - [x] I have added or updated tests
  - [x] Code is formatted with make fmt
  - [x] Code passes linter checks via make lint (golangci-lint emitted cache-write warnings in the sandbox but exited 0)
  - [x] All tests are passing