### PR TITLE
feat(cmd): add arrow keys/cursor rebindability

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -824,6 +824,57 @@ func isWordMotionParam(params string) bool {
 // processCSIFinalByte processes the final byte of a CSI sequence
 func (h *KeyHandler) processCSIFinalByte(final byte, params string) {
 	isWord := isWordMotionParam(params)
+
+	// Build the full escape sequence for keybinding matching
+	seq := h.buildCSISequence(final, params)
+	keyStroke := NewRawKeyStroke(seq)
+	km := h.GetCurrentKeyMap()
+
+	// Try keybinding-based handling first
+	if h.tryArrowKeybinding(km, keyStroke) {
+		return
+	}
+
+	// Fallback to default cursor movement and word navigation
+	h.handleDefaultArrowMovement(final, isWord)
+}
+
+// buildCSISequence builds a CSI escape sequence
+func (h *KeyHandler) buildCSISequence(final byte, params string) []byte {
+	if params == "" {
+		return []byte{27, '[', final}
+	}
+	seq := append([]byte{27, '['}, []byte(params)...)
+	return append(seq, final)
+}
+
+// tryArrowKeybinding attempts to handle arrow keys via keybindings
+func (h *KeyHandler) tryArrowKeybinding(km *KeyBindingMap, keyStroke KeyStroke) bool {
+	if km.MatchesKeyStroke("move_up", keyStroke) {
+		if !h.ui.state.showWorkflow {
+			h.ui.state.MoveUp()
+		}
+		return true
+	}
+	if km.MatchesKeyStroke("move_down", keyStroke) {
+		if !h.ui.state.showWorkflow {
+			h.ui.state.MoveDown()
+		}
+		return true
+	}
+	if km.MatchesKeyStroke("move_left", keyStroke) {
+		h.ui.state.MoveLeft()
+		return true
+	}
+	if km.MatchesKeyStroke("move_right", keyStroke) {
+		h.ui.state.MoveRight()
+		return true
+	}
+	return false
+}
+
+// handleDefaultArrowMovement handles default arrow key behavior
+func (h *KeyHandler) handleDefaultArrowMovement(final byte, isWord bool) {
 	switch final {
 	case 'C': // Right
 		if isWord {
@@ -842,28 +893,51 @@ func (h *KeyHandler) processCSIFinalByte(final byte, params string) {
 
 // handleApplicationCursorMode handles application cursor mode sequences
 func (h *KeyHandler) handleApplicationCursorMode(reader *bufio.Reader) {
-	var nb byte
-	var err error
-
-	if reader != nil {
-		// Use provided buffered reader (non-raw mode)
-		nb, err = reader.ReadByte()
-	} else {
-		// Raw mode: read directly from stdin
-		var buf [1]byte
-		_, err = h.ui.stdin.Read(buf[:])
-		nb = buf[0]
-	}
-
+	nb, err := h.readNextByte(reader)
 	if err != nil {
 		return
 	}
+
+	// Build the full escape sequence: ESC O <final>
+	seq := []byte{27, 'O', nb}
+	keyStroke := NewRawKeyStroke(seq)
+	km := h.GetCurrentKeyMap()
+
+	// Try keybinding-based handling first
+	if h.tryArrowKeybinding(km, keyStroke) {
+		return
+	}
+
+	// Fallback to default arrow key behavior
+	h.handleDefaultAppCursorMovement(nb)
+}
+
+// handleDefaultAppCursorMovement handles default application cursor mode arrow keys
+func (h *KeyHandler) handleDefaultAppCursorMovement(nb byte) {
 	switch nb {
+	case 'A':
+		if !h.ui.state.showWorkflow {
+			h.ui.state.MoveUp()
+		}
+	case 'B':
+		if !h.ui.state.showWorkflow {
+			h.ui.state.MoveDown()
+		}
 	case 'C':
 		h.ui.state.MoveRight()
 	case 'D':
 		h.ui.state.MoveLeft()
 	}
+}
+
+// readNextByte reads the next byte from either a buffered reader or stdin
+func (h *KeyHandler) readNextByte(reader *bufio.Reader) (byte, error) {
+	if reader != nil {
+		return reader.ReadByte()
+	}
+	var buf [1]byte
+	_, err := h.ui.stdin.Read(buf[:])
+	return buf[0], err
 }
 
 // handleCtrlC handles Ctrl+C key press

--- a/cmd/keybindings_parse_test.go
+++ b/cmd/keybindings_parse_test.go
@@ -144,3 +144,78 @@ func TestParseKeyStrokeErrorMessages(t *testing.T) {
 		t.Fatalf("unexpected error message: %v", err)
 	}
 }
+
+func TestParseKeyStrokeArrowKeys(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		wantKind KeyStrokeKind
+		wantSeq  []byte
+	}{
+		{name: "up", input: "up", wantKind: KeyStrokeRawSeq, wantSeq: []byte{27, '[', 'A'}},
+		{name: "down", input: "down", wantKind: KeyStrokeRawSeq, wantSeq: []byte{27, '[', 'B'}},
+		{name: "left", input: "left", wantKind: KeyStrokeRawSeq, wantSeq: []byte{27, '[', 'D'}},
+		{name: "right", input: "right", wantKind: KeyStrokeRawSeq, wantSeq: []byte{27, '[', 'C'}},
+		{name: "arrow-up", input: "arrow-up", wantKind: KeyStrokeRawSeq, wantSeq: []byte{27, '[', 'A'}},
+		{name: "arrowup", input: "arrowup", wantKind: KeyStrokeRawSeq, wantSeq: []byte{27, '[', 'A'}},
+		{name: "UP uppercase", input: "UP", wantKind: KeyStrokeRawSeq, wantSeq: []byte{27, '[', 'A'}},
+		{name: "Down mixed case", input: "Down", wantKind: KeyStrokeRawSeq, wantSeq: []byte{27, '[', 'B'}},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			ks, err := ParseKeyStroke(tt.input)
+			if err != nil {
+				t.Fatalf("ParseKeyStroke(%q) returned error: %v", tt.input, err)
+			}
+			if ks.Kind != tt.wantKind {
+				t.Fatalf("ParseKeyStroke(%q) kind = %v, want %v", tt.input, ks.Kind, tt.wantKind)
+			}
+			if len(ks.Seq) != len(tt.wantSeq) {
+				t.Fatalf("ParseKeyStroke(%q) seq length = %d, want %d", tt.input, len(ks.Seq), len(tt.wantSeq))
+			}
+			for i, b := range tt.wantSeq {
+				if ks.Seq[i] != b {
+					t.Fatalf("ParseKeyStroke(%q) seq[%d] = %d, want %d", tt.input, i, ks.Seq[i], b)
+				}
+			}
+		})
+	}
+}
+
+func TestArrowKeyStrokeConstructors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		fn       func() KeyStroke
+		wantSeq  []byte
+		wantKind KeyStrokeKind
+	}{
+		{name: "NewUpArrowKeyStroke", fn: NewUpArrowKeyStroke, wantSeq: []byte{27, '[', 'A'}, wantKind: KeyStrokeRawSeq},
+		{name: "NewDownArrowKeyStroke", fn: NewDownArrowKeyStroke, wantSeq: []byte{27, '[', 'B'}, wantKind: KeyStrokeRawSeq},
+		{name: "NewLeftArrowKeyStroke", fn: NewLeftArrowKeyStroke, wantSeq: []byte{27, '[', 'D'}, wantKind: KeyStrokeRawSeq},
+		{name: "NewRightArrowKeyStroke", fn: NewRightArrowKeyStroke, wantSeq: []byte{27, '[', 'C'}, wantKind: KeyStrokeRawSeq},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			ks := tt.fn()
+			if ks.Kind != tt.wantKind {
+				t.Fatalf("%s() kind = %v, want %v", tt.name, ks.Kind, tt.wantKind)
+			}
+			if len(ks.Seq) != len(tt.wantSeq) {
+				t.Fatalf("%s() seq length = %d, want %d", tt.name, len(ks.Seq), len(tt.wantSeq))
+			}
+			for i, b := range tt.wantSeq {
+				if ks.Seq[i] != b {
+					t.Fatalf("%s() seq[%d] = %d, want %d", tt.name, i, ks.Seq[i], b)
+				}
+			}
+		})
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -102,6 +102,8 @@ type Config struct {
 			MoveToEnd          string `yaml:"move_to_end"`
 			MoveUp             string `yaml:"move_up"`
 			MoveDown           string `yaml:"move_down"`
+			MoveLeft           string `yaml:"move_left"`
+			MoveRight          string `yaml:"move_right"`
 			AddToWorkflow      string `yaml:"add_to_workflow"`
 			ToggleWorkflowView string `yaml:"toggle_workflow_view"`
 			ClearWorkflow      string `yaml:"clear_workflow"`
@@ -1000,6 +1002,8 @@ func (c *Config) validateKeybindings() error {
 		"move_to_end":          c.Interactive.Keybindings.MoveToEnd,
 		"move_up":              c.Interactive.Keybindings.MoveUp,
 		"move_down":            c.Interactive.Keybindings.MoveDown,
+		"move_left":            c.Interactive.Keybindings.MoveLeft,
+		"move_right":           c.Interactive.Keybindings.MoveRight,
 		"add_to_workflow":      c.Interactive.Keybindings.AddToWorkflow,
 		"toggle_workflow_view": c.Interactive.Keybindings.ToggleWorkflowView,
 		"clear_workflow":       c.Interactive.Keybindings.ClearWorkflow,


### PR DESCRIPTION
## Description of Changes
adds support for rebinding arrow keys in the interactive mode. Users can now configure custom keybindings for:
- up/Down arrows for list navigation (`move_up`, `move_down`)
- left/Right arrows for cursor movement (`move_left`, `move_right`)

the implementation adds arrow key constructors (`NewUpArrowKeyStroke()`, `NewDownArrowKeyStroke()`, `NewLeftArrowKeyStroke()`, `NewRightArrowKeyStroke()`), updates the parsing logic to handle arrow key strings (e.g., "up", "down", "left", "right"), and refactors the CSI sequence handling to try keybinding-based handling before falling back to default behavior.

## Related Issue
closes #218

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/bmf-san/ggc/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests
- [x] I have updated the documentation (if required)
- [x] Code is formatted with `make fmt`
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing

## Additional Context
arrow keys now work with both CSI mode (ESC [ X) and application cursor mode (ESC O X). The default behavior is preserved (arrow keys work as before), but users can now override them in their config files using the new `move_left` and `move_right` actions, or add arrow keys to existing `move_up`/`move_down` actions.

Example configuration:
```yaml
interactive:
  keybindings:
    move_up: "up"           # or keep ctrl+p and add arrow
    move_down: "down"       # or keep ctrl+n and add arrow
    move_left: "left"       # enable left arrow for cursor movement
    move_right: "right"     # enable right arrow for cursor movement
```
