### PR TITLE
arch: Refactor Interactive And Keybindings Architecture (Wave 1)

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -12,15 +12,16 @@ import (
 
 	commandregistry "github.com/bmf-san/ggc/v7/cmd/command"
 	"github.com/bmf-san/ggc/v7/git"
+	"github.com/bmf-san/ggc/v7/internal/interactive"
 )
 
 // Interactive mode special return values
 // These constants are used to signal special states when returning from interactive mode
 const (
 	// InteractiveQuitCommand signals that the user wants to quit the interactive mode
-	InteractiveQuitCommand = "quit"
+	InteractiveQuitCommand = interactive.InteractiveQuitCommand
 	// InteractiveWorkflowCommand signals that a workflow has been executed and the interactive mode should restart
-	InteractiveWorkflowCommand = "workflow-executed"
+	InteractiveWorkflowCommand = interactive.InteractiveWorkflowCommand
 )
 
 // Executer is an interface for executing commands.
@@ -261,7 +262,7 @@ func (c *Cmd) Interactive() {
 	}()
 
 	// Create persistent UI instance to preserve state
-	ui := NewUI(c.gitClient, c)
+	ui := interactive.NewUI(c.gitClient, c)
 
 	for {
 		args := ui.Run()

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/bmf-san/ggc/v7/git"
+	"github.com/bmf-san/ggc/v7/internal/interactive"
 	"github.com/bmf-san/ggc/v7/internal/prompt"
 )
 
