### PR TITLE
bug(cmd): Introduce input validation for high risk inputs and error clarification

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -482,6 +482,12 @@ func TestGet(t *testing.T) {
 	if value != "main" {
 		t.Errorf("Expected 'main', got %s", value)
 	}
+
+	if _, err := cm.Get("invalid..path"); err == nil {
+		t.Error("Expected error for config path with empty segment, got nil")
+	} else if !strings.Contains(err.Error(), "segment") {
+		t.Errorf("unexpected error for invalid path: %v", err)
+	}
 }
 
 // TestSet tests the Set method
@@ -510,6 +516,14 @@ func TestSet(t *testing.T) {
 	err = cm.Set("invalid.nonexistent.path", "value")
 	if err == nil {
 		t.Error("Expected error when setting invalid path, but got nil")
+	}
+
+	// Test validation: empty path segment
+	err = cm.Set("interactive..profile", "default")
+	if err == nil {
+		t.Error("Expected error when setting path with empty segment, but got nil")
+	} else if !strings.Contains(err.Error(), "segment") {
+		t.Errorf("unexpected error for double dot path: %v", err)
 	}
 
 	// Test error case: invalid value type


### PR DESCRIPTION
## Description of Changes
introduces upfront validation for high-risk inputs so users get actionable errors instead of git panics: commit and amend commands now reject empty/invalid messages, branch mutations normalise and validate branch names with `git check-ref-format`, and config key lookups enforce well-formed dot paths before traversal. updated command handlers and unit tests cover the new validation paths.

## Related Issue
closes #224

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/bmf-san/ggc/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests
- [x] Code is formatted with `make fmt`
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing
