### PR TITLE
bug: Keybindings panel does not display real keybinds

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ ggc is a Git tool written in Go, offering both traditional CLI commands and an i
 
 - Traditional command-line interface (CLI): Run ggc <command> [args] to execute specific operations directly.
 - Interactive interface: Run ggc with no arguments to launch an incremental search UI for command selection.
+- **Workflow functionality**: Build and execute multi-command workflows in interactive mode (e.g., add → commit → push)
 - Simple commands for common Git operations (add, push, pull, branch, log, etc.)
 - Composite commands that combine multiple Git operations
 - Interactive UI for branch/file selection and message input
@@ -203,12 +204,25 @@ ggc
 - `Enter`: Execute selected command
 - `Ctrl+c`: Exit interactive mode
 
+**Workflow Operations:**
+- `Tab`: Add selected command to workflow
+- `Ctrl+t`: Toggle workflow detail view
+- `c`: Clear workflow (in workflow view)
+- `Enter`: Execute entire workflow (in workflow view)
+
 **Command Execution:**
 - If a command requires arguments (e.g. `<file>`, `<name>`, `<url>`), you will be prompted for input
 - After command execution, results are displayed and you can press Enter to continue
 - After viewing results, you return to the command selection screen for continuous use
 - Type `"quit"` or use `Ctrl+c` to exit interactive mode
 - All UI and prompts are in English
+
+**Workflow Feature:**
+- Build multi-command workflows by adding commands with `Tab`
+- Commands are executed sequentially when you run the workflow
+- Placeholder arguments (e.g., `<message>`) are prompted during workflow execution
+- Workflows persist after execution for reuse
+- Common workflow examples: `add` → `commit` → `push`, `fetch` → `rebase` → `push force`
 
 **Examples of Fuzzy Search:**
 - `"bd"` → finds `"branch delete"`
@@ -332,12 +346,12 @@ aliases:
     quick:
         - status
         - add .
-        - commit tmp
+        - commit
     st: status
     sync:
         - pull current
         - add .
-        - commit tmp
+        - commit
         - push current
 ```
 
@@ -371,6 +385,10 @@ interactive:
     delete_word: "ctrl+w"
     clear_line: "ctrl+u"
     delete_to_end: "ctrl+k"
+    # Workflow keybindings
+    add_to_workflow: "tab"
+    toggle_workflow_view: "ctrl+t"
+    clear_workflow: "c"
 ```
 
 ### Supported Key Format Notations
@@ -481,6 +499,7 @@ Here are some common keybinding action names you can customize:
 - **Editing**: `delete_word`, `clear_line`, `delete_to_end`
 - **Cursor Movement**: `move_to_beginning`, `move_to_end`, `move_word_left`, `move_word_right`
 - **Control**: `execute`, `cancel`, `quit`
+- **Workflow**: `add_to_workflow`, `toggle_workflow_view`, `clear_workflow`
 
 #### Special Key Support
 

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -812,3 +812,36 @@ func TestCmd_waitForContinue(t *testing.T) {
 	// but we can verify the function is callable
 	_ = cmd.waitForContinue
 }
+
+// TestCmd_InteractiveWorkflowIntegration tests workflow integration with Cmd
+func TestCmd_InteractiveWorkflowIntegration(t *testing.T) {
+	// Setup
+	mockClient := &mockGitClient{}
+	cmd := NewCmd(mockClient)
+
+	// Test that NewUI creates workflow-enabled UI
+	ui := NewUI(mockClient, cmd)
+
+	if ui.workflow == nil {
+		t.Error("Expected UI to have workflow initialized")
+	}
+
+	if ui.workflowEx == nil {
+		t.Error("Expected UI to have workflow executor initialized")
+	}
+
+	// Test workflow operations
+	id := ui.AddToWorkflow("add", []string{"."}, "add .")
+	if id != 1 {
+		t.Errorf("Expected workflow ID 1, got %d", id)
+	}
+
+	if ui.workflow.IsEmpty() {
+		t.Error("Expected workflow to have steps after adding")
+	}
+
+	ui.ClearWorkflow()
+	if !ui.workflow.IsEmpty() {
+		t.Error("Expected workflow to be empty after clearing")
+	}
+}

--- a/cmd/debug_comprehensive_test.go
+++ b/cmd/debug_comprehensive_test.go
@@ -11,16 +11,29 @@ import (
 func TestNewDebugger_Coverage(t *testing.T) {
 	debugger := NewDebugger()
 
-	// Verify all fields are properly initialized
-	if debugger == nil {
-		t.Fatal("NewDebugger returned nil")
-	}
-	if debugger.outputWriter != os.Stdout {
-		t.Error("outputWriter should be set to os.Stdout")
-	}
-	if debugger.helper == nil {
-		t.Error("helper should be initialized")
-	}
+	t.Run("debugger_creation", func(t *testing.T) {
+		if debugger == nil {
+			t.Fatal("NewDebugger returned nil")
+		}
+	})
+
+	t.Run("output_writer_setup", func(t *testing.T) {
+		if debugger == nil {
+			t.Skip("Skipping due to nil debugger")
+		}
+		if debugger.outputWriter != os.Stdout {
+			t.Fatalf("outputWriter should be set to os.Stdout, got: %v", debugger.outputWriter)
+		}
+	})
+
+	t.Run("helper_initialization", func(t *testing.T) {
+		if debugger == nil {
+			t.Skip("Skipping due to nil debugger")
+		}
+		if debugger.helper == nil {
+			t.Fatal("helper should be initialized")
+		}
+	})
 }
 
 // Test DebugKeys method edge cases

--- a/cmd/debug_test.go
+++ b/cmd/debug_test.go
@@ -8,15 +8,30 @@ import (
 
 func TestNewDebugger(t *testing.T) {
 	debugger := NewDebugger()
-	if debugger == nil {
-		t.Fatal("NewDebugger() returned nil")
-	}
-	if debugger.outputWriter == nil {
-		t.Error("outputWriter should not be nil")
-	}
-	if debugger.helper == nil {
-		t.Error("helper should not be nil")
-	}
+
+	t.Run("debugger_creation", func(t *testing.T) {
+		if debugger == nil {
+			t.Fatal("NewDebugger() returned nil")
+		}
+	})
+
+	t.Run("output_writer_initialization", func(t *testing.T) {
+		if debugger == nil {
+			t.Skip("Skipping due to nil debugger")
+		}
+		if debugger.outputWriter == nil {
+			t.Fatal("outputWriter should not be nil")
+		}
+	})
+
+	t.Run("helper_initialization", func(t *testing.T) {
+		if debugger == nil {
+			t.Skip("Skipping due to nil debugger")
+		}
+		if debugger.helper == nil {
+			t.Fatal("helper should not be nil")
+		}
+	})
 }
 
 func TestDebugger_DebugKeys_NoArgs(t *testing.T) {

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -40,13 +40,13 @@ func TestDiffer_Constructor(t *testing.T) {
 	if differ == nil {
 		t.Fatal("Expected NewDiffer to return a non-nil Differ")
 	}
-	if differ.gitClient == nil {
+	if differ != nil && differ.gitClient == nil {
 		t.Error("Expected gitClient to be set")
 	}
-	if differ.outputWriter == nil {
+	if differ != nil && differ.outputWriter == nil {
 		t.Error("Expected outputWriter to be set")
 	}
-	if differ.helper == nil {
+	if differ != nil && differ.helper == nil {
 		t.Error("Expected helper to be set")
 	}
 }

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -1779,6 +1779,7 @@ func (r *Renderer) buildSearchKeybindEntries(ui *UI) []keybindHelpEntry {
 		{key: "Ctrl+←/→", desc: "Move by word"},
 		{key: "Option+←/→", desc: "Move by word (macOS)"},
 	}
+	// Future: extend this helper for additional contexts such as workflow views.
 
 	var km *KeyBindingMap
 	if ui != nil && ui.handler != nil {

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -1812,6 +1812,12 @@ func (r *Renderer) buildSearchKeybindEntries(ui *UI) []keybindHelpEntry {
 	appendDynamic(km.MoveToEnd, defaultMap.MoveToEnd, "Move to end")
 
 	entries = append(entries, keybindHelpEntry{key: "Backspace", desc: "Delete character"})
+	entries = append(entries, keybindHelpEntry{key: "Enter", desc: "Execute selected command"})
+
+	appendDynamic(km.AddToWorkflow, defaultMap.AddToWorkflow, "Add to workflow")
+	appendDynamic(km.ToggleWorkflowView, defaultMap.ToggleWorkflowView, "Toggle workflow view")
+
+	entries = append(entries, keybindHelpEntry{key: "Ctrl+c", desc: "Quit"})
 
 	return entries
 }

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -533,6 +533,11 @@ type Renderer struct {
 	colors *ANSIColors
 }
 
+type keybindHelpEntry struct {
+	key  string
+	desc string
+}
+
 // KeyHandler manages keyboard input processing
 type KeyHandler struct {
 	ui            *UI
@@ -1650,8 +1655,11 @@ func (r *Renderer) Render(ui *UI, state *UIState) {
 
 		switch {
 		case state.input == "":
-			r.renderEmptyStateWithWorkflow(ui)
-			// Render search keybinds only when no input
+			if ui.workflow.IsEmpty() {
+				r.renderEmptyState(ui)
+			} else {
+				r.renderEmptyStateWithWorkflow(ui)
+			}
 			r.writeEmptyLine()
 			r.renderSearchKeybinds(ui)
 		case len(state.filtered) == 0:
@@ -1759,7 +1767,75 @@ func (r *Renderer) formatInputWithCursor(state *UIState) string {
 		r.colors.Reset)
 }
 
-// renderNoMatches renders the no matches found state
+// renderEmptyState renders the empty input state
+func (r *Renderer) renderEmptyState(ui *UI) {
+	r.writeColorln(ui, fmt.Sprintf("%s💭 %sStart typing to search commands...%s",
+		r.colors.BrightBlue, r.colors.BrightBlack, r.colors.Reset))
+}
+
+func (r *Renderer) buildSearchKeybindEntries(ui *UI) []keybindHelpEntry {
+	entries := []keybindHelpEntry{
+		{key: "←/→", desc: "Move cursor"},
+		{key: "Ctrl+←/→", desc: "Move by word"},
+		{key: "Option+←/→", desc: "Move by word (macOS)"},
+	}
+
+	var km *KeyBindingMap
+	if ui != nil && ui.handler != nil {
+		km = ui.handler.GetCurrentKeyMap()
+	}
+	if km == nil {
+		km = DefaultKeyBindingMap()
+	}
+
+	defaultMap := DefaultKeyBindingMap()
+
+	appendDynamic := func(primary []KeyStroke, fallback []KeyStroke, desc string) {
+		keys := primary
+		if len(keys) == 0 {
+			keys = fallback
+		}
+		if len(keys) == 0 {
+			return
+		}
+		formatted := FormatKeyStrokesForDisplay(keys)
+		if formatted == "" || formatted == "none" {
+			return
+		}
+		entries = append(entries, keybindHelpEntry{key: formatted, desc: desc})
+	}
+
+	appendDynamic(km.ClearLine, defaultMap.ClearLine, "Clear all input")
+	appendDynamic(km.DeleteWord, defaultMap.DeleteWord, "Delete word")
+	appendDynamic(km.DeleteToEnd, defaultMap.DeleteToEnd, "Delete to end")
+	appendDynamic(km.MoveToBeginning, defaultMap.MoveToBeginning, "Move to beginning")
+	appendDynamic(km.MoveToEnd, defaultMap.MoveToEnd, "Move to end")
+
+	entries = append(entries, keybindHelpEntry{key: "Backspace", desc: "Delete character"})
+
+	return entries
+}
+
+func (r *Renderer) renderKeybindEntries(ui *UI, entries []keybindHelpEntry) {
+	if len(entries) == 0 {
+		return
+	}
+
+	r.writeColorln(ui, fmt.Sprintf("%s⌨️  %sAvailable keybinds:%s",
+		r.colors.BrightBlue, r.colors.BrightWhite+r.colors.Bold, r.colors.Reset))
+
+	for _, entry := range entries {
+		r.writeColorln(ui, fmt.Sprintf("   %s%s%s  %s%s%s",
+			r.colors.BrightGreen+r.colors.Bold,
+			entry.key,
+			r.colors.Reset,
+			r.colors.BrightBlack,
+			entry.desc,
+			r.colors.Reset))
+	}
+}
+
+// renderNoMatches renders the no matches found state with keybind help
 func (r *Renderer) renderNoMatches(ui *UI, state *UIState) {
 	// No matches message
 	r.writeColorln(ui, fmt.Sprintf("%s🔍 %sNo commands found for '%s%s%s'%s",
@@ -1769,37 +1845,14 @@ func (r *Renderer) renderNoMatches(ui *UI, state *UIState) {
 		state.input,
 		r.colors.Reset+r.colors.BrightWhite,
 		r.colors.Reset))
+
+	r.writeEmptyLine()
+	r.renderKeybindEntries(ui, r.buildSearchKeybindEntries(ui))
 }
 
 // renderSearchKeybinds renders keybinds available in search UI
 func (r *Renderer) renderSearchKeybinds(ui *UI) {
-	// Basic search keybinds
-	keybinds := []struct{ key, desc string }{
-		{"←/→", "Move cursor"},
-		{"Ctrl+←/→", "Move by word"},
-		{"Ctrl+u", "Clear all input"},
-		{"Ctrl+w", "Delete word"},
-		{"Ctrl+k", "Delete to end"},
-		{"Ctrl+a", "Move to beginning"},
-		{"Ctrl+e", "Move to end"},
-		{"Enter", "Execute command"},
-		{"Tab", "Add to workflow"},
-		{"Ctrl+t", "Toggle workflow view"},
-		{"Ctrl+c", "Quit"},
-	}
-
-	r.writeColorln(ui, fmt.Sprintf("%s⌨️  %sAvailable keybinds:%s",
-		r.colors.BrightBlue, r.colors.BrightWhite+r.colors.Bold, r.colors.Reset))
-
-	for _, kb := range keybinds {
-		r.writeColorln(ui, fmt.Sprintf("   %s%s%s  %s%s%s",
-			r.colors.BrightGreen+r.colors.Bold,
-			kb.key,
-			r.colors.Reset,
-			r.colors.BrightBlack,
-			kb.desc,
-			r.colors.Reset))
-	}
+	r.renderKeybindEntries(ui, r.buildSearchKeybindEntries(ui))
 }
 
 // renderWorkflowKeybinds renders keybinds available in workflow UI

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -214,6 +214,8 @@ type UI struct {
 	reader     *bufio.Reader
 	contextMgr *ContextManager
 	profile    Profile
+	workflow   *Workflow
+	workflowEx *WorkflowExecutor
 }
 
 // UIState holds the current state of the interactive UI
@@ -225,6 +227,7 @@ type UIState struct {
 	context         Context   // Current UI context (input/results/search/global)
 	contextStack    []Context // Context stack for nested states
 	onContextChange func(Context, Context)
+	showWorkflow    bool // Whether to show the workflow builder
 }
 
 // UpdateFiltered updates the filtered commands based on current input using fuzzy matching
@@ -550,14 +553,20 @@ func (h *KeyHandler) GetCurrentKeyMap() *KeyBindingMap {
 			return contextMap
 		}
 	}
+
 	return DefaultKeyBindingMap()
 }
 
 // HandleKey processes UTF-8 rune input and returns true if should continue
 // This method handles both single-byte (ASCII/control) and multibyte characters
-func (h *KeyHandler) HandleKey(r rune, isSingleByte bool, oldState *term.State) (bool, []string) {
-	// Handle control characters (single-byte)
-	if isSingleByte {
+func (h *KeyHandler) HandleKey(r rune, _ bool, oldState *term.State) (bool, []string) {
+	// Handle workflow-specific keys first (Tab, etc.)
+	if handled := h.handleWorkflowKeys(r); handled {
+		return true, nil
+	}
+
+	// Handle control characters (ASCII range)
+	if r < 128 && unicode.IsControl(r) { // ASCII control characters
 		if handled, shouldContinue, result := h.handleControlChar(byte(r), oldState); handled {
 			return shouldContinue, result
 		}
@@ -565,9 +574,47 @@ func (h *KeyHandler) HandleKey(r rune, isSingleByte bool, oldState *term.State) 
 
 	// Handle printable characters (both ASCII and multibyte)
 	if unicode.IsPrint(r) {
-		h.ui.state.AddRune(r)
+		// Don't accept text input in workflow view
+		if !h.ui.state.showWorkflow {
+			h.ui.state.AddRune(r)
+		}
 	}
 	return true, nil
+}
+
+// handleWorkflowKeys processes workflow-related key bindings and returns (handled, result)
+func (h *KeyHandler) handleWorkflowKeys(r rune) bool {
+	km := h.GetCurrentKeyMap()
+
+	// Create KeyStroke for this character
+	keyStroke := NewCharKeyStroke(r)
+
+	// Check add to workflow
+	if km.MatchesKeyStroke("add_to_workflow", keyStroke) {
+		// Add current selection to workflow
+		if !h.ui.state.showWorkflow && h.ui.state.HasInput() {
+			selectedCmd := h.ui.state.GetSelectedCommand()
+			if selectedCmd != nil {
+				h.addCommandToWorkflow(selectedCmd.Command)
+				// Clear input after adding to workflow
+				h.ui.state.ClearInput()
+				return true
+			}
+		}
+		return true
+	}
+
+	// Check clear workflow
+	if km.MatchesKeyStroke("clear_workflow", keyStroke) {
+		// Clear workflow
+		if h.ui.state.showWorkflow {
+			h.clearWorkflow()
+			return true
+		}
+		return true
+	}
+
+	return false
 }
 
 // handleControlChar processes control characters and returns (handled, shouldContinue, result)
@@ -585,11 +632,17 @@ func (h *KeyHandler) handleControlChar(b byte, oldState *term.State) (bool, bool
 
 		// Check each action using new KeyStroke matching
 		if km.MatchesKeyStroke("move_up", ctrlStroke) {
-			h.ui.state.MoveUp()
+			// No navigation in workflow view - just normal command navigation
+			if !h.ui.state.showWorkflow {
+				h.ui.state.MoveUp()
+			}
 			return true, true, nil
 		}
 		if km.MatchesKeyStroke("move_down", ctrlStroke) {
-			h.ui.state.MoveDown()
+			// No navigation in workflow view - just normal command navigation
+			if !h.ui.state.showWorkflow {
+				h.ui.state.MoveDown()
+			}
 			return true, true, nil
 		}
 		if km.MatchesKeyStroke("clear_line", ctrlStroke) {
@@ -610,6 +663,12 @@ func (h *KeyHandler) handleControlChar(b byte, oldState *term.State) (bool, bool
 		}
 		if km.MatchesKeyStroke("move_to_end", ctrlStroke) {
 			h.ui.state.MoveToEnd()
+			return true, true, nil
+		}
+
+		// Check for workflow toggle
+		if km.MatchesKeyStroke("toggle_workflow_view", ctrlStroke) && h.ui.state.input == "" {
+			h.ui.ToggleWorkflowView()
 			return true, true, nil
 		}
 	}
@@ -735,6 +794,12 @@ func (h *KeyHandler) handleCtrlC(oldState *term.State) {
 
 // handleEnter handles Enter key press
 func (h *KeyHandler) handleEnter(oldState *term.State) (bool, []string) {
+	// Handle workflow mode
+	if h.ui.state.showWorkflow {
+		// Execute workflow
+		return h.executeWorkflow(oldState)
+	}
+
 	if !h.ui.state.HasInput() {
 		return true, nil
 	}
@@ -1361,7 +1426,7 @@ func (t *defaultTerminal) restore(fd int, state *term.State) error {
 }
 
 // NewUI creates a new UI with the provided git client and loads keybindings from config
-func NewUI(gitClient git.StatusInfoReader) *UI {
+func NewUI(gitClient git.StatusInfoReader, router ...CommandRouter) *UI {
 	colors := NewANSIColors()
 
 	renderer := &Renderer{
@@ -1437,6 +1502,7 @@ func NewUI(gitClient git.StatusInfoReader) *UI {
 		gitStatus:  getGitStatus(gitClient),
 		contextMgr: contextManager,
 		profile:    profile,
+		workflow:   NewWorkflow(),
 	}
 	state.onContextChange = func(_ Context, newCtx Context) {
 		contextManager.SetContext(newCtx)
@@ -1447,7 +1513,40 @@ func NewUI(gitClient git.StatusInfoReader) *UI {
 		contextualMap: contextualMap,
 	}
 
+	// Set up workflow executor if router is provided
+	if len(router) > 0 && router[0] != nil {
+		ui.workflowEx = NewWorkflowExecutor(router[0])
+	}
+
 	return ui
+}
+
+// ToggleWorkflowView toggles between normal command view and workflow view
+func (ui *UI) ToggleWorkflowView() {
+	ui.state.showWorkflow = !ui.state.showWorkflow
+}
+
+// AddToWorkflow adds a command to the workflow
+func (ui *UI) AddToWorkflow(command string, args []string, description string) int {
+	return ui.workflow.AddStep(command, args, description)
+}
+
+// ClearWorkflow removes all steps from the workflow
+func (ui *UI) ClearWorkflow() {
+	ui.workflow.Clear()
+}
+
+// ExecuteWorkflow executes the current workflow
+func (ui *UI) ExecuteWorkflow() error {
+	if ui.workflowEx == nil {
+		return fmt.Errorf("workflow executor not initialized")
+	}
+
+	if ui.workflow.IsEmpty() {
+		return fmt.Errorf("workflow is empty")
+	}
+
+	return ui.workflowEx.Execute(ui.workflow)
 }
 
 // updateSize updates the terminal dimensions
@@ -1536,17 +1635,30 @@ func (r *Renderer) Render(ui *UI, state *UIState) {
 
 	// Render each section
 	r.renderHeader(ui)
-	r.renderSearchPrompt(ui, state)
-	restoreCursor = r.saveCursorAtSearchPrompt(state)
+
+	// Render workflow status if it has steps and no search input
+	if !ui.workflow.IsEmpty() && !state.showWorkflow && state.input == "" {
+		r.renderWorkflowStatus(ui)
+	}
 
 	// Render content based on state
-	switch {
-	case state.input == "":
-		r.renderEmptyState(ui)
-	case len(state.filtered) == 0:
-		r.renderNoMatches(ui, state)
-	default:
-		r.renderCommandList(ui, state)
+	if state.showWorkflow {
+		r.renderWorkflowView(ui, state)
+	} else {
+		r.renderSearchPrompt(ui, state)
+		restoreCursor = r.saveCursorAtSearchPrompt(state)
+
+		switch {
+		case state.input == "":
+			r.renderEmptyStateWithWorkflow(ui)
+			// Render search keybinds only when no input
+			r.writeEmptyLine()
+			r.renderSearchKeybinds(ui)
+		case len(state.filtered) == 0:
+			r.renderNoMatches(ui, state)
+		default:
+			r.renderCommandList(ui, state)
+		}
 	}
 
 }
@@ -1565,24 +1677,6 @@ func (r *Renderer) renderHeader(ui *UI) {
 		r.renderGitStatus(ui, ui.gitStatus)
 	}
 
-	// Navigation subtitle
-	subtitle := fmt.Sprintf("%sType to search • %sCtrl+n/p%s navigate • %s←/→%s move • %sCtrl+←/→%s word • %sCtrl+a/e%s line • %sEnter%s execute • %sCtrl+c%s quit%s",
-		r.colors.BrightBlack,
-		r.colors.BrightGreen+r.colors.Bold,
-		r.colors.BrightBlack,
-		r.colors.BrightCyan+r.colors.Bold,
-		r.colors.BrightBlack,
-		r.colors.BrightCyan+r.colors.Bold,
-		r.colors.BrightBlack,
-		r.colors.BrightCyan+r.colors.Bold,
-		r.colors.BrightBlack,
-		r.colors.BrightGreen+r.colors.Bold,
-		r.colors.BrightBlack,
-		r.colors.BrightGreen+r.colors.Bold,
-		r.colors.BrightBlack,
-		r.colors.Reset)
-	r.writeColorln(ui, subtitle)
-	r.writeEmptyLine()
 }
 
 // renderSearchPrompt renders the search input with cursor
@@ -1665,13 +1759,7 @@ func (r *Renderer) formatInputWithCursor(state *UIState) string {
 		r.colors.Reset)
 }
 
-// renderEmptyState renders the empty input state
-func (r *Renderer) renderEmptyState(ui *UI) {
-	r.writeColorln(ui, fmt.Sprintf("%s💭 %sStart typing to search commands...%s",
-		r.colors.BrightBlue, r.colors.BrightBlack, r.colors.Reset))
-}
-
-// renderNoMatches renders the no matches found state with keybind help
+// renderNoMatches renders the no matches found state
 func (r *Renderer) renderNoMatches(ui *UI, state *UIState) {
 	// No matches message
 	r.writeColorln(ui, fmt.Sprintf("%s🔍 %sNo commands found for '%s%s%s'%s",
@@ -1681,20 +1769,47 @@ func (r *Renderer) renderNoMatches(ui *UI, state *UIState) {
 		state.input,
 		r.colors.Reset+r.colors.BrightWhite,
 		r.colors.Reset))
-	r.writeEmptyLine()
+}
 
-	// Available keybinds
+// renderSearchKeybinds renders keybinds available in search UI
+func (r *Renderer) renderSearchKeybinds(ui *UI) {
+	// Basic search keybinds
 	keybinds := []struct{ key, desc string }{
 		{"←/→", "Move cursor"},
 		{"Ctrl+←/→", "Move by word"},
-		{"Option+←/→", "Move by word (macOS)"},
-		{"Option+Backspace", "Delete word (macOS)"},
 		{"Ctrl+u", "Clear all input"},
 		{"Ctrl+w", "Delete word"},
 		{"Ctrl+k", "Delete to end"},
 		{"Ctrl+a", "Move to beginning"},
 		{"Ctrl+e", "Move to end"},
-		{"Backspace", "Delete character"},
+		{"Enter", "Execute command"},
+		{"Tab", "Add to workflow"},
+		{"Ctrl+t", "Toggle workflow view"},
+		{"Ctrl+c", "Quit"},
+	}
+
+	r.writeColorln(ui, fmt.Sprintf("%s⌨️  %sAvailable keybinds:%s",
+		r.colors.BrightBlue, r.colors.BrightWhite+r.colors.Bold, r.colors.Reset))
+
+	for _, kb := range keybinds {
+		r.writeColorln(ui, fmt.Sprintf("   %s%s%s  %s%s%s",
+			r.colors.BrightGreen+r.colors.Bold,
+			kb.key,
+			r.colors.Reset,
+			r.colors.BrightBlack,
+			kb.desc,
+			r.colors.Reset))
+	}
+}
+
+// renderWorkflowKeybinds renders keybinds available in workflow UI
+func (r *Renderer) renderWorkflowKeybinds(ui *UI) {
+	// Workflow-specific keybinds
+	keybinds := []struct{ key, desc string }{
+		{"Enter", "Execute workflow"},
+		{"c", "Clear workflow"},
+		{"Ctrl+t", "Back to search view"},
+		{"Ctrl+c", "Quit"},
 	}
 
 	r.writeColorln(ui, fmt.Sprintf("%s⌨️  %sAvailable keybinds:%s",
@@ -1790,6 +1905,88 @@ func (r *Renderer) writeColorln(_ *UI, text string) {
 	_, _ = fmt.Fprint(r.writer, text+"\r\n")
 }
 
+// renderEmptyStateWithWorkflow renders the empty state with workflow info
+func (r *Renderer) renderEmptyStateWithWorkflow(ui *UI) {
+	r.writeColorln(ui, fmt.Sprintf("%s📝 Start typing to search commands...%s",
+		r.colors.BrightBlue,
+		r.colors.Reset))
+}
+
+// renderWorkflowStatus renders workflow information at the top of the UI
+func (r *Renderer) renderWorkflowStatus(ui *UI) {
+	steps := ui.workflow.GetSteps()
+	if len(steps) == 0 {
+		return
+	}
+
+	// Workflow status bar
+	statusText := fmt.Sprintf("%s📋 Workflow Ready (%d steps):%s",
+		r.colors.BrightYellow+r.colors.Bold,
+		len(steps),
+		r.colors.Reset)
+
+	// Show first few steps inline
+	stepTexts := make([]string, 0, min(3, len(steps)))
+	for i, step := range steps[:min(3, len(steps))] {
+		stepText := fmt.Sprintf("%s%d.%s %s%s%s",
+			r.colors.BrightBlue+r.colors.Bold,
+			i+1,
+			r.colors.Reset,
+			r.colors.BrightGreen,
+			step.Description,
+			r.colors.Reset)
+		stepTexts = append(stepTexts, stepText)
+	}
+
+	if len(steps) > 3 {
+		stepTexts = append(stepTexts, fmt.Sprintf("%s...+%d more%s",
+			r.colors.BrightBlack, len(steps)-3, r.colors.Reset))
+	}
+
+	r.writeColorln(ui, statusText+" "+strings.Join(stepTexts, " → "))
+	r.writeColorln(ui, "")
+}
+
+// renderWorkflowView renders the detailed workflow view
+func (r *Renderer) renderWorkflowView(ui *UI, _ *UIState) {
+	steps := ui.workflow.GetSteps()
+
+	// Detailed workflow header
+	r.writeColorln(ui, fmt.Sprintf("%s📋 Workflow Details (%d steps)%s",
+		r.colors.BrightYellow+r.colors.Bold,
+		len(steps),
+		r.colors.Reset))
+	r.writeColorln(ui, "")
+
+	if len(steps) == 0 {
+		r.writeColorln(ui, fmt.Sprintf("%s  No steps in workflow%s",
+			r.colors.BrightBlack,
+			r.colors.Reset))
+		r.writeColorln(ui, "")
+
+		// Render workflow keybinds even for empty workflow
+		r.renderWorkflowKeybinds(ui)
+		return
+	}
+
+	// Render all workflow steps
+	for i, step := range steps {
+		stepLine := fmt.Sprintf("  %s%d.%s %s%s%s",
+			r.colors.BrightBlue+r.colors.Bold,
+			i+1,
+			r.colors.Reset,
+			r.colors.BrightGreen+r.colors.Bold,
+			step.Description,
+			r.colors.Reset)
+		r.writeColorln(ui, stepLine)
+	}
+
+	r.writeColorln(ui, "")
+
+	// Render workflow keybinds
+	r.renderWorkflowKeybinds(ui)
+}
+
 // renderGitStatus renders the Git repository status information
 func (r *Renderer) renderGitStatus(ui *UI, status *GitStatus) {
 	var parts []string
@@ -1849,19 +2046,29 @@ func (r *Renderer) writeEmptyLine() {
 
 // calculateMaxCommandLength calculates the maximum command length for alignment
 func (r *Renderer) calculateMaxCommandLength(filtered []CommandInfo) int {
-	maxCmdLen := 0
+	if len(filtered) == 0 {
+		return 0
+	}
+
+	maxLen := 0
 	for _, cmd := range filtered {
-		if len(cmd.Command) > maxCmdLen {
-			maxCmdLen = len(cmd.Command)
+		if len(cmd.Command) > maxLen {
+			maxLen = len(cmd.Command)
 		}
 	}
-	return maxCmdLen
+	return maxLen
 }
 
 // setupTerminal configures terminal raw mode and returns the old state and error status
 func (ui *UI) setupTerminal() (*term.State, bool) {
 	var oldState *term.State
 	if f, ok := ui.stdin.(*os.File); ok {
+		// Check if it's a real terminal (TTY) - skip for non-TTY or when term is nil
+		if ui.term == nil || !term.IsTerminal(int(f.Fd())) {
+			// Not a real terminal, skip raw mode setup for debugging
+			return nil, true
+		}
+
 		fd := int(f.Fd())
 		var err error
 		oldState, err = ui.term.makeRaw(fd)
@@ -1875,11 +2082,13 @@ func (ui *UI) setupTerminal() (*term.State, bool) {
 
 // Run executes the interactive UI
 func (ui *UI) Run() []string {
-	oldState, ok := ui.setupTerminal()
-	if !ok {
+	oldState, reader, isRawMode := ui.initializeTerminal()
+	if oldState == nil && isRawMode {
 		return nil
 	}
-	if f, ok := ui.stdin.(*os.File); ok {
+
+	// Set up terminal restoration for raw mode
+	if f, ok := ui.stdin.(*os.File); ok && isRawMode {
 		fd := int(f.Fd())
 		defer func() {
 			if err := ui.term.restore(fd, oldState); err != nil {
@@ -1888,27 +2097,74 @@ func (ui *UI) Run() []string {
 		}()
 	}
 
-	ui.reader = bufio.NewReader(ui.stdin)
+	return ui.runMainLoop(reader, isRawMode, oldState)
+}
 
+// initializeTerminal sets up the terminal and returns the old state, reader, and raw mode status
+func (ui *UI) initializeTerminal() (*term.State, *bufio.Reader, bool) {
+	oldState, ok := ui.setupTerminal()
+	if !ok {
+		return nil, nil, false
+	}
+
+	// Check if we're in raw mode (real terminal) or not
+	isRawMode := oldState != nil
+
+	// Set up reader based on mode
+	var reader *bufio.Reader
+	if !isRawMode {
+		reader = bufio.NewReader(ui.stdin)
+	}
+
+	return oldState, reader, isRawMode
+}
+
+// runMainLoop handles the main input loop
+func (ui *UI) runMainLoop(reader *bufio.Reader, isRawMode bool, oldState *term.State) []string {
 	for {
 		ui.state.UpdateFiltered()
 		ui.renderer.Render(ui, ui.state)
 
-		// Read UTF-8 rune instead of single byte
-		r, size, err := ui.reader.ReadRune()
+		r, err := ui.readNextRune(reader, isRawMode)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				return nil
 			}
-			continue
+			continue // Skip this iteration for other errors
 		}
 
 		// Handle key input with rune
-		shouldContinue, result := ui.handler.HandleKey(r, size == 1, oldState)
+		isSingleByte := isRawMode // In raw mode, we read single bytes; in buffered mode, we read full runes
+		shouldContinue, result := ui.handler.HandleKey(r, isSingleByte, oldState)
 		if !shouldContinue {
 			return result
 		}
 	}
+}
+
+// readNextRune reads the next rune from input based on the mode
+func (ui *UI) readNextRune(reader *bufio.Reader, isRawMode bool) (rune, error) {
+	if isRawMode {
+		for {
+			// Read single byte directly from stdin in raw mode
+			var buf [1]byte
+			n, readErr := ui.stdin.Read(buf[:])
+
+			if readErr != nil {
+				return 0, readErr
+			}
+
+			if n == 0 {
+				continue // Try again if no bytes read
+			}
+
+			return rune(buf[0]), nil
+		}
+	}
+
+	// Use buffered reader for non-TTY
+	r, _, err := reader.ReadRune()
+	return r, err
 }
 
 // Extract <...> placeholders from a string
@@ -1924,4 +2180,76 @@ func extractPlaceholders(s string) []string {
 		}
 	}
 	return res
+}
+
+// addCommandToWorkflow adds a command to the workflow (preserving placeholders)
+func (h *KeyHandler) addCommandToWorkflow(cmdTemplate string) {
+	// Don't process placeholders here - save the template as-is
+	// Placeholders will be resolved during workflow execution
+
+	// Parse command and arguments from template
+	parts := strings.Fields(cmdTemplate)
+	if len(parts) == 0 {
+		return
+	}
+
+	command := parts[0]
+	args := parts[1:]
+
+	// Add template to workflow (with placeholders intact)
+	id := h.ui.AddToWorkflow(command, args, cmdTemplate)
+
+	// Show success message
+	placeholders := extractPlaceholders(cmdTemplate)
+	if len(placeholders) > 0 {
+		h.ui.write("\n%s🎯 Added to workflow!%s\n",
+			h.ui.colors.BrightGreen+h.ui.colors.Bold, h.ui.colors.Reset)
+		h.ui.write("%s  Step %d: %s%s%s %s(will prompt for: %v)%s\n",
+			h.ui.colors.BrightCyan, id, h.ui.colors.BrightWhite+h.ui.colors.Bold, cmdTemplate, h.ui.colors.Reset,
+			h.ui.colors.BrightYellow, placeholders, h.ui.colors.Reset)
+	} else {
+		h.ui.write("\n%s🎯 Added to workflow!%s\n",
+			h.ui.colors.BrightGreen+h.ui.colors.Bold, h.ui.colors.Reset)
+		h.ui.write("%s  Step %d: %s%s%s\n",
+			h.ui.colors.BrightCyan, id, h.ui.colors.BrightWhite+h.ui.colors.Bold, cmdTemplate, h.ui.colors.Reset)
+	}
+	h.ui.write("%s  Press 'Ctrl+t' to view workflow, or continue adding more commands%s\n\n",
+		h.ui.colors.BrightBlack, h.ui.colors.Reset)
+}
+
+// clearWorkflow clears all steps from workflow
+func (h *KeyHandler) clearWorkflow() {
+	h.ui.ClearWorkflow()
+	h.ui.write("%s🧹 Workflow cleared%s\n", h.ui.colors.BrightYellow, h.ui.colors.Reset)
+}
+
+// executeWorkflow executes the current workflow
+func (h *KeyHandler) executeWorkflow(oldState *term.State) (bool, []string) {
+	if h.ui.workflow.IsEmpty() {
+		h.ui.write("%sWorkflow is empty. Add some steps first!%s\n",
+			h.ui.colors.BrightRed, h.ui.colors.Reset)
+		return true, nil
+	}
+
+	// Restore terminal state before execution
+	if oldState != nil {
+		if f, ok := h.ui.stdin.(*os.File); ok {
+			if err := h.ui.term.restore(int(f.Fd()), oldState); err != nil {
+				h.ui.writeError("failed to restore terminal state: %v", err)
+			}
+		}
+	}
+
+	// Clear screen and execute workflow
+	clearScreen(h.ui.stdout)
+
+	err := h.ui.ExecuteWorkflow()
+	if err != nil {
+		fmt.Printf("\n❌ Workflow execution failed: %v\n", err)
+	} else {
+		fmt.Printf("\n✨ Workflow preserved for reuse. Press 'Ctrl+t' to view or modify.\n")
+	}
+
+	// Keep workflow for reuse - don't clear it
+	return false, []string{"ggc", InteractiveWorkflowCommand}
 }

--- a/cmd/interactive_keybinds_test.go
+++ b/cmd/interactive_keybinds_test.go
@@ -1,0 +1,76 @@
+package cmd
+
+import "testing"
+
+func TestBuildSearchKeybindEntriesUsesConfiguredBindings(t *testing.T) {
+	renderer := &Renderer{}
+
+	ui := newUIWithKeyMap(&KeyBindingMap{
+		ClearLine:       []KeyStroke{NewCtrlKeyStroke('l')},
+		DeleteWord:      []KeyStroke{NewAltKeyStroke(0, "backspace")},
+		DeleteToEnd:     []KeyStroke{NewCtrlKeyStroke('k')},
+		MoveToBeginning: []KeyStroke{NewCtrlKeyStroke('a')},
+		MoveToEnd:       []KeyStroke{NewCtrlKeyStroke('e')},
+	})
+
+	entries := renderer.buildSearchKeybindEntries(ui)
+
+	if entry, ok := findEntry(entries, "Clear all input"); !ok || entry.key != "Ctrl+l" {
+		t.Fatalf("expected clear line key to be Ctrl+l, got %+v", entry)
+	}
+
+	if entry, ok := findEntry(entries, "Delete word"); !ok || entry.key != "Alt+Backspace" {
+		t.Fatalf("expected delete word key to be Alt+Backspace, got %+v", entry)
+	}
+}
+
+func TestBuildSearchKeybindEntriesFallsBackToDefaults(t *testing.T) {
+	renderer := &Renderer{}
+
+	entries := renderer.buildSearchKeybindEntries(&UI{})
+
+	if entry, ok := findEntry(entries, "Delete word"); !ok || entry.key != "Ctrl+w" {
+		t.Fatalf("expected default delete word to be Ctrl+w, got %+v", entry)
+	}
+
+	if _, ok := findEntry(entries, "Delete character"); !ok {
+		t.Fatalf("expected static Backspace hint to be present")
+	}
+}
+
+func TestBuildSearchKeybindEntriesFormatsMultipleKeys(t *testing.T) {
+	renderer := &Renderer{}
+
+	ui := newUIWithKeyMap(&KeyBindingMap{
+		DeleteWord: []KeyStroke{
+			NewCtrlKeyStroke('w'),
+			NewAltKeyStroke(0, "backspace"),
+		},
+	})
+
+	entries := renderer.buildSearchKeybindEntries(ui)
+
+	if entry, ok := findEntry(entries, "Delete word"); !ok || entry.key != "Ctrl+w, Alt+Backspace" {
+		t.Fatalf("expected combined delete word bindings, got %+v", entry)
+	}
+}
+
+func newUIWithKeyMap(km *KeyBindingMap) *UI {
+	state := &UIState{context: ContextSearch}
+	ui := &UI{state: state}
+	contextMap := NewContextualKeyBindingMap(ProfileDefault, "darwin", "iterm")
+	contextMap.SetContext(ContextSearch, km)
+	handler := &KeyHandler{contextualMap: contextMap}
+	handler.ui = ui
+	ui.handler = handler
+	return ui
+}
+
+func findEntry(entries []keybindHelpEntry, desc string) (keybindHelpEntry, bool) {
+	for _, entry := range entries {
+		if entry.desc == desc {
+			return entry, true
+		}
+	}
+	return keybindHelpEntry{}, false
+}

--- a/cmd/keybindings.go
+++ b/cmd/keybindings.go
@@ -3545,10 +3545,7 @@ func FormatKeyStrokeForDisplay(ks KeyStroke) string { //nolint:revive // handles
 		return fmt.Sprintf("Ctrl+%c", ks.Rune)
 	case KeyStrokeAlt:
 		if ks.Name != "" {
-			label := ks.Name
-			if label != "" {
-				label = strings.ToUpper(label[:1]) + label[1:]
-			}
+			label := strings.ToUpper(ks.Name[:1]) + ks.Name[1:]
 			return fmt.Sprintf("Alt+%s", label)
 		}
 		if ks.Rune != 0 {

--- a/cmd/keybindings.go
+++ b/cmd/keybindings.go
@@ -3484,27 +3484,27 @@ func (skc *ShowKeysCommand) Execute(profile Profile, context Context, format str
 	fmt.Printf("Core Actions:\n")
 	fmt.Printf("  Navigation:\n")
 	if len(keyMap.MoveUp) > 0 {
-		fmt.Printf("    move_up                 %-20s Move up one line\n", skc.formatKeystrokes(keyMap.MoveUp))
+		fmt.Printf("    move_up                 %-20s Move up one line\n", FormatKeyStrokesForDisplay(keyMap.MoveUp))
 	}
 	if len(keyMap.MoveDown) > 0 {
-		fmt.Printf("    move_down               %-20s Move down one line\n", skc.formatKeystrokes(keyMap.MoveDown))
+		fmt.Printf("    move_down               %-20s Move down one line\n", FormatKeyStrokesForDisplay(keyMap.MoveDown))
 	}
 	if len(keyMap.MoveToBeginning) > 0 {
-		fmt.Printf("    move_to_beginning       %-20s Move to line beginning\n", skc.formatKeystrokes(keyMap.MoveToBeginning))
+		fmt.Printf("    move_to_beginning       %-20s Move to line beginning\n", FormatKeyStrokesForDisplay(keyMap.MoveToBeginning))
 	}
 	if len(keyMap.MoveToEnd) > 0 {
-		fmt.Printf("    move_to_end             %-20s Move to line end\n", skc.formatKeystrokes(keyMap.MoveToEnd))
+		fmt.Printf("    move_to_end             %-20s Move to line end\n", FormatKeyStrokesForDisplay(keyMap.MoveToEnd))
 	}
 
 	fmt.Printf("\n  Editing:\n")
 	if len(keyMap.DeleteWord) > 0 {
-		fmt.Printf("    delete_word             %-20s Delete previous word\n", skc.formatKeystrokes(keyMap.DeleteWord))
+		fmt.Printf("    delete_word             %-20s Delete previous word\n", FormatKeyStrokesForDisplay(keyMap.DeleteWord))
 	}
 	if len(keyMap.DeleteToEnd) > 0 {
-		fmt.Printf("    delete_to_end           %-20s Delete to line end\n", skc.formatKeystrokes(keyMap.DeleteToEnd))
+		fmt.Printf("    delete_to_end           %-20s Delete to line end\n", FormatKeyStrokesForDisplay(keyMap.DeleteToEnd))
 	}
 	if len(keyMap.ClearLine) > 0 {
-		fmt.Printf("    clear_line              %-20s Clear entire line\n", skc.formatKeystrokes(keyMap.ClearLine))
+		fmt.Printf("    clear_line              %-20s Clear entire line\n", FormatKeyStrokesForDisplay(keyMap.ClearLine))
 	}
 
 	fmt.Printf("\nQuick Reference:\n")
@@ -3524,27 +3524,37 @@ func (skc *ShowKeysCommand) Execute(profile Profile, context Context, format str
 	return nil
 }
 
-// formatKeystrokes formats keystrokes for display
-func (skc *ShowKeysCommand) formatKeystrokes(keystrokes []KeyStroke) string {
+// FormatKeyStrokesForDisplay returns a comma-separated list of keystrokes suitable for user-facing output.
+func FormatKeyStrokesForDisplay(keystrokes []KeyStroke) string {
 	if len(keystrokes) == 0 {
 		return "none"
 	}
 
 	var parts []string
 	for _, ks := range keystrokes {
-		parts = append(parts, skc.formatKeystroke(ks))
+		parts = append(parts, FormatKeyStrokeForDisplay(ks))
 	}
 
 	return strings.Join(parts, ", ")
 }
 
-// formatKeystroke formats a single keystroke for display
-func (skc *ShowKeysCommand) formatKeystroke(ks KeyStroke) string { //nolint:revive // handles numerous escape sequences
+// FormatKeyStrokeForDisplay converts a single keystroke into a readable label.
+func FormatKeyStrokeForDisplay(ks KeyStroke) string { //nolint:revive // handles numerous escape sequences
 	switch ks.Kind {
 	case KeyStrokeCtrl:
 		return fmt.Sprintf("Ctrl+%c", ks.Rune)
 	case KeyStrokeAlt:
-		return fmt.Sprintf("Alt+%c", ks.Rune)
+		if ks.Name != "" {
+			label := ks.Name
+			if label != "" {
+				label = strings.ToUpper(label[:1]) + label[1:]
+			}
+			return fmt.Sprintf("Alt+%s", label)
+		}
+		if ks.Rune != 0 {
+			return fmt.Sprintf("Alt+%c", ks.Rune)
+		}
+		return "Alt+?"
 	case KeyStrokeRawSeq:
 		// Handle common sequences
 		if len(ks.Seq) == 1 {

--- a/cmd/keybindings_display_test.go
+++ b/cmd/keybindings_display_test.go
@@ -1,0 +1,57 @@
+package cmd
+
+import "testing"
+
+func TestFormatKeyStrokeForDisplay(t *testing.T) {
+	tests := []struct {
+		name     string
+		stroke   KeyStroke
+		expected string
+	}{
+		{
+			name:     "ctrl letter",
+			stroke:   NewCtrlKeyStroke('q'),
+			expected: "Ctrl+q",
+		},
+		{
+			name:     "alt named key",
+			stroke:   NewAltKeyStroke(0, "backspace"),
+			expected: "Alt+Backspace",
+		},
+		{
+			name:     "alt rune",
+			stroke:   NewAltKeyStroke('f', ""),
+			expected: "Alt+f",
+		},
+		{
+			name:     "raw tab",
+			stroke:   NewRawKeyStroke([]byte{9}),
+			expected: "Tab",
+		},
+		{
+			name:     "raw arrow",
+			stroke:   NewRawKeyStroke([]byte{27, 91, 67}),
+			expected: "→",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := FormatKeyStrokeForDisplay(tc.stroke); got != tc.expected {
+				t.Fatalf("expected %q, got %q", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestFormatKeyStrokesForDisplayJoinsMultiple(t *testing.T) {
+	strokes := []KeyStroke{
+		NewCtrlKeyStroke('w'),
+		NewAltKeyStroke(0, "backspace"),
+	}
+
+	expected := "Ctrl+w, Alt+Backspace"
+	if got := FormatKeyStrokesForDisplay(strokes); got != expected {
+		t.Fatalf("expected %q, got %q", expected, got)
+	}
+}

--- a/cmd/remote_test.go
+++ b/cmd/remote_test.go
@@ -48,13 +48,13 @@ func TestRemoter_Constructor(t *testing.T) {
 	if remoter == nil {
 		t.Fatal("Expected NewRemoter to return a non-nil Remoter")
 	}
-	if remoter.gitClient == nil {
+	if remoter != nil && remoter.gitClient == nil {
 		t.Error("Expected gitClient to be set")
 	}
-	if remoter.outputWriter == nil {
+	if remoter != nil && remoter.outputWriter == nil {
 		t.Error("Expected outputWriter to be set")
 	}
-	if remoter.helper == nil {
+	if remoter != nil && remoter.helper == nil {
 		t.Error("Expected helper to be set")
 	}
 }

--- a/cmd/reset_test.go
+++ b/cmd/reset_test.go
@@ -40,13 +40,13 @@ func TestResetter_Constructor(t *testing.T) {
 	if resetter == nil {
 		t.Fatal("Expected NewResetter to return a non-nil Resetter")
 	}
-	if resetter.gitClient == nil {
+	if resetter != nil && resetter.gitClient == nil {
 		t.Error("Expected gitClient to be set")
 	}
-	if resetter.outputWriter == nil {
+	if resetter != nil && resetter.outputWriter == nil {
 		t.Error("Expected outputWriter to be set")
 	}
-	if resetter.helper == nil {
+	if resetter != nil && resetter.helper == nil {
 		t.Error("Expected helper to be set")
 	}
 }

--- a/cmd/restore_test.go
+++ b/cmd/restore_test.go
@@ -50,13 +50,13 @@ func TestRestorer_Constructor(t *testing.T) {
 	if restorer == nil {
 		t.Fatal("Expected NewRestorer to return a non-nil Restorer")
 	}
-	if restorer.gitClient == nil {
+	if restorer != nil && restorer.gitClient == nil {
 		t.Error("Expected gitClient to be set")
 	}
-	if restorer.outputWriter == nil {
+	if restorer != nil && restorer.outputWriter == nil {
 		t.Error("Expected outputWriter to be set")
 	}
-	if restorer.helper == nil {
+	if restorer != nil && restorer.helper == nil {
 		t.Error("Expected helper to be set")
 	}
 }

--- a/cmd/runtime_profile_switch_test.go
+++ b/cmd/runtime_profile_switch_test.go
@@ -82,7 +82,7 @@ func TestProfileSwitcherUpdatesHandler(t *testing.T) {
 	if emacsContextual == nil {
 		t.Fatal("expected handler contextual map to be updated")
 	}
-	if emacsContextual.Profile != ProfileEmacs {
+	if emacsContextual != nil && emacsContextual.Profile != ProfileEmacs {
 		t.Fatalf("contextual profile = %s, want %s", emacsContextual.Profile, ProfileEmacs)
 	}
 

--- a/cmd/stash_test.go
+++ b/cmd/stash_test.go
@@ -56,13 +56,13 @@ func TestStasher_Constructor(t *testing.T) {
 	if stasher == nil {
 		t.Fatal("Expected NewStasher to return a non-nil Stasher")
 	}
-	if stasher.gitClient == nil {
+	if stasher != nil && stasher.gitClient == nil {
 		t.Error("Expected gitClient to be set")
 	}
-	if stasher.outputWriter == nil {
+	if stasher != nil && stasher.outputWriter == nil {
 		t.Error("Expected outputWriter to be set")
 	}
-	if stasher.helper == nil {
+	if stasher != nil && stasher.helper == nil {
 		t.Error("Expected helper to be set")
 	}
 }

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -50,13 +50,13 @@ func TestStatuser_Constructor(t *testing.T) {
 	if statuser == nil {
 		t.Fatal("Expected NewStatuser to return a non-nil Statuser")
 	}
-	if statuser.gitClient == nil {
+	if statuser != nil && statuser.gitClient == nil {
 		t.Error("Expected gitClient to be set")
 	}
-	if statuser.outputWriter == nil {
+	if statuser != nil && statuser.outputWriter == nil {
 		t.Error("Expected outputWriter to be set")
 	}
-	if statuser.helper == nil {
+	if statuser != nil && statuser.helper == nil {
 		t.Error("Expected helper to be set")
 	}
 }

--- a/cmd/tag_test.go
+++ b/cmd/tag_test.go
@@ -94,13 +94,13 @@ func TestTagger_Constructor(t *testing.T) {
 	if tagger == nil {
 		t.Fatal("Expected NewTagger to return a non-nil Tagger")
 	}
-	if tagger.gitClient == nil {
+	if tagger != nil && tagger.gitClient == nil {
 		t.Error("Expected gitClient to be set")
 	}
-	if tagger.outputWriter == nil {
+	if tagger != nil && tagger.outputWriter == nil {
 		t.Error("Expected outputWriter to be set")
 	}
-	if tagger.helper == nil {
+	if tagger != nil && tagger.helper == nil {
 		t.Error("Expected helper to be set")
 	}
 }

--- a/cmd/workflow.go
+++ b/cmd/workflow.go
@@ -1,0 +1,204 @@
+// Package cmd provides workflow functionality for sequential command execution.
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+)
+
+// WorkflowStep represents a single step in a workflow
+type WorkflowStep struct {
+	ID          int      `json:"id"`
+	Command     string   `json:"command"`
+	Args        []string `json:"args"`
+	Description string   `json:"description"`
+}
+
+// String returns a string representation of the workflow step
+func (ws *WorkflowStep) String() string {
+	if ws.Description != "" {
+		return fmt.Sprintf("[%d] %s", ws.ID, ws.Description)
+	}
+
+	cmdStr := ws.Command
+	if len(ws.Args) > 0 {
+		cmdStr += " " + strings.Join(ws.Args, " ")
+	}
+	return fmt.Sprintf("[%d] %s", ws.ID, cmdStr)
+}
+
+// Workflow manages a sequence of commands to be executed
+type Workflow struct {
+	steps  []WorkflowStep
+	nextID int
+	mutex  sync.RWMutex
+}
+
+// NewWorkflow creates a new workflow
+func NewWorkflow() *Workflow {
+	return &Workflow{
+		steps:  make([]WorkflowStep, 0),
+		nextID: 1,
+	}
+}
+
+// AddStep adds a step to the workflow
+func (w *Workflow) AddStep(command string, args []string, description string) int {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
+	step := WorkflowStep{
+		ID:          w.nextID,
+		Command:     command,
+		Args:        args,
+		Description: description,
+	}
+
+	w.steps = append(w.steps, step)
+	id := w.nextID
+	w.nextID++
+
+	return id
+}
+
+// GetSteps returns a copy of all workflow steps
+func (w *Workflow) GetSteps() []WorkflowStep {
+	w.mutex.RLock()
+	defer w.mutex.RUnlock()
+
+	result := make([]WorkflowStep, len(w.steps))
+	copy(result, w.steps)
+	return result
+}
+
+// Clear removes all steps from the workflow
+func (w *Workflow) Clear() {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
+	w.steps = w.steps[:0]
+	w.nextID = 1
+}
+
+// IsEmpty returns true if the workflow has no steps
+func (w *Workflow) IsEmpty() bool {
+	w.mutex.RLock()
+	defer w.mutex.RUnlock()
+
+	return len(w.steps) == 0
+}
+
+// Size returns the number of steps in the workflow
+func (w *Workflow) Size() int {
+	w.mutex.RLock()
+	defer w.mutex.RUnlock()
+
+	return len(w.steps)
+}
+
+// CommandRouter represents an interface for routing commands
+type CommandRouter interface {
+	Route(args []string)
+}
+
+// WorkflowExecutor executes workflow steps sequentially using existing Route mechanism
+type WorkflowExecutor struct {
+	router CommandRouter
+}
+
+// NewWorkflowExecutor creates a new workflow executor
+func NewWorkflowExecutor(router CommandRouter) *WorkflowExecutor {
+	return &WorkflowExecutor{
+		router: router,
+	}
+}
+
+// Execute runs all steps in the workflow sequentially
+func (we *WorkflowExecutor) Execute(workflow *Workflow) error {
+	steps := workflow.GetSteps()
+
+	if len(steps) == 0 {
+		return fmt.Errorf("workflow is empty")
+	}
+
+	fmt.Printf("🚀 Starting workflow execution (%d steps)\n\n", len(steps))
+
+	for i, step := range steps {
+		fmt.Printf("📋 Step %d/%d: %s\n", i+1, len(steps), step.String())
+
+		// Resolve placeholders in the description (which contains the original template)
+		finalCmd := step.Description
+		placeholders := extractPlaceholders(finalCmd)
+
+		if len(placeholders) > 0 {
+			// Interactive input for placeholders
+			inputs := interactiveInputForWorkflow(placeholders)
+
+			// Placeholder replacement
+			for ph, val := range inputs {
+				finalCmd = strings.ReplaceAll(finalCmd, "<"+ph+">", val)
+			}
+
+			fmt.Printf("   → Resolved to: %s\n", finalCmd)
+		}
+
+		// Parse resolved command
+		parts := strings.Fields(finalCmd)
+		if len(parts) == 0 {
+			continue
+		}
+
+		// Execute the resolved command using existing Route mechanism
+		we.router.Route(parts)
+
+		fmt.Printf("✅ Step %d completed successfully\n", i+1)
+
+		// Add separator between steps (except for the last one)
+		if i < len(steps)-1 {
+			fmt.Println("─────────────────────────────────────")
+		}
+	}
+
+	fmt.Printf("\n🎉 Workflow completed successfully! (%d steps executed)\n", len(steps))
+	return nil
+}
+
+// interactiveInputForWorkflow provides interactive input for placeholders during workflow execution
+func interactiveInputForWorkflow(placeholders []string) map[string]string {
+	inputs := make(map[string]string)
+
+	for i, ph := range placeholders {
+		if len(placeholders) > 1 {
+			fmt.Printf("\n[%d/%d] ", i+1, len(placeholders))
+		} else {
+			fmt.Print("\n")
+		}
+
+		fmt.Printf("? %s: ", ph)
+
+		// Read complete line including spaces using bufio.Scanner
+		scanner := bufio.NewScanner(os.Stdin)
+		if !scanner.Scan() {
+			if err := scanner.Err(); err != nil {
+				fmt.Printf("Input error: %v\n", err)
+			} else {
+				fmt.Printf("Input canceled\n")
+			}
+			return nil
+		}
+		value := strings.TrimSpace(scanner.Text())
+
+		if value == "" {
+			fmt.Printf("Operation canceled\n")
+			return nil
+		}
+
+		inputs[ph] = value
+		fmt.Printf("✓ %s: %s\n", ph, value)
+	}
+
+	return inputs
+}

--- a/cmd/workflow_test.go
+++ b/cmd/workflow_test.go
@@ -1,0 +1,197 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestWorkflow_AddStep(t *testing.T) {
+	workflow := NewWorkflow()
+
+	id1 := workflow.AddStep("add", []string{"."}, "add .")
+	id2 := workflow.AddStep("commit", []string{"-m", "test"}, "commit -m test")
+
+	if id1 != 1 {
+		t.Errorf("Expected first ID to be 1, got %d", id1)
+	}
+	if id2 != 2 {
+		t.Errorf("Expected second ID to be 2, got %d", id2)
+	}
+
+	steps := workflow.GetSteps()
+	if len(steps) != 2 {
+		t.Errorf("Expected 2 steps, got %d", len(steps))
+	}
+
+	if steps[0].Command != "add" {
+		t.Errorf("Expected first command 'add', got '%s'", steps[0].Command)
+	}
+	if steps[1].Command != "commit" {
+		t.Errorf("Expected second command 'commit', got '%s'", steps[1].Command)
+	}
+}
+
+func TestWorkflow_Clear(t *testing.T) {
+	workflow := NewWorkflow()
+
+	workflow.AddStep("add", []string{"."}, "add .")
+	workflow.AddStep("commit", []string{"-m", "test"}, "commit -m test")
+
+	if workflow.IsEmpty() {
+		t.Error("Expected workflow to not be empty")
+	}
+	if workflow.Size() != 2 {
+		t.Errorf("Expected size 2, got %d", workflow.Size())
+	}
+
+	workflow.Clear()
+
+	if !workflow.IsEmpty() {
+		t.Error("Expected workflow to be empty after clear")
+	}
+	if workflow.Size() != 0 {
+		t.Errorf("Expected size 0 after clear, got %d", workflow.Size())
+	}
+}
+
+func TestWorkflowStep_String(t *testing.T) {
+	// Test with description
+	step1 := WorkflowStep{
+		ID:          1,
+		Command:     "commit",
+		Args:        []string{"-m", "test message"},
+		Description: "commit -m test message",
+	}
+
+	result1 := step1.String()
+	expected1 := "[1] commit -m test message"
+
+	if result1 != expected1 {
+		t.Errorf("Expected '%s', got '%s'", expected1, result1)
+	}
+
+	// Test without description
+	step2 := WorkflowStep{
+		ID:      2,
+		Command: "push",
+		Args:    []string{"origin", "main"},
+	}
+
+	result2 := step2.String()
+	expected2 := "[2] push origin main"
+
+	if result2 != expected2 {
+		t.Errorf("Expected '%s', got '%s'", expected2, result2)
+	}
+}
+
+// Mock Router for testing workflow execution
+type mockWorkflowRouter struct {
+	executedCommands [][]string
+}
+
+func (m *mockWorkflowRouter) Route(args []string) {
+	m.executedCommands = append(m.executedCommands, args)
+}
+
+func TestWorkflowExecutor_Execute(t *testing.T) {
+	mock := &mockWorkflowRouter{}
+	executor := NewWorkflowExecutor(mock)
+	workflow := NewWorkflow()
+
+	// Test empty workflow
+	err := executor.Execute(workflow)
+	if err == nil {
+		t.Error("Expected error for empty workflow")
+	}
+
+	// Add steps to workflow
+	workflow.AddStep("add", []string{"."}, "add .")
+	workflow.AddStep("commit", []string{"-m", "test"}, "commit -m test")
+	workflow.AddStep("push", []string{}, "push")
+
+	// Execute workflow
+	err = executor.Execute(workflow)
+	if err != nil {
+		t.Errorf("Unexpected error executing workflow: %v", err)
+	}
+
+	// Check that all commands were routed in order
+	expectedCommands := [][]string{
+		{"add", "."},
+		{"commit", "-m", "test"},
+		{"push"},
+	}
+
+	if len(mock.executedCommands) != len(expectedCommands) {
+		t.Errorf("Expected %d commands executed, got %d", len(expectedCommands), len(mock.executedCommands))
+	}
+
+	for i, expectedCmd := range expectedCommands {
+		if len(mock.executedCommands[i]) != len(expectedCmd) {
+			t.Errorf("Expected command %d to have %d args, got %d", i, len(expectedCmd), len(mock.executedCommands[i]))
+			continue
+		}
+		for j, expectedArg := range expectedCmd {
+			if mock.executedCommands[i][j] != expectedArg {
+				t.Errorf("Expected command %d arg %d to be '%s', got '%s'", i, j, expectedArg, mock.executedCommands[i][j])
+			}
+		}
+	}
+}
+
+// TestWorkflowExecutor_ExecuteEmptyWorkflow tests executing an empty workflow
+func TestWorkflowExecutor_ExecuteEmptyWorkflow(t *testing.T) {
+	// Setup
+	mockRouter := &mockRouterNew{}
+	executor := NewWorkflowExecutor(mockRouter)
+	workflow := NewWorkflow()
+
+	// Execute
+	err := executor.Execute(workflow)
+
+	// Verify
+	if err == nil {
+		t.Error("Expected error when executing empty workflow")
+	}
+	if err.Error() != "workflow is empty" {
+		t.Errorf("Expected 'workflow is empty' error, got '%s'", err.Error())
+	}
+}
+
+// TestWorkflow_ConcurrentAccess tests concurrent access to workflow
+func TestWorkflow_ConcurrentAccess(t *testing.T) {
+	workflow := NewWorkflow()
+
+	// Test concurrent adds
+	done := make(chan bool, 10)
+	for i := 0; i < 10; i++ {
+		go func(id int) {
+			workflow.AddStep("test", []string{}, fmt.Sprintf("test %d", id))
+			done <- true
+		}(i)
+	}
+
+	// Wait for all goroutines
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+
+	// Verify all steps were added
+	steps := workflow.GetSteps()
+	if len(steps) != 10 {
+		t.Errorf("Expected 10 steps, got %d", len(steps))
+	}
+}
+
+// mockRouterNew is a mock implementation of CommandRouter for testing
+type mockRouterNew struct {
+	routedCommands [][]string
+}
+
+func (m *mockRouterNew) Route(args []string) {
+	if m.routedCommands == nil {
+		m.routedCommands = make([][]string, 0)
+	}
+	m.routedCommands = append(m.routedCommands, args)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -95,13 +95,16 @@ type Config struct {
 		Profile string `yaml:"profile,omitempty"`
 
 		Keybindings struct {
-			DeleteWord      string `yaml:"delete_word"`
-			ClearLine       string `yaml:"clear_line"`
-			DeleteToEnd     string `yaml:"delete_to_end"`
-			MoveToBeginning string `yaml:"move_to_beginning"`
-			MoveToEnd       string `yaml:"move_to_end"`
-			MoveUp          string `yaml:"move_up"`
-			MoveDown        string `yaml:"move_down"`
+			DeleteWord         string `yaml:"delete_word"`
+			ClearLine          string `yaml:"clear_line"`
+			DeleteToEnd        string `yaml:"delete_to_end"`
+			MoveToBeginning    string `yaml:"move_to_beginning"`
+			MoveToEnd          string `yaml:"move_to_end"`
+			MoveUp             string `yaml:"move_up"`
+			MoveDown           string `yaml:"move_down"`
+			AddToWorkflow      string `yaml:"add_to_workflow"`
+			ToggleWorkflowView string `yaml:"toggle_workflow_view"`
+			ClearWorkflow      string `yaml:"clear_workflow"`
 		} `yaml:"keybindings"`
 
 		Contexts struct {
@@ -989,13 +992,16 @@ func (c *Config) validateKeybindings() error {
 
 	// Validate global keybindings
 	bindings := map[string]string{
-		"delete_word":       c.Interactive.Keybindings.DeleteWord,
-		"clear_line":        c.Interactive.Keybindings.ClearLine,
-		"delete_to_end":     c.Interactive.Keybindings.DeleteToEnd,
-		"move_to_beginning": c.Interactive.Keybindings.MoveToBeginning,
-		"move_to_end":       c.Interactive.Keybindings.MoveToEnd,
-		"move_up":           c.Interactive.Keybindings.MoveUp,
-		"move_down":         c.Interactive.Keybindings.MoveDown,
+		"delete_word":          c.Interactive.Keybindings.DeleteWord,
+		"clear_line":           c.Interactive.Keybindings.ClearLine,
+		"delete_to_end":        c.Interactive.Keybindings.DeleteToEnd,
+		"move_to_beginning":    c.Interactive.Keybindings.MoveToBeginning,
+		"move_to_end":          c.Interactive.Keybindings.MoveToEnd,
+		"move_up":              c.Interactive.Keybindings.MoveUp,
+		"move_down":            c.Interactive.Keybindings.MoveDown,
+		"add_to_workflow":      c.Interactive.Keybindings.AddToWorkflow,
+		"toggle_workflow_view": c.Interactive.Keybindings.ToggleWorkflowView,
+		"clear_workflow":       c.Interactive.Keybindings.ClearWorkflow,
 	}
 
 	for action, keyStr := range bindings {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -167,19 +167,38 @@ func TestNewConfigManager(t *testing.T) {
 	mockClient := testutil.NewMockGitClient()
 	cm := NewConfigManager(mockClient)
 
-	if cm == nil {
-		t.Fatal("Expected config manager to be created")
-	}
-	if cm.config == nil {
-		t.Fatal("Expected config to be initialized")
-	}
-	if cm.configPath != "" {
-		t.Errorf("Expected configPath to be empty initially, got %s", cm.configPath)
-	}
+	t.Run("manager_creation", func(t *testing.T) {
+		if cm == nil {
+			t.Fatal("Expected config manager to be created")
+		}
+	})
 
-	if cm.config.Default.Branch != "main" {
-		t.Errorf("Expected default branch to be 'main', got %s", cm.config.Default.Branch)
-	}
+	t.Run("config_initialization", func(t *testing.T) {
+		if cm == nil {
+			t.Skip("Skipping due to nil manager")
+		}
+		if cm.config == nil {
+			t.Fatal("Expected config to be initialized")
+		}
+	})
+
+	t.Run("config_path_initialization", func(t *testing.T) {
+		if cm == nil {
+			t.Skip("Skipping due to nil manager")
+		}
+		if cm.configPath != "" {
+			t.Fatalf("Expected configPath to be empty initially, got: %s", cm.configPath)
+		}
+	})
+
+	t.Run("default_branch", func(t *testing.T) {
+		if cm == nil || cm.config == nil {
+			t.Skip("Skipping due to nil manager or config")
+		}
+		if cm.config.Default.Branch != "main" {
+			t.Errorf("Expected default branch to be 'main', got %s", cm.config.Default.Branch)
+		}
+	})
 }
 
 // TestGetConfigPaths tests the configuration path resolution


### PR DESCRIPTION
## Description of Changes
- replaced the static interactive help card with dynamic entries sourced from the active key map so customised bindings (e.g. `Ctrl+l`, `Alt+Backspace`) surface automatically (`cmd/interactive.go`, `cmd/keybindings.go`).
- added reusable keystroke display helpers plus unit coverage to keep terminal output in sync across the CLI and UI (`cmd/keybindings_display_test.go`, `cmd/interactive_keybinds_test.go`).

## Related Issue
closes #210

## Checklist
- [X] I have read the [CONTRIBUTING.md](https://github.com/bmf-san/ggc/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests
- [x] Code is formatted with `make fmt`
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing

## Screenshots (if appropriate)
N/A
