### PR TITLE
bug(branch): select upstream branch error handling

### DIFF
--- a/cmd/branch.go
+++ b/cmd/branch.go
@@ -692,6 +692,9 @@ func (b *Brancher) selectUpstreamBranch() string {
 		return ""
 	}
 
+	if len(remotes) == 0 {
+		_, _ = fmt.Fprintln(b.outputWriter, "No remote branches found.")
+	}
 	b.displayRemoteBranches(remotes)
 
 	upIn, ok := b.readLine("Enter upstream (name or number): ")


### PR DESCRIPTION
## Description of Changes
This PR fixes error handling in the `selectUpstreamBranch()` method and improves user experience when no remote branches are available.

### Problem
The `selectUpstreamBranch()` method was ignoring errors from `ListRemoteBranches()` by using the blank identifier (`_`). This caused:
1. Network/auth errors to be silently hidden from users
2. Potential index out of range panics when accessing an empty slice
3. Confusing UI showing no branch list without explanation

### Solution
1. **Error Handling** - Handle `ListRemoteBranches()` errors instead of ignoring them
2. **Empty String Filtering** - Filter out empty strings to prevent index panics
3. **Code Refactoring** - Split into smaller functions to reduce cyclomatic complexity (11 → 6)
4. **UX Improvement** - Display "No remote branches found." message when no remote branches exist
5. **Test Coverage** - Added 5 comprehensive test cases

### Before/After
**Before:**
```
Enter upstream (name or number):
```
(No explanation, confusing to users)

**After:**
```
No remote branches found.
Enter upstream (name or number):
```
(Clear message explaining the situation)

## Related Issue
close https://github.com/bmf-san/ggc/issues/258

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/bmf-san/ggc/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests
- [x] I have updated the documentation (if required)
- [x] Code is formatted with `make fmt`
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing
- [x] If commands were added/modified: I have run `make docs` to update README.md
- [x] I have run `make demos` to regenerate demo assets (if applicable)

## Screenshots (if appropriate)

### Manual Testing - Before Fix
```bash
$ git checkout 6698f40
$ make build
$ cd /tmp/test-repo  # repo with no remote branches
$ echo -e "1\norigin/main" | ./ggc branch set upstream

Output:
Local branches:
[1] main
Enter the number of the branch to set upstream: Enter upstream (name or number):
# ↑ No message explaining why no remote branches shown!
```

### Manual Testing - After Fix
```bash
$ git checkout fix/select-upstream-branch-error-handling
$ make build
$ cd /tmp/test-repo  # repo with no remote branches
$ echo -e "1\norigin/main" | ./ggc branch set upstream

Output:
Local branches:
[1] main
Enter the number of the branch to set upstream: No remote branches found.
Enter upstream (name or number):
# ↑ Clear message explaining the situation!
```

### Test Results
```bash
$ make test
ok      github.com/bmf-san/ggc/v7/cmd   0.567s

$ go test ./cmd -run TestBrancher_selectUpstreamBranch -v
=== RUN   TestBrancher_selectUpstreamBranch_ErrorHandling
--- PASS: TestBrancher_selectUpstreamBranch_ErrorHandling (0.00s)
=== RUN   TestBrancher_selectUpstreamBranch_EmptyBranchesFiltered
--- PASS: TestBrancher_selectUpstreamBranch_EmptyBranchesFiltered (0.00s)
=== RUN   TestBrancher_selectUpstreamBranch_Success
--- PASS: TestBrancher_selectUpstreamBranch_Success (0.00s)
=== RUN   TestBrancher_selectUpstreamBranch_IndexOutOfRange
--- PASS: TestBrancher_selectUpstreamBranch_IndexOutOfRange (0.00s)
=== RUN   TestBrancher_selectUpstreamBranch_NoRemoteBranches
--- PASS: TestBrancher_selectUpstreamBranch_NoRemoteBranches (0.00s)
PASS
```

## Additional Context

### Code Changes Summary
- **`cmd/branch.go`**: Refactored `selectUpstreamBranch()` into 4 functions:
  - `selectUpstreamBranch()` - Main entry point (reduced complexity)
  - `getValidRemoteBranches()` - Retrieve and filter remote branches
  - `displayRemoteBranches()` - Display numbered branch list
  - `resolveUpstreamInput()` - Convert user input to branch name

- **`cmd/branch_test.go`**: Added 5 test cases covering:
  - Error handling (when `ListRemoteBranches()` fails)
  - Empty string filtering
  - Normal flow (selecting from list)
  - Index out of range handling
  - Zero remote branches scenario

### Technical Notes
The implementation uses `git branch -r` which lists locally cached remote branches (not fetching from network). While network errors don't occur in practice, this fix:
1. Prevents future issues if the implementation changes
2. Handles other types of errors (permission issues, corrupted git state, etc.)
3. Improves UX by filtering empty strings and showing clear messages
4. Improves code maintainability and testability
