### PR TITLE
feature: Enhanced diff with commit comparison and path filtering

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,7 @@ type DiffReader interface {
     Diff() (string, error)
     DiffStaged() (string, error)
     DiffHead() (string, error)
+    DiffWith(args []string) (string, error)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ ggc
 | `restore staged .` | Unstage all files |
 | `restore staged <file>` | Unstage file (restore from HEAD to index) |
 | `diff` | Show changes (git diff HEAD) |
+| `diff head` | Alias for default diff against HEAD |
 | `diff staged` | Show staged changes |
 | `diff unstaged` | Show unstaged changes |
 | `tag annotated <tag> <message>` | Create annotated tag |

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -85,6 +85,9 @@ func (m *mockAddGitClient) CommitAllowEmpty() error               { return nil }
 func (m *mockAddGitClient) Diff() (string, error)       { return "", nil }
 func (m *mockAddGitClient) DiffStaged() (string, error) { return "", nil }
 func (m *mockAddGitClient) DiffHead() (string, error)   { return "", nil }
+func (m *mockAddGitClient) DiffWith(_ []string) (string, error) {
+	return "", nil
+}
 
 // Branch Operations methods
 func (m *mockAddGitClient) ListLocalBranches() ([]string, error) { return []string{"main"}, nil }

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -120,6 +120,9 @@ func (m *mockGitClient) CommitAmendWithMessage(_ string) error { return nil }
 func (m *mockGitClient) Diff() (string, error)       { return "", nil }
 func (m *mockGitClient) DiffStaged() (string, error) { return "", nil }
 func (m *mockGitClient) DiffHead() (string, error)   { return "", nil }
+func (m *mockGitClient) DiffWith(_ []string) (string, error) {
+	return "", nil
+}
 
 // Branch Operations methods
 func (m *mockGitClient) CheckoutNewBranch(_ string) error { return nil }

--- a/cmd/command/registry.go
+++ b/cmd/command/registry.go
@@ -252,18 +252,23 @@ var registry = []Info{
 	{
 		Name:     "diff",
 		Category: CategoryDiff,
-		Summary:  "Inspect changes between commits and the working tree",
-		Usage:    []string{"ggc diff", "ggc diff staged", "ggc diff unstaged"},
+		Summary:  "Inspect changes between commits, the index, and the working tree",
+		Usage: []string{
+			"ggc diff [staged|unstaged|head] [--stat|--name-only|--name-status] [<commit>|<commit1> <commit2>] [--] [<path>...]",
+		},
 		Examples: []string{
-			"ggc diff           # Diff all changes (unstaged and staged)",
-			"ggc diff staged    # Diff only staged changes",
-			"ggc diff unstaged  # Diff only unstaged changes",
+			"ggc diff --stat                     # Show staged + unstaged changes with summary",
+			"ggc diff staged cmd/diff.go         # Diff staged changes for a file",
+			"ggc diff abc123 def456              # Compare two commits",
+			"ggc diff abc123 cmd/diff.go         # Compare commit to working tree for a path",
+			"ggc diff -- cmd/deleted_file.go     # Diff a path using -- for disambiguation",
 		},
 		HandlerID: "diff",
 		Subcommands: []SubcommandInfo{
 			{Name: "diff", Summary: "Show changes (git diff HEAD)", Usage: []string{"ggc diff"}},
 			{Name: "diff unstaged", Summary: "Show unstaged changes", Usage: []string{"ggc diff unstaged"}},
 			{Name: "diff staged", Summary: "Show staged changes", Usage: []string{"ggc diff staged"}},
+			{Name: "diff head", Summary: "Alias for default diff against HEAD", Usage: []string{"ggc diff head"}},
 		},
 	},
 	{

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/bmf-san/ggc/v6/git"
 )
@@ -24,31 +26,295 @@ func NewDiffer(client git.DiffReader) *Differ {
 	}
 }
 
+type diffMode int
+
+const (
+	diffModeDefault diffMode = iota
+	diffModeUnstaged
+	diffModeStaged
+	diffModeHead
+)
+
+func (m diffMode) String() string {
+	switch m {
+	case diffModeUnstaged:
+		return "unstaged"
+	case diffModeStaged:
+		return "staged"
+	case diffModeHead:
+		return "head"
+	default:
+		return "default"
+	}
+}
+
+type diffOptions struct {
+	mode       diffMode
+	commits    []string
+	paths      []string
+	stat       bool
+	nameOnly   bool
+	nameStatus bool
+}
+
+type diffUsageError struct {
+	message string
+}
+
+func (e *diffUsageError) Error() string {
+	return e.message
+}
+
+func newDiffUsageError(message string) error {
+	return &diffUsageError{message: message}
+}
+
 // Diff executes git diff with the given arguments.
 func (d *Differ) Diff(args []string) {
-	var output string
-	var err error
+	if d.helper != nil && d.helper.outputWriter != d.outputWriter {
+		d.helper.outputWriter = d.outputWriter
+	}
 
-	if len(args) == 0 {
-		output, err = d.gitClient.DiffHead()
-	} else {
-		switch args[0] {
-		case "unstaged":
-			output, err = d.gitClient.Diff()
-		case "staged":
-			output, err = d.gitClient.DiffStaged()
-		case "head":
-			output, err = d.gitClient.DiffHead()
-		default:
+	opts, err := parseDiffArgs(args, defaultPathExists)
+	if err != nil {
+		var usageErr *diffUsageError
+		if errors.As(err, &usageErr) {
+			if usageErr.message != "" {
+				_, _ = fmt.Fprintf(d.outputWriter, "Error: %s\n", usageErr.message)
+			}
 			d.helper.ShowDiffHelp()
 			return
 		}
+
+		_, _ = fmt.Fprintf(d.outputWriter, "Error: %v\n", err)
+		return
 	}
 
+	gitArgs := buildDiffArgs(opts)
+	output, err := d.gitClient.DiffWith(gitArgs)
 	if err != nil {
 		_, _ = fmt.Fprintf(d.outputWriter, "Error: %v\n", err)
 		return
 	}
 
 	_, _ = fmt.Fprint(d.outputWriter, output)
+}
+
+func parseDiffArgs(args []string, pathExists func(string) bool) (*diffOptions, error) {
+	if pathExists == nil {
+		pathExists = func(string) bool { return false }
+	}
+
+	state := newDiffParseState()
+	for _, arg := range args {
+		if err := state.consume(arg); err != nil {
+			return nil, err
+		}
+	}
+
+	commits, prePaths, err := classifyDiffArgs(state.positional, pathExists)
+	if err != nil {
+		return nil, err
+	}
+
+	state.opts.commits = commits
+	state.opts.paths = append(append([]string(nil), prePaths...), state.pathsAfterDash...)
+
+	if err := state.validateModes(); err != nil {
+		return nil, err
+	}
+
+	return state.opts, nil
+}
+
+type diffParseState struct {
+	opts           *diffOptions
+	positional     []string
+	pathsAfterDash []string
+	modeSet        bool
+	seenDoubleDash bool
+}
+
+func newDiffParseState() *diffParseState {
+	return &diffParseState{opts: &diffOptions{mode: diffModeDefault}}
+}
+
+func (s *diffParseState) consume(arg string) error {
+	if !s.seenDoubleDash && arg == "--" {
+		s.seenDoubleDash = true
+		return nil
+	}
+
+	if s.seenDoubleDash {
+		s.pathsAfterDash = append(s.pathsAfterDash, arg)
+		return nil
+	}
+
+	return s.handleBeforeDoubleDash(arg)
+}
+
+func (s *diffParseState) handleBeforeDoubleDash(arg string) error {
+	switch arg {
+	case "unstaged", "staged", "head":
+		return s.setMode(arg)
+	case "--stat":
+		s.opts.stat = true
+		return nil
+	case "--name-only":
+		if s.opts.nameStatus {
+			return newDiffUsageError("--name-only cannot be combined with --name-status")
+		}
+		s.opts.nameOnly = true
+		return nil
+	case "--name-status":
+		if s.opts.nameOnly {
+			return newDiffUsageError("--name-only cannot be combined with --name-status")
+		}
+		s.opts.nameStatus = true
+		return nil
+	}
+
+	if strings.HasPrefix(arg, "--") {
+		return newDiffUsageError(fmt.Sprintf("unknown flag %s", arg))
+	}
+
+	s.positional = append(s.positional, arg)
+	return nil
+}
+
+func (s *diffParseState) setMode(mode string) error {
+	if s.modeSet {
+		return newDiffUsageError("multiple diff modes specified")
+	}
+
+	s.modeSet = true
+	s.opts.mode = mapMode(mode)
+	return nil
+}
+
+func mapMode(mode string) diffMode {
+	switch mode {
+	case "unstaged":
+		return diffModeUnstaged
+	case "staged":
+		return diffModeStaged
+	case "head":
+		return diffModeHead
+	default:
+		return diffModeDefault
+	}
+}
+
+func (s *diffParseState) validateModes() error {
+	if (s.opts.mode == diffModeStaged || s.opts.mode == diffModeUnstaged) && len(s.opts.commits) > 0 {
+		return newDiffUsageError(fmt.Sprintf("%s mode does not accept commit arguments", s.opts.mode.String()))
+	}
+
+	if s.opts.mode == diffModeHead && len(s.opts.commits) > 0 {
+		return newDiffUsageError("head mode cannot be combined with commit arguments")
+	}
+
+	return nil
+}
+
+func classifyDiffArgs(tokens []string, pathExists func(string) bool) ([]string, []string, error) {
+	if len(tokens) == 0 {
+		return nil, nil, nil
+	}
+
+	maxCommits := len(tokens)
+	if maxCommits > 2 {
+		maxCommits = 2
+	}
+
+	for commitsCount := 0; commitsCount <= maxCommits; commitsCount++ {
+		commitsCandidate := append([]string(nil), tokens[:commitsCount]...)
+		pathsCandidate := tokens[commitsCount:]
+
+		if pathsAreValid(pathsCandidate, pathExists) {
+			return commitsCandidate, append([]string(nil), pathsCandidate...), nil
+		}
+	}
+
+	if len(tokens) > 2 {
+		return nil, nil, newDiffUsageError("too many commit arguments (maximum two)")
+	}
+
+	return nil, nil, newDiffUsageError("unable to determine commit and path arguments")
+}
+
+func pathsAreValid(paths []string, pathExists func(string) bool) bool {
+	for _, p := range paths {
+		if p == "" {
+			return false
+		}
+		if pathExists(p) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func buildDiffArgs(opts *diffOptions) []string {
+	args := append([]string(nil), modeArg(opts)...)
+	args = append(args, summaryArgs(opts)...)
+	args = append(args, commitArgs(opts)...)
+
+	if len(opts.paths) > 0 {
+		args = append(args, "--")
+		args = append(args, opts.paths...)
+	}
+
+	return args
+}
+
+func modeArg(opts *diffOptions) []string {
+	switch opts.mode {
+	case diffModeStaged:
+		return []string{"--staged"}
+	default:
+		return nil
+	}
+}
+
+func summaryArgs(opts *diffOptions) []string {
+	var out []string
+	if opts.stat {
+		out = append(out, "--stat")
+	}
+	if opts.nameOnly {
+		out = append(out, "--name-only")
+	}
+	if opts.nameStatus {
+		out = append(out, "--name-status")
+	}
+	return out
+}
+
+func commitArgs(opts *diffOptions) []string {
+	if len(opts.commits) > 0 {
+		return append([]string(nil), opts.commits...)
+	}
+
+	switch opts.mode {
+	case diffModeDefault, diffModeHead:
+		return []string{"HEAD"}
+	default:
+		return nil
+	}
+}
+
+func defaultPathExists(path string) bool {
+	if path == "" {
+		return false
+	}
+	if strings.HasPrefix(path, "--") {
+		return false
+	}
+
+	if _, err := os.Stat(path); err == nil {
+		return true
+	}
+	return false
 }

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -206,14 +206,9 @@ func mapMode(mode string) diffMode {
 }
 
 func (s *diffParseState) validateModes() error {
-	if (s.opts.mode == diffModeStaged || s.opts.mode == diffModeUnstaged) && len(s.opts.commits) > 0 {
-		return newDiffUsageError(fmt.Sprintf("%s mode does not accept commit arguments", s.opts.mode.String()))
+	if (s.opts.mode == diffModeStaged || s.opts.mode == diffModeUnstaged || s.opts.mode == diffModeHead) && len(s.opts.commits) > 0 {
+		return newDiffUsageError(fmt.Sprintf("%s mode does not accept commit arguments (but allows path arguments)", s.opts.mode.String()))
 	}
-
-	if s.opts.mode == diffModeHead && len(s.opts.commits) > 0 {
-		return newDiffUsageError("head mode cannot be combined with commit arguments")
-	}
-
 	return nil
 }
 

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -2,255 +2,405 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/bmf-san/ggc/v6/git"
 )
 
-// mockDiffClient implements git.DiffReader with simple call tracking.
+// mockDiffClient implements git.DiffReader with argument capture.
 type mockDiffClient struct {
-	called      string
-	headOut     string
-	stagedOut   string
-	unstagedOut string
+	diffArgs []string
+	output   string
+	err      error
 }
 
-func (m *mockDiffClient) Diff() (string, error) {
-	m.called = "unstaged"
-	return m.unstagedOut, nil
-}
-
-func (m *mockDiffClient) DiffStaged() (string, error) {
-	m.called = "staged"
-	return m.stagedOut, nil
-}
-
-func (m *mockDiffClient) DiffHead() (string, error) {
-	m.called = "head"
-	return m.headOut, nil
+func (m *mockDiffClient) Diff() (string, error)       { return "", nil }
+func (m *mockDiffClient) DiffStaged() (string, error) { return "", nil }
+func (m *mockDiffClient) DiffHead() (string, error)   { return "", nil }
+func (m *mockDiffClient) DiffWith(args []string) (string, error) {
+	m.diffArgs = append([]string(nil), args...)
+	if m.err != nil {
+		return "", m.err
+	}
+	return m.output, nil
 }
 
 var _ git.DiffReader = (*mockDiffClient)(nil)
 
-func TestDiffer_Constructor(t *testing.T) {
-	mockClient := &mockDiffClient{}
-	differ := NewDiffer(mockClient)
-
-	if differ == nil {
-		t.Fatal("Expected NewDiffer to return a non-nil Differ")
-	}
-	if differ != nil && differ.gitClient == nil {
-		t.Error("Expected gitClient to be set")
-	}
-	if differ != nil && differ.outputWriter == nil {
-		t.Error("Expected outputWriter to be set")
-	}
-	if differ != nil && differ.helper == nil {
-		t.Error("Expected helper to be set")
-	}
-}
-
-func TestDiffer_Diff(t *testing.T) {
-	tests := []struct {
-		name           string
-		args           []string
-		expectedOutput string
-		shouldShowHelp bool
-	}{
-		{
-			name:           "no args - should call DiffHead",
-			args:           []string{},
-			expectedOutput: "",
-			shouldShowHelp: false,
-		},
-		{
-			name:           "unstaged - should call Diff",
-			args:           []string{"unstaged"},
-			expectedOutput: "",
-			shouldShowHelp: false,
-		},
-		{
-			name:           "staged - should call DiffStaged",
-			args:           []string{"staged"},
-			expectedOutput: "",
-			shouldShowHelp: false,
-		},
-		{
-			name:           "head - should call DiffHead",
-			args:           []string{"head"},
-			expectedOutput: "",
-			shouldShowHelp: false,
-		},
-		{
-			name:           "unknown arg - should show help",
-			args:           []string{"unknown"},
-			expectedOutput: "Usage: ggc diff [options]",
-			shouldShowHelp: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			buf := &bytes.Buffer{}
-			mockClient := &mockDiffClient{}
-
-			differ := &Differ{
-				gitClient:    mockClient,
-				outputWriter: buf,
-				helper:       NewHelper(),
-			}
-			differ.helper.outputWriter = buf
-
-			differ.Diff(tt.args)
-
-			output := buf.String()
-
-			if tt.shouldShowHelp {
-				if !strings.Contains(output, tt.expectedOutput) {
-					t.Errorf("Expected help output containing '%s', got: %s", tt.expectedOutput, output)
-				}
-			} else {
-				if tt.expectedOutput == "" {
-					if strings.Contains(output, "Error:") {
-						t.Errorf("Unexpected error in diff operation: %s", output)
-					}
-				} else {
-					if !strings.Contains(output, tt.expectedOutput) {
-						t.Errorf("Expected output containing '%s', got: %s", tt.expectedOutput, output)
-					}
-				}
-			}
-
-			if t.Failed() {
-				t.Logf("Command args: %v", tt.args)
-				t.Logf("Full output: %s", output)
-			}
-		})
-	}
-}
-
-func TestDiffer_DiffOperations(t *testing.T) {
-	tests := []struct {
-		name     string
-		args     []string
-		testFunc func(*testing.T, *Differ, *mockDiffClient, *bytes.Buffer)
-	}{
-		{
-			name: "default calls DiffHead",
-			args: []string{},
-			testFunc: func(t *testing.T, differ *Differ, mock *mockDiffClient, buf *bytes.Buffer) {
-				if mock.called != "head" {
-					t.Errorf("Expected DiffHead to be called, got %s", mock.called)
-				}
-			},
-		},
-		{
-			name: "unstaged calls Diff",
-			args: []string{"unstaged"},
-			testFunc: func(t *testing.T, differ *Differ, mock *mockDiffClient, buf *bytes.Buffer) {
-				if mock.called != "unstaged" {
-					t.Errorf("Expected Diff to be called, got %s", mock.called)
-				}
-			},
-		},
-		{
-			name: "staged calls DiffStaged",
-			args: []string{"staged"},
-			testFunc: func(t *testing.T, differ *Differ, mock *mockDiffClient, buf *bytes.Buffer) {
-				if mock.called != "staged" {
-					t.Errorf("Expected DiffStaged to be called, got %s", mock.called)
-				}
-			},
-		},
-		{
-			name: "head calls DiffHead",
-			args: []string{"head"},
-			testFunc: func(t *testing.T, differ *Differ, mock *mockDiffClient, buf *bytes.Buffer) {
-				if mock.called != "head" {
-					t.Errorf("Expected DiffHead to be called, got %s", mock.called)
-				}
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			buf := &bytes.Buffer{}
-			mockClient := &mockDiffClient{}
-
-			differ := &Differ{
-				gitClient:    mockClient,
-				outputWriter: buf,
-				helper:       NewHelper(),
-			}
-
-			differ.Diff(tt.args)
-			tt.testFunc(t, differ, mockClient, buf)
-		})
-	}
+func newTestDiffer(client git.DiffReader, buf *bytes.Buffer) *Differ {
+	helper := NewHelper()
+	helper.outputWriter = buf
+	return &Differ{gitClient: client, outputWriter: buf, helper: helper}
 }
 
 func TestDiffer_Diff_DefaultsToHead(t *testing.T) {
-	mc := &mockDiffClient{headOut: "HEAD DIFF"}
-	var buf bytes.Buffer
+	buf := &bytes.Buffer{}
+	mockClient := &mockDiffClient{output: "DIFF"}
+	differ := newTestDiffer(mockClient, buf)
 
-	d := &Differ{gitClient: mc, outputWriter: &buf, helper: NewHelper()}
-	d.Diff([]string{})
+	differ.Diff(nil)
 
-	if mc.called != "head" {
-		t.Fatalf("expected DiffHead to be called, got %q", mc.called)
+	if want := []string{"HEAD"}; !slices.Equal(mockClient.diffArgs, want) {
+		t.Fatalf("expected git args %v, got %v", want, mockClient.diffArgs)
 	}
-	if got := buf.String(); got != "HEAD DIFF" {
-		t.Fatalf("unexpected output: %q", got)
-	}
-}
 
-func TestDiffer_Diff_Unstaged(t *testing.T) {
-	mc := &mockDiffClient{unstagedOut: "UNSTAGED DIFF"}
-	var buf bytes.Buffer
-
-	d := &Differ{gitClient: mc, outputWriter: &buf, helper: NewHelper()}
-	d.Diff([]string{"unstaged"})
-
-	if mc.called != "unstaged" {
-		t.Fatalf("expected Diff to be called, got %q", mc.called)
-	}
-	if got := buf.String(); got != "UNSTAGED DIFF" {
-		t.Fatalf("unexpected output: %q", got)
+	if buf.String() != "DIFF" {
+		t.Fatalf("expected diff output to be written, got %q", buf.String())
 	}
 }
 
-func TestDiffer_Diff_Staged(t *testing.T) {
-	mc := &mockDiffClient{stagedOut: "STAGED DIFF"}
-	var buf bytes.Buffer
+func TestDiffer_Diff_UnstagedMode(t *testing.T) {
+	buf := &bytes.Buffer{}
+	mockClient := &mockDiffClient{}
+	differ := newTestDiffer(mockClient, buf)
 
-	d := &Differ{gitClient: mc, outputWriter: &buf, helper: NewHelper()}
-	d.Diff([]string{"staged"})
+	differ.Diff([]string{"unstaged"})
 
-	if mc.called != "staged" {
-		t.Fatalf("expected DiffStaged to be called, got %q", mc.called)
-	}
-	if got := buf.String(); got != "STAGED DIFF" {
-		t.Fatalf("unexpected output: %q", got)
+	if len(mockClient.diffArgs) != 0 {
+		t.Fatalf("expected no additional args for unstaged diff, got %v", mockClient.diffArgs)
 	}
 }
 
-func TestDiffer_Diff_InvalidArg_ShowsHelp(t *testing.T) {
-	mc := &mockDiffClient{}
-	var buf bytes.Buffer
-
-	// Use helper with our buffer to capture help output
-	h := NewHelper()
-	h.outputWriter = &buf
-
-	d := &Differ{gitClient: mc, outputWriter: &buf, helper: h}
-	d.Diff([]string{"unknown"})
-
-	if mc.called != "" {
-		t.Fatalf("diff methods should not be called for invalid arg, got %q", mc.called)
+func TestDiffer_Diff_StagedWithPath(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "file.txt")
+	if err := os.WriteFile(filePath, []byte("content"), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
 	}
-	if buf.Len() == 0 {
-		t.Fatal("expected help output for invalid arg")
+
+	buf := &bytes.Buffer{}
+	mockClient := &mockDiffClient{}
+	differ := newTestDiffer(mockClient, buf)
+
+	differ.Diff([]string{"staged", filePath})
+
+	want := []string{"--staged", "--", filePath}
+	if !slices.Equal(mockClient.diffArgs, want) {
+		t.Fatalf("expected git args %v, got %v", want, mockClient.diffArgs)
+	}
+}
+
+func TestDiffer_Diff_WithFlagsAndPath(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "file.txt")
+	if err := os.WriteFile(filePath, []byte("content"), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	buf := &bytes.Buffer{}
+	mockClient := &mockDiffClient{}
+	differ := newTestDiffer(mockClient, buf)
+
+	differ.Diff([]string{"--stat", filePath})
+
+	want := []string{"--stat", "HEAD", "--", filePath}
+	if !slices.Equal(mockClient.diffArgs, want) {
+		t.Fatalf("expected git args %v, got %v", want, mockClient.diffArgs)
+	}
+}
+
+func TestDiffer_Diff_CommitRange(t *testing.T) {
+	buf := &bytes.Buffer{}
+	mockClient := &mockDiffClient{}
+	differ := newTestDiffer(mockClient, buf)
+
+	differ.Diff([]string{"abc123", "def456"})
+
+	want := []string{"abc123", "def456"}
+	if !slices.Equal(mockClient.diffArgs, want) {
+		t.Fatalf("expected git args %v, got %v", want, mockClient.diffArgs)
+	}
+}
+
+func TestDiffer_Diff_CommitWithPath(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "file.txt")
+	if err := os.WriteFile(filePath, []byte("content"), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	buf := &bytes.Buffer{}
+	mockClient := &mockDiffClient{}
+	differ := newTestDiffer(mockClient, buf)
+
+	differ.Diff([]string{"abc123", filePath})
+
+	want := []string{"abc123", "--", filePath}
+	if !slices.Equal(mockClient.diffArgs, want) {
+		t.Fatalf("expected git args %v, got %v", want, mockClient.diffArgs)
+	}
+}
+
+func TestDiffer_Diff_DoubleDashForPaths(t *testing.T) {
+	buf := &bytes.Buffer{}
+	mockClient := &mockDiffClient{}
+	differ := newTestDiffer(mockClient, buf)
+
+	differ.Diff([]string{"--", "deleted.txt"})
+
+	want := []string{"HEAD", "--", "deleted.txt"}
+	if !slices.Equal(mockClient.diffArgs, want) {
+		t.Fatalf("expected git args %v, got %v", want, mockClient.diffArgs)
+	}
+}
+
+func TestDiffer_Diff_InvalidFlagShowsHelp(t *testing.T) {
+	buf := &bytes.Buffer{}
+	mockClient := &mockDiffClient{}
+	differ := newTestDiffer(mockClient, buf)
+
+	differ.Diff([]string{"--unknown"})
+
+	output := buf.String()
+	if !strings.Contains(output, "unknown flag") {
+		t.Fatalf("expected unknown flag message, got %q", output)
+	}
+	if !strings.Contains(output, "Usage:") {
+		t.Fatalf("expected help output, got %q", output)
+	}
+}
+
+func TestDiffer_Diff_ConflictingFlags(t *testing.T) {
+	buf := &bytes.Buffer{}
+	mockClient := &mockDiffClient{}
+	differ := newTestDiffer(mockClient, buf)
+
+	differ.Diff([]string{"--name-only", "--name-status"})
+
+	output := buf.String()
+	if !strings.Contains(output, "cannot be combined") {
+		t.Fatalf("expected conflict message, got %q", output)
+	}
+}
+
+func TestDiffer_Diff_StagedRejectsCommits(t *testing.T) {
+	buf := &bytes.Buffer{}
+	mockClient := &mockDiffClient{}
+	differ := newTestDiffer(mockClient, buf)
+
+	differ.Diff([]string{"staged", "abc123"})
+
+	output := buf.String()
+	if !strings.Contains(output, "does not accept commit arguments") {
+		t.Fatalf("expected staged error, got %q", output)
+	}
+}
+
+func TestDiffer_Diff_HeadModeAllowsPaths(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "file.txt")
+	if err := os.WriteFile(filePath, []byte("content"), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	buf := &bytes.Buffer{}
+	mockClient := &mockDiffClient{}
+	differ := newTestDiffer(mockClient, buf)
+
+	differ.Diff([]string{"head", filePath})
+
+	want := []string{"HEAD", "--", filePath}
+	if !slices.Equal(mockClient.diffArgs, want) {
+		t.Fatalf("expected git args %v, got %v", want, mockClient.diffArgs)
+	}
+}
+
+func TestDiffer_Diff_GitErrorSurfaced(t *testing.T) {
+	buf := &bytes.Buffer{}
+	mockClient := &mockDiffClient{err: errors.New("git diff failed")}
+	differ := newTestDiffer(mockClient, buf)
+
+	differ.Diff(nil)
+
+	if !strings.Contains(buf.String(), "git diff failed") {
+		t.Fatalf("expected git error in output, got %q", buf.String())
+	}
+}
+
+func TestParseDiffArgs_PathClassification(t *testing.T) {
+	fakeExists := func(target string) func(string) bool {
+		return func(path string) bool { return path == target }
+	}
+
+	opts, err := parseDiffArgs([]string{"--stat", "file.txt"}, fakeExists("file.txt"))
+	if err != nil {
+		t.Fatalf("parseDiffArgs returned error: %v", err)
+	}
+
+	if !opts.stat {
+		t.Fatalf("expected --stat to be set")
+	}
+	if want := []string{"file.txt"}; !slices.Equal(opts.paths, want) {
+		t.Fatalf("expected paths %v, got %v", want, opts.paths)
+	}
+	if len(opts.commits) != 0 {
+		t.Fatalf("expected no commits, got %v", opts.commits)
+	}
+}
+
+func TestParseDiffArgs_CommitDetection(t *testing.T) {
+	opts, err := parseDiffArgs([]string{"abc123"}, func(string) bool { return false })
+	if err != nil {
+		t.Fatalf("parseDiffArgs returned error: %v", err)
+	}
+
+	if want := []string{"abc123"}; !slices.Equal(opts.commits, want) {
+		t.Fatalf("expected commits %v, got %v", want, opts.commits)
+	}
+}
+
+func TestParseDiffArgs_TooManyCommits(t *testing.T) {
+	_, err := parseDiffArgs([]string{"a", "b", "c"}, func(string) bool { return false })
+	if err == nil || !strings.Contains(err.Error(), "too many commit arguments") {
+		t.Fatalf("expected too many commit arguments error, got %v", err)
+	}
+}
+
+func TestParseDiffArgs_NameStatusFlag(t *testing.T) {
+	opts, err := parseDiffArgs([]string{"--name-status"}, func(string) bool { return false })
+	if err != nil {
+		t.Fatalf("parseDiffArgs returned error: %v", err)
+	}
+
+	if !opts.nameStatus {
+		t.Fatalf("expected name-status flag to be set")
+	}
+	if opts.nameOnly {
+		t.Fatalf("did not expect name-only to be set")
+	}
+}
+
+func TestParseDiffArgs_RepeatedDoubleDash(t *testing.T) {
+	opts, err := parseDiffArgs([]string{"--", "--", "file"}, func(string) bool { return false })
+	if err != nil {
+		t.Fatalf("parseDiffArgs returned error: %v", err)
+	}
+
+	if want := []string{"--", "file"}; !slices.Equal(opts.paths, want) {
+		t.Fatalf("expected paths %v, got %v", want, opts.paths)
+	}
+}
+
+func TestDiffMode_String(t *testing.T) {
+	cases := []struct {
+		mode diffMode
+		want string
+	}{
+		{diffModeDefault, "default"},
+		{diffModeUnstaged, "unstaged"},
+		{diffModeStaged, "staged"},
+		{diffModeHead, "head"},
+	}
+
+	for _, tc := range cases {
+		if got := tc.mode.String(); got != tc.want {
+			t.Fatalf("mode %v: expected %q, got %q", tc.mode, tc.want, got)
+		}
+	}
+}
+
+func TestMapMode(t *testing.T) {
+	cases := map[string]diffMode{
+		"unstaged": diffModeUnstaged,
+		"staged":   diffModeStaged,
+		"head":     diffModeHead,
+		"":         diffModeDefault,
+		"other":    diffModeDefault,
+	}
+
+	for input, want := range cases {
+		if got := mapMode(input); got != want {
+			t.Fatalf("mapMode(%q) expected %v, got %v", input, want, got)
+		}
+	}
+}
+
+func TestModeArg(t *testing.T) {
+	if got := modeArg(&diffOptions{mode: diffModeStaged}); !slices.Equal(got, []string{"--staged"}) {
+		t.Fatalf("expected staged mode arg, got %v", got)
+	}
+
+	if got := modeArg(&diffOptions{mode: diffModeUnstaged}); len(got) != 0 {
+		t.Fatalf("expected no args for unstaged/default modes, got %v", got)
+	}
+}
+
+func TestSummaryArgs(t *testing.T) {
+	cases := []struct {
+		name string
+		opts diffOptions
+		want []string
+	}{
+		{name: "stat only", opts: diffOptions{stat: true}, want: []string{"--stat"}},
+		{name: "name only", opts: diffOptions{nameOnly: true}, want: []string{"--name-only"}},
+		{name: "name status", opts: diffOptions{nameStatus: true}, want: []string{"--name-status"}},
+		{name: "combo", opts: diffOptions{stat: true, nameOnly: true}, want: []string{"--stat", "--name-only"}},
+	}
+
+	for _, tc := range cases {
+		if got := summaryArgs(&tc.opts); !slices.Equal(got, tc.want) {
+			t.Fatalf("%s: expected %v, got %v", tc.name, tc.want, got)
+		}
+	}
+}
+
+func TestCommitArgs(t *testing.T) {
+	cases := []struct {
+		name string
+		opts diffOptions
+		want []string
+	}{
+		{name: "explicit commits", opts: diffOptions{commits: []string{"a", "b"}}, want: []string{"a", "b"}},
+		{name: "default fallback", opts: diffOptions{mode: diffModeDefault}, want: []string{"HEAD"}},
+		{name: "head fallback", opts: diffOptions{mode: diffModeHead}, want: []string{"HEAD"}},
+		{name: "staged no commits", opts: diffOptions{mode: diffModeStaged}, want: nil},
+	}
+
+	for _, tc := range cases {
+		if got := commitArgs(&tc.opts); !slices.Equal(got, tc.want) {
+			t.Fatalf("%s: expected %v, got %v", tc.name, tc.want, got)
+		}
+	}
+}
+
+func TestDefaultPathExists(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "exists.txt")
+	if err := os.WriteFile(file, []byte("content"), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "empty", path: "", want: false},
+		{name: "flag", path: "--name-only", want: false},
+		{name: "missing", path: filepath.Join(dir, "missing.txt"), want: false},
+		{name: "exists", path: file, want: true},
+	}
+
+	for _, tc := range cases {
+		if got := defaultPathExists(tc.path); got != tc.want {
+			t.Fatalf("%s: expected %v, got %v", tc.name, tc.want, got)
+		}
+	}
+}
+
+func TestDiffer_Diff_NameStatusFlag(t *testing.T) {
+	buf := &bytes.Buffer{}
+	mockClient := &mockDiffClient{}
+	differ := newTestDiffer(mockClient, buf)
+
+	differ.Diff([]string{"--name-status"})
+
+	if want := []string{"--name-status", "HEAD"}; !slices.Equal(mockClient.diffArgs, want) {
+		t.Fatalf("expected git args %v, got %v", want, mockClient.diffArgs)
 	}
 }

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -283,7 +283,11 @@ func (h *Helper) ShowDeleteMergedBranchHelp() {
 
 // ShowDiffHelp displays help for the git diff command.
 func (h *Helper) ShowDiffHelp() {
-	h.renderCommandFromRegistry("diff", []string{"ggc diff [options]"}, "Show changes between commits, commit and working tree, etc")
+	h.renderCommandFromRegistry(
+		"diff",
+		[]string{"ggc diff [staged|unstaged|head] [options] [<commit> [<commit>]] [--] [<path>...]"},
+		"Show changes between commits, the index, and the working tree",
+	)
 }
 
 // ShowFetchHelp shows help message for fetch command.

--- a/git/diff.go
+++ b/git/diff.go
@@ -1,31 +1,30 @@
 package git
 
+import "strings"
+
 // Diff gets git diff output.
 func (c *Client) Diff() (string, error) {
-	cmd := c.execCommand("git", "diff")
-	out, err := cmd.Output()
-	if err != nil {
-		return "", NewError("get diff", "git diff", err)
-	}
-	return string(out), nil
+	return c.DiffWith(nil)
 }
 
 // DiffStaged gets git diff --staged output.
 func (c *Client) DiffStaged() (string, error) {
-	cmd := c.execCommand("git", "diff", "--staged")
-	out, err := cmd.Output()
-	if err != nil {
-		return "", NewError("get diff staged", "git diff --staged", err)
-	}
-	return string(out), nil
+	return c.DiffWith([]string{"--staged"})
 }
 
 // DiffHead gets git diff HEAD output.
 func (c *Client) DiffHead() (string, error) {
-	cmd := c.execCommand("git", "diff", "HEAD")
+	return c.DiffWith([]string{"HEAD"})
+}
+
+// DiffWith executes git diff with custom arguments.
+func (c *Client) DiffWith(args []string) (string, error) {
+	cmdArgs := append([]string{"diff"}, args...)
+	cmd := c.execCommand("git", cmdArgs...)
 	out, err := cmd.Output()
 	if err != nil {
-		return "", NewError("get diff HEAD", "git diff HEAD", err)
+		command := strings.Join(append([]string{"git"}, cmdArgs...), " ")
+		return "", NewError("get diff", command, err)
 	}
 	return string(out), nil
 }

--- a/git/diff_test.go
+++ b/git/diff_test.go
@@ -123,3 +123,30 @@ func TestClient_DiffHead_Error(t *testing.T) {
 		t.Error("Expected DiffHead to return an error")
 	}
 }
+
+func TestClient_DiffWith(t *testing.T) {
+	var gotArgs []string
+	expectedOutput := "custom diff"
+	args := []string{"--staged", "HEAD~1", "--", "cmd/diff.go"}
+
+	client := &Client{
+		execCommand: func(name string, a ...string) *exec.Cmd {
+			gotArgs = append([]string{name}, a...)
+			return exec.Command("echo", "-n", expectedOutput)
+		},
+	}
+
+	result, err := client.DiffWith(args)
+	if err != nil {
+		t.Fatalf("DiffWith() error = %v", err)
+	}
+
+	wantArgs := append([]string{"git", "diff"}, args...)
+	if !slices.Equal(gotArgs, wantArgs) {
+		t.Errorf("DiffWith() gotArgs = %v, want %v", gotArgs, wantArgs)
+	}
+
+	if result != expectedOutput {
+		t.Errorf("DiffWith() result = %q, want %q", result, expectedOutput)
+	}
+}

--- a/git/interfaces.go
+++ b/git/interfaces.go
@@ -12,6 +12,7 @@ type DiffReader interface {
 	Diff() (string, error)
 	DiffStaged() (string, error)
 	DiffHead() (string, error)
+	DiffWith(args []string) (string, error)
 }
 
 // StatusReader provides read-only status output with color support.

--- a/internal/testutil/git_client.go
+++ b/internal/testutil/git_client.go
@@ -49,6 +49,9 @@ func (m *testMockGitClient) CommitAllowEmpty() error               { return nil 
 func (m *testMockGitClient) Diff() (string, error)       { return "", nil }
 func (m *testMockGitClient) DiffStaged() (string, error) { return "", nil }
 func (m *testMockGitClient) DiffHead() (string, error)   { return "", nil }
+func (m *testMockGitClient) DiffWith(_ []string) (string, error) {
+	return "", nil
+}
 
 // Branch Operations
 func (m *testMockGitClient) ListLocalBranches() ([]string, error) { return []string{"main"}, nil }


### PR DESCRIPTION
## Description of Changes

- replaced the old ggc diff dispatcher with a stateful parser that understands modes, summary flags, commit ranges, and path filters, then funnels the assembled argv through DiffWith.
- added DiffWith to the git client surface and refactored the existing helpers (Diff, DiffStaged, DiffHead) to delegate to it for consistency.
- expanded the diff test suite with parser state coverage, helper-unit checks, and execution cases.

## Related Issue

closes #110

## Checklist

- [x] I have read the CONTRIBUTING.md (https://github.com/bmf-san/ggc/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests
- [x] I have updated the documentation (if required)
- [x] Code is formatted with make fmt
- [x] Code passes linter checks via make lint
- [x] All tests are passing
- [x] If commands were added/modified: I have run make docs to update README.md