### PR TITLE
fix: Continuous workflow interception of c key

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -621,7 +621,6 @@ func (h *KeyHandler) handleWorkflowKeys(r rune) bool {
 			h.clearWorkflow()
 			return true
 		}
-		return true
 	}
 
 	return false

--- a/cmd/interactive_test.go
+++ b/cmd/interactive_test.go
@@ -1798,12 +1798,12 @@ func TestKeyHandler_HandleWorkflowKeys(t *testing.T) {
 			expectedAction: "clear_workflow",
 		},
 		{
-			name:           "c key in search view returns true but no action",
+			name:           "c key in search view returns false because it is unhandled",
 			key:            'c',
 			showWorkflow:   false,
 			hasInput:       true,
 			selectedCmd:    nil,
-			expectedResult: true,
+			expectedResult: false,
 			expectedAction: "no_action",
 		},
 		{


### PR DESCRIPTION
## Description of Changes
the workflow handler currently constantly intercepts the c key. this fixes that behaviour and the associated test.

## Related Issue
closes #219 

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/bmf-san/ggc/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests
- [x] Code is formatted with `make fmt`
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing
