### PR TITLE
bug(cmd): Race condition in signal handler

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -248,15 +248,14 @@ func (c *Cmd) DebugKeys(args []string) {
 
 // Interactive starts the interactive UI mode.
 func (c *Cmd) Interactive() {
-	// Reset existing signal handlers
-	signal.Reset(os.Interrupt, syscall.SIGTERM)
-
-	// Set up global Ctrl+C handling
+	// Set up global Ctrl+C handling without introducing a reset window
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigChan)
 	go func() {
 		<-sigChan
 		fmt.Println("\nExiting...")
+		signal.Stop(sigChan)
 		os.Exit(0)
 	}()
 


### PR DESCRIPTION
## Description of Changes
ensure the interactive installs SIGINT/SIGTERM handlers atomically by dropping the interim `signal.Reset()` call, deferring `signal.Stop`, and stopping notifications on exit so signals can't be lost.

## Related Issue
closes #225

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/bmf-san/ggc/blob/main/CONTRIBUTING.md)
- [x] Code is formatted with `make fmt`
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing