### PR TITLE
fix: Fixed non-existent branchDelete method call in test to branchDeleteArgs

### DIFF
--- a/cmd/branch.go
+++ b/cmd/branch.go
@@ -770,4 +770,3 @@ func (b *Brancher) branchContains() {
 		_, _ = fmt.Fprintln(b.outputWriter, br)
 	}
 }
-

--- a/cmd/branch_test.go
+++ b/cmd/branch_test.go
@@ -324,7 +324,7 @@ func TestBrancher_branchDelete_Success(t *testing.T) {
 		prompter:     prompt.New(strings.NewReader("1 2\n"), &buf),
 	}
 
-	brancher.branchDelete()
+	brancher.branchDeleteArgs(nil)
 
 	output := buf.String()
 	if !strings.Contains(output, "feature/test") {
@@ -348,7 +348,7 @@ func TestBrancher_branchDelete_All(t *testing.T) {
 		prompter:     prompt.New(strings.NewReader("all\n"), &buf),
 	}
 
-	brancher.branchDelete()
+	brancher.branchDeleteArgs(nil)
 
 	output := buf.String()
 	if !strings.Contains(output, "All branches deleted.") {
@@ -369,7 +369,7 @@ func TestBrancher_branchDelete_Cancel(t *testing.T) {
 		prompter:     prompt.New(strings.NewReader("\n"), &buf),
 	}
 
-	brancher.branchDelete()
+	brancher.branchDeleteArgs(nil)
 
 	output := buf.String()
 	if !strings.Contains(output, "Canceled.") {
@@ -389,7 +389,7 @@ func TestBrancher_branchDelete_Error(t *testing.T) {
 		outputWriter: &buf,
 	}
 
-	brancher.branchDelete()
+	brancher.branchDeleteArgs(nil)
 
 	output := buf.String()
 	if !strings.Contains(output, "Error: failed to list branches") {
@@ -409,7 +409,7 @@ func TestBrancher_branchDelete_NoBranches(t *testing.T) {
 		outputWriter: &buf,
 	}
 
-	brancher.branchDelete()
+	brancher.branchDeleteArgs(nil)
 
 	output := buf.String()
 	if !strings.Contains(output, "No local branches found.") {
@@ -1054,7 +1054,7 @@ func TestBrancher_Branch_BoundaryDeleteOperations(t *testing.T) {
 				prompter:     prompt.New(strings.NewReader(tt.input), &buf),
 			}
 
-			brancher.branchDelete()
+			brancher.branchDeleteArgs(nil)
 
 			output := buf.String()
 			if !strings.Contains(output, tt.expected) {
@@ -1105,7 +1105,7 @@ func TestBrancher_Branch_BoundaryRemoteOperations(t *testing.T) {
 				prompter:     prompt.New(strings.NewReader(tt.input), &buf),
 			}
 
-			brancher.branchDelete()
+			brancher.branchDeleteArgs(nil)
 
 			output := buf.String()
 			if !strings.Contains(output, tt.expected) {


### PR DESCRIPTION
## Description of Changes
This PR fixes test compilation errors in `cmd/branch_test.go` caused by calls to a non-existent method `branchDelete()`. The method was refactored/renamed to `branchDeleteArgs()` in the implementation, but the test file was not updated accordingly.

### Changes Made:
- Updated 7 test cases in `cmd/branch_test.go` to call `branchDeleteArgs(nil)` instead of `branchDelete()`
- Fixed file formatting issues in `cmd/branch.go` (missing newline at end of file)
- All tests now pass successfully

### Test Cases Updated:
1. `TestBrancher_branchDelete` (line 327)
2. `TestBrancher_branchDelete_All` (line 351)
3. `TestBrancher_branchDelete_Cancel` (line 372)
4. `TestBrancher_branchDelete_Error` (line 392)
5. `TestBrancher_branchDelete_NoBranches` (line 412)
6. Table-driven test case (line 1057)
7. `TestBrancher_Branch_BoundaryRemoteOperations` (line 1108)

## Related Issue
This fixes the build failure where `cmd` package tests were failing with:
```
brancher.branchDelete undefined (type *Brancher has no field or method branchDelete)
```

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/bmf-san/ggc/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests
- [x] I have updated the documentation (if required)
- [x] Code is formatted with `make fmt`
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing
- [ ] If commands were added/modified: I have run `make docs` to update README.md (N/A - no command changes)
- [ ] I have run `make demos` to regenerate demo assets (if applicable) (N/A - no UI/behavior changes)

## Screenshots (if appropriate)
Before fix:
```
cmd/branch_test.go:327:11: brancher.branchDelete undefined (type *Brancher has no field or method branchDelete)
FAIL    github.com/bmf-san/ggc/v7/cmd [build failed]
```

After fix:
```
ok      github.com/bmf-san/ggc/v7/cmd   0.909s
```

## Additional Context
The `branchDelete()` method no longer exists in the `Brancher` struct. The implementation uses `branchDeleteArgs(args []string)` which handles both interactive deletion (when args is nil) and direct deletion (when branch names are provided as args). This PR ensures all test cases use the correct method signature.

All tests pass with this change:
- `make test` - All packages pass
- `make lint` - 0 issues