@@ -822,29 +823,21 @@ func TestCmd_InteractiveWorkflowIntegration(t *testing.T) {
 	mockClient := &mockGitClient{}
 	cmd := NewCmd(mockClient)
 
-	// Test that NewUI creates workflow-enabled UI
-	ui := NewUI(mockClient, cmd)
-
-	if ui.workflow == nil {
-		t.Error("Expected UI to have workflow initialized")
+	ui := interactive.NewUI(mockClient, cmd)
+	if ui == nil {
+		t.Fatal("interactive.NewUI returned nil")
 	}
 
-	if ui.workflowEx == nil {
-		t.Error("Expected UI to have workflow executor initialized")
+	// Test workflow operations using exported methods
+	if got := ui.AddToWorkflow("add", []string{"."}, "add ."); got != 1 {
+		t.Errorf("AddToWorkflow first ID = %d, want 1", got)
 	}
-
-	// Test workflow operations
-	id := ui.AddToWorkflow("add", []string{"."}, "add .")
-	if id != 1 {
-		t.Errorf("Expected workflow ID 1, got %d", id)
-	}
-
-	if ui.workflow.IsEmpty() {
-		t.Error("Expected workflow to have steps after adding")
+	if got := ui.AddToWorkflow("commit", []string{"-m", "msg"}, "commit"); got != 2 {
+		t.Errorf("AddToWorkflow second ID = %d, want 2", got)
 	}
 
 	ui.ClearWorkflow()
-	if !ui.workflow.IsEmpty() {
-		t.Error("Expected workflow to be empty after clearing")
+	if got := ui.AddToWorkflow("status", nil, "status"); got != 1 {
+		t.Errorf("AddToWorkflow after ClearWorkflow ID = %d, want 1", got)
 	}
 }

--- a/cmd/keybindings_bridge.go
+++ b/cmd/keybindings_bridge.go
@@ -1,0 +1,9 @@
+package cmd
+
+import "github.com/bmf-san/ggc/v7/internal/keybindings"
+
+type DebugKeysCommand = keybindings.DebugKeysCommand
+
+var (
+	NewDebugKeysCommand = keybindings.NewDebugKeysCommand
+)

--- a/cmd/keybindings_bridge.go
+++ b/cmd/keybindings_bridge.go
@@ -2,8 +2,10 @@ package cmd
 
 import "github.com/bmf-san/ggc/v7/internal/keybindings"
 
+// DebugKeysCommand exposes the keybindings debug command to the cmd package.
 type DebugKeysCommand = keybindings.DebugKeysCommand
 
 var (
+	// NewDebugKeysCommand builds a command that emits debug information about keybindings.
 	NewDebugKeysCommand = keybindings.NewDebugKeysCommand
 )

--- a/internal/interactive/constants.go
+++ b/internal/interactive/constants.go
@@ -1,0 +1,6 @@
+package interactive
+
+const (
+	InteractiveQuitCommand     = "quit"
+	InteractiveWorkflowCommand = "workflow-executed"
+)

--- a/internal/interactive/constants.go
+++ b/internal/interactive/constants.go
@@ -1,6 +1,9 @@
+// Package interactive houses interactive UI types and helpers shared across the application.
 package interactive
 
 const (
-	InteractiveQuitCommand     = "quit"
+	// InteractiveQuitCommand instructs the interactive UI to exit.
+	InteractiveQuitCommand = "quit"
+	// InteractiveWorkflowCommand signals that an interactive workflow has been executed.
 	InteractiveWorkflowCommand = "workflow-executed"
 )

--- a/internal/interactive/controller.go
+++ b/internal/interactive/controller.go
@@ -1784,9 +1784,9 @@ func (r *Renderer) updateSize() {
 
 var commands = buildInteractiveCommands()
 
-// InteractiveUI provides an incremental search interactive UI with custom git client.
+// Run provides an incremental search interactive UI with custom git client.
 // Returns the selected command as []string (nil if nothing selected)
-func InteractiveUI(gitClient git.StatusInfoReader) []string {
+func Run(gitClient git.StatusInfoReader) []string {
 	ui := NewUI(gitClient)
 	return ui.Run()
 }

--- a/internal/interactive/controller.go
+++ b/internal/interactive/controller.go
@@ -1,5 +1,4 @@
-// Package cmd provides command implementations for the ggc CLI tool.
-package cmd
+package interactive
 
 import (
 	"bufio"
@@ -1722,6 +1721,14 @@ func (ui *UI) ToggleWorkflowView() {
 // AddToWorkflow adds a command to the workflow
 func (ui *UI) AddToWorkflow(command string, args []string, description string) int {
 	return ui.workflow.AddStep(command, args, description)
+}
+
+// ApplyContextualKeybindings updates the active keybinding map, satisfying keybindings.ContextualMapApplier.
+func (ui *UI) ApplyContextualKeybindings(contextual *ContextualKeyBindingMap) {
+	if ui == nil || ui.handler == nil || contextual == nil {
+		return
+	}
+	ui.handler.contextualMap = contextual
 }
 
 func (ui *UI) resetToSearchMode() bool {

--- a/internal/interactive/interactive_keybinds_test.go
+++ b/internal/interactive/interactive_keybinds_test.go
@@ -1,4 +1,4 @@
-package cmd
+package interactive
 
 import "testing"
 

--- a/internal/interactive/interactive_terminal_test.go
+++ b/internal/interactive/interactive_terminal_test.go
@@ -1,4 +1,4 @@
-package cmd
+package interactive
 
 import (
 	"bytes"

--- a/internal/interactive/interactive_test.go
+++ b/internal/interactive/interactive_test.go
@@ -1,4 +1,4 @@
-package cmd
+package interactive
 
 import (
 	"bufio"
@@ -1820,7 +1820,7 @@ func TestKeyHandler_HandleWorkflowKeys(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Setup
-			gitClient := &mockGitClient{}
+			gitClient := testutil.NewMockGitClient()
 			ui := NewUI(gitClient)
 			ui.state.showWorkflow = tt.showWorkflow
 			if tt.hasInput {
@@ -1886,7 +1886,7 @@ func TestKeyHandler_AddCommandToWorkflow(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Setup
-			gitClient := &mockGitClient{}
+			gitClient := testutil.NewMockGitClient()
 			ui := NewUI(gitClient)
 
 			// Redirect output to avoid test output pollution
@@ -1913,7 +1913,7 @@ func TestKeyHandler_AddCommandToWorkflow(t *testing.T) {
 // TestKeyHandler_ClearWorkflow tests clearing workflow
 func TestKeyHandler_ClearWorkflow(t *testing.T) {
 	// Setup
-	gitClient := &mockGitClient{}
+	gitClient := testutil.NewMockGitClient()
 	ui := NewUI(gitClient)
 
 	// Redirect output to avoid test output pollution
@@ -1939,7 +1939,7 @@ func TestKeyHandler_ClearWorkflow(t *testing.T) {
 // TestUI_ToggleWorkflowView tests workflow view toggling
 func TestUI_ToggleWorkflowView(t *testing.T) {
 	// Setup
-	gitClient := &mockGitClient{}
+	gitClient := testutil.NewMockGitClient()
 	ui := NewUI(gitClient)
 
 	// Initial state should be false
@@ -1963,7 +1963,7 @@ func TestUI_ToggleWorkflowView(t *testing.T) {
 // TestUI_WorkflowOperations tests workflow operations
 func TestUI_WorkflowOperations(t *testing.T) {
 	// Setup
-	gitClient := &mockGitClient{}
+	gitClient := testutil.NewMockGitClient()
 	ui := NewUI(gitClient)
 
 	// Test AddToWorkflow
@@ -2015,7 +2015,7 @@ func TestKeyHandler_ExecuteWorkflow(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Setup
-			gitClient := &mockGitClient{}
+			gitClient := testutil.NewMockGitClient()
 			ui := NewUI(gitClient)
 
 			// Redirect output to avoid test output pollution

--- a/internal/interactive/interactive_unicode_test.go
+++ b/internal/interactive/interactive_unicode_test.go
@@ -1,4 +1,4 @@
-package cmd
+package interactive
 
 import (
 	"strings"

--- a/internal/interactive/keybindings_bridge.go
+++ b/internal/interactive/keybindings_bridge.go
@@ -3,39 +3,67 @@ package interactive
 import kb "github.com/bmf-san/ggc/v7/internal/keybindings"
 
 type (
-	Profile                 = kb.Profile
-	Context                 = kb.Context
-	KeyStroke               = kb.KeyStroke
-	KeyBindingMap           = kb.KeyBindingMap
+	// Profile exposes the kb.Profile type to interactive consumers.
+	Profile = kb.Profile
+	// Context exposes the kb.Context type to interactive consumers.
+	Context = kb.Context
+	// KeyStroke exposes the kb.KeyStroke type to interactive consumers.
+	KeyStroke = kb.KeyStroke
+	// KeyBindingMap exposes the kb.KeyBindingMap type to interactive consumers.
+	KeyBindingMap = kb.KeyBindingMap
+	// ContextualKeyBindingMap exposes the kb.ContextualKeyBindingMap type to interactive consumers.
 	ContextualKeyBindingMap = kb.ContextualKeyBindingMap
-	KeyBindingResolver      = kb.KeyBindingResolver
-	ContextManager          = kb.ContextManager
+	// KeyBindingResolver exposes the kb.KeyBindingResolver type to interactive consumers.
+	KeyBindingResolver = kb.KeyBindingResolver
+	// ContextManager exposes the kb.ContextManager type to interactive consumers.
+	ContextManager = kb.ContextManager
 )
 
 var (
-	NewKeyBindingResolver      = kb.NewKeyBindingResolver
-	RegisterBuiltinProfiles    = kb.RegisterBuiltinProfiles
-	DefaultKeyBindingMap       = kb.DefaultKeyBindingMap
-	DetectPlatform             = kb.DetectPlatform
-	DetectTerminal             = kb.DetectTerminal
-	NewContextManager          = kb.NewContextManager
-	NewCtrlKeyStroke           = kb.NewCtrlKeyStroke
-	NewCharKeyStroke           = kb.NewCharKeyStroke
-	NewRawKeyStroke            = kb.NewRawKeyStroke
-	NewEscapeKeyStroke         = kb.NewEscapeKeyStroke
-	NewAltKeyStroke            = kb.NewAltKeyStroke
+	// NewKeyBindingResolver constructs a key binding resolver using the keybindings package implementation.
+	NewKeyBindingResolver = kb.NewKeyBindingResolver
+	// RegisterBuiltinProfiles registers builtin profiles in the underlying keybindings package.
+	RegisterBuiltinProfiles = kb.RegisterBuiltinProfiles
+	// DefaultKeyBindingMap provides the default key binding map from the keybindings package.
+	DefaultKeyBindingMap = kb.DefaultKeyBindingMap
+	// DetectPlatform returns the inferred platform from the keybindings package.
+	DetectPlatform = kb.DetectPlatform
+	// DetectTerminal returns the inferred terminal from the keybindings package.
+	DetectTerminal = kb.DetectTerminal
+	// NewContextManager constructs a context manager using the keybindings package.
+	NewContextManager = kb.NewContextManager
+	// NewCtrlKeyStroke creates a control key stroke using the keybindings package implementation.
+	NewCtrlKeyStroke = kb.NewCtrlKeyStroke
+	// NewCharKeyStroke creates a character key stroke using the keybindings package implementation.
+	NewCharKeyStroke = kb.NewCharKeyStroke
+	// NewRawKeyStroke creates a raw key stroke using the keybindings package implementation.
+	NewRawKeyStroke = kb.NewRawKeyStroke
+	// NewEscapeKeyStroke creates an escape key stroke using the keybindings package implementation.
+	NewEscapeKeyStroke = kb.NewEscapeKeyStroke
+	// NewAltKeyStroke creates an alt key stroke using the keybindings package implementation.
+	NewAltKeyStroke = kb.NewAltKeyStroke
+	// NewContextualKeyBindingMap builds a contextual key binding map using the keybindings package implementation.
 	NewContextualKeyBindingMap = kb.NewContextualKeyBindingMap
+	// FormatKeyStrokesForDisplay formats key strokes for human-readable display.
 	FormatKeyStrokesForDisplay = kb.FormatKeyStrokesForDisplay
 )
 
 const (
-	ProfileDefault  = kb.ProfileDefault
-	ProfileEmacs    = kb.ProfileEmacs
-	ProfileVi       = kb.ProfileVi
+	// ProfileDefault exposes the default key binding profile identifier.
+	ProfileDefault = kb.ProfileDefault
+	// ProfileEmacs exposes the emacs key binding profile identifier.
+	ProfileEmacs = kb.ProfileEmacs
+	// ProfileVi exposes the vi key binding profile identifier.
+	ProfileVi = kb.ProfileVi
+	// ProfileReadline exposes the readline key binding profile identifier.
 	ProfileReadline = kb.ProfileReadline
 
-	ContextGlobal  = kb.ContextGlobal
-	ContextInput   = kb.ContextInput
+	// ContextGlobal exposes the global key binding context identifier.
+	ContextGlobal = kb.ContextGlobal
+	// ContextInput exposes the input key binding context identifier.
+	ContextInput = kb.ContextInput
+	// ContextResults exposes the results key binding context identifier.
 	ContextResults = kb.ContextResults
-	ContextSearch  = kb.ContextSearch
+	// ContextSearch exposes the search key binding context identifier.
+	ContextSearch = kb.ContextSearch
 )

--- a/internal/interactive/keybindings_bridge.go
+++ b/internal/interactive/keybindings_bridge.go
@@ -1,0 +1,41 @@
+package interactive
+
+import kb "github.com/bmf-san/ggc/v7/internal/keybindings"
+
+type (
+	Profile                 = kb.Profile
+	Context                 = kb.Context
+	KeyStroke               = kb.KeyStroke
+	KeyBindingMap           = kb.KeyBindingMap
+	ContextualKeyBindingMap = kb.ContextualKeyBindingMap
+	KeyBindingResolver      = kb.KeyBindingResolver
+	ContextManager          = kb.ContextManager
+)
+
+var (
+	NewKeyBindingResolver      = kb.NewKeyBindingResolver
+	RegisterBuiltinProfiles    = kb.RegisterBuiltinProfiles
+	DefaultKeyBindingMap       = kb.DefaultKeyBindingMap
+	DetectPlatform             = kb.DetectPlatform
+	DetectTerminal             = kb.DetectTerminal
+	NewContextManager          = kb.NewContextManager
+	NewCtrlKeyStroke           = kb.NewCtrlKeyStroke
+	NewCharKeyStroke           = kb.NewCharKeyStroke
+	NewRawKeyStroke            = kb.NewRawKeyStroke
+	NewEscapeKeyStroke         = kb.NewEscapeKeyStroke
+	NewAltKeyStroke            = kb.NewAltKeyStroke
+	NewContextualKeyBindingMap = kb.NewContextualKeyBindingMap
+	FormatKeyStrokesForDisplay = kb.FormatKeyStrokesForDisplay
+)
+
+const (
+	ProfileDefault  = kb.ProfileDefault
+	ProfileEmacs    = kb.ProfileEmacs
+	ProfileVi       = kb.ProfileVi
+	ProfileReadline = kb.ProfileReadline
+
+	ContextGlobal  = kb.ContextGlobal
+	ContextInput   = kb.ContextInput
+	ContextResults = kb.ContextResults
+	ContextSearch  = kb.ContextSearch
+)

--- a/internal/interactive/new_ui_config_test.go
+++ b/internal/interactive/new_ui_config_test.go
@@ -41,7 +41,7 @@ func TestNewUIHonorsConfigProfileAndOverrides(t *testing.T) {
 		t.Fatal("expected results context map")
 	}
 
-	if len(resultsMap.MoveDown) == 0 || resultsMap.MoveDown[0].Rune != 'j' {
+	if len(resultsMap.MoveDown) == 0 || resultsMap.MoveDown[0].Rune != 'j' || !resultsMap.MoveDown[0].Ctrl {
 		t.Fatalf("config override not applied: %#v", resultsMap.MoveDown)
 	}
 }

--- a/internal/interactive/new_ui_config_test.go
+++ b/internal/interactive/new_ui_config_test.go
@@ -1,4 +1,4 @@
-package cmd
+package interactive
 
 import (
 	"os"
@@ -14,9 +14,10 @@ func TestNewUIHonorsConfigProfileAndOverrides(t *testing.T) {
 
 	configContent := `interactive:
   profile: emacs
-  darwin:
-    keybindings:
-      move_down: "Ctrl+J"
+  contexts:
+    results:
+      keybindings:
+        move_down: "Ctrl+J"
 `
 	configPath := filepath.Join(tempHome, ".ggcconfig.yaml")
 	if err := os.WriteFile(configPath, []byte(configContent), 0o644); err != nil {
@@ -30,15 +31,17 @@ func TestNewUIHonorsConfigProfileAndOverrides(t *testing.T) {
 		t.Fatalf("profile = %v, want %v", ui.profile, ProfileEmacs)
 	}
 
-	ui.contextMgr.resolver.platform = "darwin"
-	ui.contextMgr.resolver.ClearCache()
-
-	keyMap, err := ui.contextMgr.resolver.Resolve(ProfileEmacs, ContextResults)
-	if err != nil {
-		t.Fatalf("Resolve returned error: %v", err)
+	contextual := ui.handler.contextualMap
+	if contextual == nil {
+		t.Fatal("expected contextual keybinding map to be initialized")
 	}
 
-	if len(keyMap.MoveDown) == 0 || keyMap.MoveDown[0].Rune != 'j' {
-		t.Fatalf("darwin override not applied: %#v", keyMap.MoveDown)
+	resultsMap, exists := contextual.GetContext(ContextResults)
+	if !exists || resultsMap == nil {
+		t.Fatal("expected results context map")
+	}
+
+	if len(resultsMap.MoveDown) == 0 || resultsMap.MoveDown[0].Rune != 'j' {
+		t.Fatalf("config override not applied: %#v", resultsMap.MoveDown)
 	}
 }

--- a/internal/interactive/ui_state_test.go
+++ b/internal/interactive/ui_state_test.go
@@ -1,4 +1,4 @@
-package cmd
+package interactive
 
 import (
 	"strings"

--- a/internal/interactive/workflow.go
+++ b/internal/interactive/workflow.go
@@ -1,5 +1,4 @@
-// Package cmd provides workflow functionality for sequential command execution.
-package cmd
+package interactive
 
 import (
 	"bufio"

--- a/internal/interactive/workflow_test.go
+++ b/internal/interactive/workflow_test.go
@@ -1,4 +1,4 @@
-package cmd
+package interactive
 
 import (
 	"bytes"

--- a/internal/keybindings/context_manager_test.go
+++ b/internal/keybindings/context_manager_test.go
@@ -1,4 +1,4 @@
-package cmd
+package keybindings
 
 import (
 	"testing"

--- a/internal/keybindings/debug_keys_command_test.go
+++ b/internal/keybindings/debug_keys_command_test.go
@@ -1,4 +1,4 @@
-package cmd
+package keybindings
 
 import (
 	"os"

--- a/internal/keybindings/display_test.go
+++ b/internal/keybindings/display_test.go
@@ -1,4 +1,4 @@
-package cmd
+package keybindings
 
 import "testing"
 

--- a/internal/keybindings/features_test.go
+++ b/internal/keybindings/features_test.go
@@ -1,4 +1,4 @@
-package cmd
+package keybindings
 
 import (
 	"os"

--- a/internal/keybindings/keybindings_test.go
+++ b/internal/keybindings/keybindings_test.go
@@ -1,4 +1,4 @@
-package cmd
+package keybindings
 
 import "testing"
 

--- a/internal/keybindings/layers_test.go
+++ b/internal/keybindings/layers_test.go
@@ -1,4 +1,4 @@
-package cmd
+package keybindings
 
 import (
 	"strings"

--- a/internal/keybindings/parse_test.go
+++ b/internal/keybindings/parse_test.go
@@ -1,4 +1,4 @@
-package cmd
+package keybindings
 
 import (
 	"strings"

--- a/internal/keybindings/parser.go
+++ b/internal/keybindings/parser.go
@@ -1,4 +1,4 @@
-package cmd
+package keybindings
 
 import (
 	"fmt"
@@ -998,6 +998,17 @@ func (r *KeyBindingResolver) GetProfile(profile Profile) (*KeyBindingProfile, bo
 // ClearCache clears the resolution cache (useful for config reloads)
 func (r *KeyBindingResolver) ClearCache() {
 	r.cache = make(map[string]*ContextualKeyBindingMap)
+}
+
+// ForceEnvironment overrides detected platform and terminal (primarily for tests).
+func (r *KeyBindingResolver) ForceEnvironment(platform, terminal string) {
+	if strings.TrimSpace(platform) != "" {
+		r.platform = platform
+	}
+	if strings.TrimSpace(terminal) != "" {
+		r.terminal = terminal
+	}
+	r.ClearCache()
 }
 
 // Resolve performs layered keybinding resolution for a specific profile and context
@@ -2340,48 +2351,47 @@ func CompareProfiles(profile1, profile2 *KeyBindingProfile) map[string]interface
 
 // Runtime Profile Switching
 
+// ContextualMapApplier applies resolved keybindings to interested consumers.
+type ContextualMapApplier interface {
+	ApplyContextualKeybindings(*ContextualKeyBindingMap)
+}
+
 // ProfileSwitcher manages runtime profile switching functionality
 type ProfileSwitcher struct {
 	resolver       *KeyBindingResolver
 	currentProfile Profile
-	ui             *UI // Reference to UI for hot-swapping
+	applier        ContextualMapApplier
 }
 
 // NewProfileSwitcher creates a new profile switcher
-func NewProfileSwitcher(resolver *KeyBindingResolver, ui *UI) *ProfileSwitcher {
+func NewProfileSwitcher(resolver *KeyBindingResolver, applier ContextualMapApplier) *ProfileSwitcher {
 	return &ProfileSwitcher{
 		resolver:       resolver,
 		currentProfile: ProfileDefault,
-		ui:             ui,
+		applier:        applier,
 	}
 }
 
 // SwitchProfile switches to a new profile at runtime
 func (ps *ProfileSwitcher) SwitchProfile(newProfile Profile) error {
-	// Validate the profile exists
 	if _, exists := ps.resolver.GetProfile(newProfile); !exists {
 		return fmt.Errorf("profile %s not found", newProfile)
 	}
 
-	// Clear resolver cache to force re-resolution with new profile
 	ps.resolver.ClearCache()
 
-	// Resolve new contextual keybindings
 	newContextualMap, err := ps.resolver.ResolveContextual(newProfile)
 	if err != nil {
 		return fmt.Errorf("failed to resolve profile %s: %w", newProfile, err)
 	}
 
-	// Update UI handler with new keybindings
-	if ps.ui != nil && ps.ui.handler != nil {
-		ps.ui.handler.contextualMap = newContextualMap
+	if ps.applier != nil {
+		ps.applier.ApplyContextualKeybindings(newContextualMap)
 	}
 
-	// Update current profile
 	oldProfile := ps.currentProfile
 	ps.currentProfile = newProfile
 
-	// Log the switch (could be configurable)
 	fmt.Printf("Switched keybinding profile from %s to %s\n", oldProfile, newProfile)
 
 	return nil
@@ -2403,7 +2413,6 @@ func (ps *ProfileSwitcher) CanSwitchTo(profile Profile) (bool, error) {
 		return false, fmt.Errorf("profile %s not registered", profile)
 	}
 
-	// Additional validation - ensure profile is valid
 	profileDef, _ := ps.resolver.GetProfile(profile)
 	if err := ValidateProfile(profileDef); err != nil {
 		return false, fmt.Errorf("profile %s validation failed: %w", profile, err)
@@ -2418,7 +2427,6 @@ func (ps *ProfileSwitcher) PreviewProfile(profile Profile) (*ContextualKeyBindin
 		return nil, fmt.Errorf("profile %s not found", profile)
 	}
 
-	// Create a temporary resolver to avoid affecting the main one
 	tempResolver := NewKeyBindingResolver(ps.resolver.userConfig)
 	RegisterBuiltinProfiles(tempResolver)
 
@@ -2445,299 +2453,81 @@ func (ps *ProfileSwitcher) ReloadCurrentProfile() error {
 	return ps.SwitchProfile(ps.currentProfile)
 }
 
-// UI Integration for Profile Switching
-
-// HandleProfileSwitchCommand processes profile switch commands from UI
+// HandleProfileSwitchCommand processes profile switching commands
 func HandleProfileSwitchCommand(switcher *ProfileSwitcher, command string) error {
-	parts := strings.Fields(command)
-	if len(parts) < 2 {
-		return fmt.Errorf("usage: set profile <profile_name>")
+	parts := strings.Fields(strings.TrimSpace(command))
+	if len(parts) == 0 {
+		return fmt.Errorf("no command provided")
 	}
 
-	if parts[0] != "set" || parts[1] != "profile" {
-		return fmt.Errorf("unknown command: %s", command)
-	}
+	subcommand := parts[0]
 
-	if len(parts) < 3 {
-		return fmt.Errorf("missing profile name")
-	}
-
-	profileName := parts[2]
-	profile := Profile(profileName)
-
-	// Validate profile name
-	validProfiles := GetAllProfilesBuiltin()
-	isValid := false
-	for _, validProfile := range validProfiles {
-		if validProfile == profile {
-			isValid = true
-			break
+	switch subcommand {
+	case "list":
+		profiles := switcher.GetAvailableProfiles()
+		fmt.Println("Available profiles:")
+		for _, profile := range profiles {
+			currentMarker := ""
+			if profile == switcher.GetCurrentProfile() {
+				currentMarker = " (current)"
+			}
+			fmt.Printf("  - %s%s\n", profile, currentMarker)
 		}
-	}
-
-	if !isValid {
-		return fmt.Errorf("invalid profile: %s. Available profiles: %v", profileName, validProfiles)
-	}
-
-	return switcher.SwitchProfile(profile)
-}
-
-// ListProfilesCommand returns information about all available profiles
-func ListProfilesCommand() string {
-	profiles := GetAllProfilesBuiltin()
-	result := "Available keybinding profiles:\n"
-
-	for _, profile := range profiles {
-		description := GetProfileDescription(profile)
-		result += fmt.Sprintf("  %-10s - %s\n", profile, description)
-	}
-
-	return result
-}
-
-// ShowCurrentProfileCommand returns information about the current profile
-func ShowCurrentProfileCommand(switcher *ProfileSwitcher) string {
-	currentProfile := switcher.GetCurrentProfile()
-	description := GetProfileDescription(currentProfile)
-
-	profileDef, _ := switcher.resolver.GetProfile(currentProfile)
-	stats := GetProfileStatistics(profileDef)
-
-	result := fmt.Sprintf("Current Profile: %s\n", currentProfile)
-	result += fmt.Sprintf("Description: %s\n", description)
-	result += fmt.Sprintf("Total Bindings: %v\n", stats["total_context_bindings"])
-	result += fmt.Sprintf("Global Bindings: %v\n", stats["global_bindings"])
-	result += fmt.Sprintf("Contexts: %v\n", stats["contexts_defined"])
-
-	return result
-}
-
-// ===============================================
-// Advanced keybinding features (power user)
-// ===============================================
-
-// ContextManager provides dynamic context management with stack support
-type ContextManager struct {
-	current   Context
-	stack     []Context
-	resolver  *KeyBindingResolver
-	callbacks map[Context][]func(Context, Context) // context change callbacks
-	debug     bool
-}
-
-// NewContextManager creates a new context manager
-func NewContextManager(resolver *KeyBindingResolver) *ContextManager {
-	return &ContextManager{
-		current:   ContextGlobal,
-		stack:     make([]Context, 0),
-		resolver:  resolver,
-		callbacks: make(map[Context][]func(Context, Context)),
-		debug:     false,
-	}
-}
-
-// GetCurrentContext returns the current context
-func (cm *ContextManager) GetCurrentContext() Context {
-	return cm.current
-}
-
-// SetContext directly updates the current context without modifying the stack
-func (cm *ContextManager) SetContext(ctx Context) {
-	if cm.current == ctx {
-		return
-	}
-
-	oldContext := cm.current
-	cm.current = ctx
-
-	if cm.debug {
-		fmt.Printf("DEBUG: Context set: %s -> %s\n", oldContext, ctx)
-	}
-
-	cm.notifyContextChange(oldContext, ctx)
-}
-
-// EnterContext pushes the current context onto the stack and enters a new context
-func (cm *ContextManager) EnterContext(ctx Context) {
-	if cm.debug {
-		fmt.Printf("DEBUG: Context transition: %s -> %s\n", cm.current, ctx)
-	}
-
-	oldContext := cm.current
-	cm.stack = append(cm.stack, cm.current)
-	cm.current = ctx
-
-	// Call context change callbacks
-	cm.notifyContextChange(oldContext, ctx)
-}
-
-// ExitContext pops the previous context from the stack
-func (cm *ContextManager) ExitContext() Context {
-	if len(cm.stack) == 0 {
-		return cm.current // No context to exit to
-	}
-
-	oldContext := cm.current
-	cm.current = cm.stack[len(cm.stack)-1]
-	cm.stack = cm.stack[:len(cm.stack)-1]
-
-	if cm.debug {
-		fmt.Printf("DEBUG: Context exit: %s -> %s\n", oldContext, cm.current)
-	}
-
-	// Call context change callbacks
-	cm.notifyContextChange(oldContext, cm.current)
-
-	return cm.current
-}
-
-// GetContextStack returns a copy of the current context stack
-func (cm *ContextManager) GetContextStack() []Context {
-	stack := make([]Context, len(cm.stack))
-	copy(stack, cm.stack)
-	return stack
-}
-
-// RegisterContextCallback registers a callback for context changes
-func (cm *ContextManager) RegisterContextCallback(ctx Context, callback func(Context, Context)) {
-	cm.callbacks[ctx] = append(cm.callbacks[ctx], callback)
-}
-
-// SetDebugMode enables or disables debug output for context transitions
-func (cm *ContextManager) SetDebugMode(debug bool) {
-	cm.debug = debug
-}
-
-// notifyContextChange calls registered callbacks for context changes
-func (cm *ContextManager) notifyContextChange(from, to Context) {
-	// Call callbacks for the target context
-	if callbacks, exists := cm.callbacks[to]; exists {
-		for _, callback := range callbacks {
-			callback(from, to)
+	case "switch":
+		if len(parts) < 2 {
+			return fmt.Errorf("usage: switch <profile>")
 		}
-	}
-
-	// Call global callbacks (registered under ContextGlobal)
-	if callbacks, exists := cm.callbacks[ContextGlobal]; exists && to != ContextGlobal {
-		for _, callback := range callbacks {
-			callback(from, to)
+		profile := Profile(parts[1])
+		if err := switcher.SwitchProfile(profile); err != nil {
+			return err
 		}
-	}
-}
-
-// PlatformOptimizations provides platform-specific keybinding optimizations
-type PlatformOptimizations struct {
-	platform     string
-	terminal     string
-	capabilities map[string]bool
-	keyMappings  map[string][]KeyStroke
-}
-
-// NewPlatformOptimizations creates platform-specific optimizations
-func NewPlatformOptimizations(platform, terminal string) *PlatformOptimizations {
-	po := &PlatformOptimizations{
-		platform:     platform,
-		terminal:     terminal,
-		capabilities: GetTerminalCapabilities(terminal),
-		keyMappings:  make(map[string][]KeyStroke),
-	}
-
-	po.initializePlatformMappings()
-	return po
-}
-
-// initializePlatformMappings sets up platform-specific key mappings
-func (po *PlatformOptimizations) initializePlatformMappings() {
-	switch po.platform {
-	case "darwin":
-		po.initializeMacOSMappings()
-	case "linux":
-		po.initializeLinuxMappings()
-	case "windows":
-		po.initializeWindowsMappings()
+	case "preview":
+		if len(parts) < 2 {
+			return fmt.Errorf("usage: preview <profile>")
+		}
+		profile := Profile(parts[1])
+		preview, err := switcher.PreviewProfile(profile)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Preview for profile %s:\n", profile)
+		for ctx, mapBinding := range preview.Contexts {
+			fmt.Printf("  Context: %s\n", ctx)
+			fmt.Printf("    move_up                 %-20s Move up one line\n", FormatKeyStrokesForDisplay(mapBinding.MoveUp))
+			fmt.Printf("    move_down               %-20s Move down one line\n", FormatKeyStrokesForDisplay(mapBinding.MoveDown))
+			fmt.Printf("    move_to_beginning       %-20s Move to line beginning\n", FormatKeyStrokesForDisplay(mapBinding.MoveToBeginning))
+			fmt.Printf("    move_to_end             %-20s Move to line end\n", FormatKeyStrokesForDisplay(mapBinding.MoveToEnd))
+			fmt.Printf("    delete_word             %-20s Delete previous word\n", FormatKeyStrokesForDisplay(mapBinding.DeleteWord))
+			fmt.Printf("    delete_to_end           %-20s Delete to line end\n", FormatKeyStrokesForDisplay(mapBinding.DeleteToEnd))
+			fmt.Printf("    clear_line              %-20s Clear entire line\n", FormatKeyStrokesForDisplay(mapBinding.ClearLine))
+		}
+	case "compare":
+		if len(parts) < 2 {
+			return fmt.Errorf("usage: compare <profile>")
+		}
+		profile := Profile(parts[1])
+		comparison, err := switcher.GetProfileComparison(profile)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Comparison between current profile (%s) and %s:\n", switcher.GetCurrentProfile(), profile)
+		for category, value := range comparison {
+			fmt.Printf("  %s: %v\n", category, value)
+		}
+	case "reload":
+		if err := switcher.ReloadCurrentProfile(); err != nil {
+			return err
+		}
 	default:
-		po.initializeUnixMappings()
+		return fmt.Errorf("unknown subcommand: %s", subcommand)
 	}
+
+	return nil
 }
 
-// initializeMacOSMappings sets up macOS-specific optimizations
-func (po *PlatformOptimizations) initializeMacOSMappings() {
-	// Option+Backspace for delete word
-	if po.capabilities["alt_keys"] {
-		po.keyMappings["delete_word"] = []KeyStroke{
-			NewAltKeyStroke('\b', "alt+backspace"), // Option+Backspace
-			NewCtrlKeyStroke('w'),                  // Keep Ctrl+W as fallback
-		}
-	}
-
-	// Option+Arrow keys for word movement
-	if po.capabilities["alt_keys"] {
-		po.keyMappings["word_forward"] = []KeyStroke{
-			NewAltKeyStroke('f', "alt+f"),
-		}
-		po.keyMappings["word_backward"] = []KeyStroke{
-			NewAltKeyStroke('b', "alt+b"),
-		}
-	}
-
-	// Cmd+C for copy (if terminal supports it)
-	if po.terminal == "iterm" || po.terminal == "terminal" {
-		po.keyMappings["copy"] = []KeyStroke{
-			NewRawKeyStroke([]byte{27, 91, 51, 59, 53, 126}), // Cmd+C sequence
-		}
-	}
-}
-
-// initializeLinuxMappings sets up Linux-specific optimizations
-func (po *PlatformOptimizations) initializeLinuxMappings() {
-	// Alt+Backspace for delete word (common in bash)
-	if po.capabilities["alt_keys"] {
-		po.keyMappings["delete_word"] = []KeyStroke{
-			NewAltKeyStroke('\b', "alt+backspace"),
-			NewCtrlKeyStroke('w'),
-		}
-	}
-
-	// Ctrl+Alt+T for new terminal (if in tmux/screen)
-	if po.terminal == "tmux" || po.terminal == "screen" {
-		po.keyMappings["new_window"] = []KeyStroke{
-			NewRawKeyStroke([]byte{27, 91, 50, 48, 126}), // Custom sequence
-		}
-	}
-}
-
-// initializeWindowsMappings sets up Windows-specific optimizations
-func (po *PlatformOptimizations) initializeWindowsMappings() {
-	// Ctrl+Backspace for delete word
-	po.keyMappings["delete_word"] = []KeyStroke{
-		NewCtrlKeyStroke('\b'),
-		NewCtrlKeyStroke('w'),
-	}
-
-	// Windows terminal specific sequences
-	if po.terminal == "windows-terminal" || po.terminal == "cmd" {
-		po.keyMappings["paste"] = []KeyStroke{
-			NewCtrlKeyStroke('v'),
-		}
-	}
-}
-
-// initializeUnixMappings sets up generic Unix optimizations
-func (po *PlatformOptimizations) initializeUnixMappings() {
-	// Standard Unix keybindings
-	po.keyMappings["delete_word"] = []KeyStroke{
-		NewCtrlKeyStroke('w'),
-	}
-
-	po.keyMappings["clear_line"] = []KeyStroke{
-		NewCtrlKeyStroke('u'),
-	}
-}
-
-// GetOptimizedBindings returns platform-optimized keybindings for an action
-func (po *PlatformOptimizations) GetOptimizedBindings(action string) ([]KeyStroke, bool) {
-	bindings, exists := po.keyMappings[action]
-	return bindings, exists
+// ShowCurrentProfileCommand returns a string representing the current profile status
+func ShowCurrentProfileCommand(switcher *ProfileSwitcher) string {
+	return fmt.Sprintf("Current profile: %s", switcher.GetCurrentProfile())
 }
 
 // RuntimeProfileSwitcher enables switching profiles without restart
@@ -2804,6 +2594,158 @@ func (rps *RuntimeProfileSwitcher) CycleProfile() error {
 
 	nextIndex := (currentIndex + 1) % len(profiles)
 	return rps.SwitchProfile(profiles[nextIndex])
+}
+
+// ContextManager manages active contexts and notifies callbacks on transitions.
+type ContextManager struct {
+	resolver  *KeyBindingResolver
+	current   Context
+	stack     []Context
+	callbacks map[Context][]func(Context, Context)
+}
+
+// NewContextManager creates a new ContextManager.
+func NewContextManager(resolver *KeyBindingResolver) *ContextManager {
+	return &ContextManager{
+		resolver:  resolver,
+		current:   ContextGlobal,
+		stack:     make([]Context, 0, 4),
+		callbacks: make(map[Context][]func(Context, Context)),
+	}
+}
+
+// RegisterContextCallback registers a callback invoked when the target context becomes active.
+func (cm *ContextManager) RegisterContextCallback(ctx Context, callback func(Context, Context)) {
+	if callback == nil {
+		return
+	}
+	cm.callbacks[ctx] = append(cm.callbacks[ctx], callback)
+}
+
+// GetCurrentContext returns the currently active context.
+func (cm *ContextManager) GetCurrentContext() Context {
+	return cm.current
+}
+
+// GetContextStack returns a copy of the context stack.
+func (cm *ContextManager) GetContextStack() []Context {
+	dup := make([]Context, len(cm.stack))
+	copy(dup, cm.stack)
+	return dup
+}
+
+// EnterContext pushes the current context on the stack and switches to the new context.
+func (cm *ContextManager) EnterContext(ctx Context) {
+	if ctx == cm.current {
+		return
+	}
+
+	old := cm.current
+	cm.stack = append(cm.stack, cm.current)
+	cm.current = ctx
+	cm.invokeCallbacks(old, ctx)
+}
+
+// ExitContext pops the last context from the stack and activates it.
+func (cm *ContextManager) ExitContext() Context {
+	if len(cm.stack) == 0 {
+		return cm.current
+	}
+
+	old := cm.current
+	idx := len(cm.stack) - 1
+	cm.current = cm.stack[idx]
+	cm.stack = cm.stack[:idx]
+	cm.invokeCallbacks(old, cm.current)
+	return cm.current
+}
+
+// SetContext forcefully changes the current context without modifying the stack.
+func (cm *ContextManager) SetContext(ctx Context) {
+	if ctx == cm.current {
+		return
+	}
+
+	old := cm.current
+	cm.current = ctx
+	cm.invokeCallbacks(old, ctx)
+}
+
+// ForceEnvironment overrides resolver platform/terminal (primarily for tests).
+func (cm *ContextManager) ForceEnvironment(platform, terminal string) {
+	if cm == nil || cm.resolver == nil {
+		return
+	}
+	cm.resolver.ForceEnvironment(platform, terminal)
+}
+
+func (cm *ContextManager) invokeCallbacks(from, to Context) {
+	if from == to {
+		return
+	}
+
+	if callbacks, exists := cm.callbacks[to]; exists {
+		for _, cb := range callbacks {
+			cb(from, to)
+		}
+	}
+
+	if to != ContextGlobal {
+		if callbacks, exists := cm.callbacks[ContextGlobal]; exists {
+			for _, cb := range callbacks {
+				cb(from, to)
+			}
+		}
+	}
+}
+
+// PlatformOptimizations provides platform-specific keybinding recommendations.
+type PlatformOptimizations struct {
+	platform string
+	terminal string
+	keyMap   map[string][]KeyStroke
+}
+
+// NewPlatformOptimizations builds platform-aware keybinding suggestions.
+func NewPlatformOptimizations(platform, terminal string) *PlatformOptimizations {
+	po := &PlatformOptimizations{
+		platform: platform,
+		terminal: terminal,
+		keyMap:   make(map[string][]KeyStroke),
+	}
+
+	po.initialize()
+	return po
+}
+
+func (po *PlatformOptimizations) initialize() {
+	switch po.platform {
+	case "darwin":
+		po.keyMap["delete_word"] = []KeyStroke{
+			NewAltKeyStroke('', "alt+backspace"),
+			NewCtrlKeyStroke('w'),
+		}
+	case "linux":
+		po.keyMap["delete_word"] = []KeyStroke{NewCtrlKeyStroke('w')}
+		po.keyMap["clear_line"] = []KeyStroke{NewCtrlKeyStroke('u')}
+	case "windows":
+		po.keyMap["paste"] = []KeyStroke{NewCtrlKeyStroke('v')}
+		po.keyMap["clear_line"] = []KeyStroke{NewCtrlKeyStroke('u')}
+	default:
+		po.keyMap["delete_word"] = []KeyStroke{NewCtrlKeyStroke('w')}
+		po.keyMap["clear_line"] = []KeyStroke{NewCtrlKeyStroke('u')}
+	}
+
+	if po.platform == "darwin" {
+		po.keyMap["word_forward"] = []KeyStroke{NewAltKeyStroke('f', "alt+f")}
+		po.keyMap["word_backward"] = []KeyStroke{NewAltKeyStroke('b', "alt+b")}
+	}
+}
+
+// GetOptimizedBindings returns platform-aware bindings for the given action.
+func (po *PlatformOptimizations) GetOptimizedBindings(action string) ([]KeyStroke, bool) {
+	bindings, ok := po.keyMap[action]
+	return bindings, ok
 }
 
 // HotConfigReloader enables reloading configuration without restart

--- a/internal/keybindings/parser_internal.go
+++ b/internal/keybindings/parser_internal.go
@@ -1,4 +1,4 @@
-package cmd
+package keybindings
 
 import (
 	"fmt"

--- a/internal/keybindings/parser_internal_test.go
+++ b/internal/keybindings/parser_internal_test.go
@@ -1,4 +1,4 @@
-package cmd
+package keybindings
 
 import (
 	"testing"

--- a/internal/keybindings/platform_optimizations_test.go
+++ b/internal/keybindings/platform_optimizations_test.go
@@ -1,4 +1,4 @@
-package cmd
+package keybindings
 
 import "testing"
 

--- a/internal/keybindings/profile_test.go
+++ b/internal/keybindings/profile_test.go
@@ -1,4 +1,4 @@
-package cmd
+package keybindings
 
 import "testing"
 

--- a/internal/keybindings/resolver_test.go
+++ b/internal/keybindings/resolver_test.go
@@ -1,4 +1,4 @@
-package cmd
+package keybindings
 
 import (
 	"testing"

--- a/internal/keybindings/test_helpers_test.go
+++ b/internal/keybindings/test_helpers_test.go
@@ -1,4 +1,4 @@
-package cmd
+package keybindings
 
 import (
 	"strings"


### PR DESCRIPTION
## Description of Changes
- extract the interactive UI implementation into `internal/interactive`, leaving `cmd/interactive.go` as a lightweight facade wired through the new controller and renderer.
- split keybinding logic into `internal/keybindings`, expose the necessary bridge in `cmd/keybindings_bridge.go`, and update command wiring to use the new package.
- relocate and refresh interactive/keybinding tests to target the new packages and validate workflow/profile switching behaviour.

## Related Issue
part #207 

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/bmf-san/ggc/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests
- [x] Code is formatted with `make fmt`
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing
- [x] If commands were added/modified: I have run `make docs` to update README.md

## Additional Context
- modularisation prepares for future waves of the architecture refactor by isolating interactive UI and keybinding concerns under `internal/` while keeping the CLI layer stable.
