### PR TITLE
fix: clean up github configuration

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func RunApp(args []string) {
 	cmd.SetVersionGetter(GetVersionInfo)
 	c := cmd.NewCmd(git.NewClient())
 	// Cache default remote in tagger to avoid repeated config loads.
-	if r := strings.TrimSpace(cm.GetConfig().Integration.Github.DefaultRemote); r != "" {
+	if r := strings.TrimSpace(cm.GetConfig().Git.DefaultRemote); r != "" {
 		c.SetDefaultRemote(r)
 	}
 	r := router.NewRouter(c, cm)

--- a/main_test.go
+++ b/main_test.go
@@ -445,7 +445,7 @@ func TestMain_DefaultRemoteHandling(t *testing.T) {
 
 			// Set up the mock config to return our test value
 			cfg := cm.GetConfig()
-			cfg.Integration.Github.DefaultRemote = tt.mockDefaultRemote
+			cfg.Git.DefaultRemote = tt.mockDefaultRemote
 
 			// Initialize cmd and check default remote setting logic
 			cmd.SetVersionGetter(GetVersionInfo)
@@ -509,7 +509,7 @@ func TestMain_CompleteFlow(t *testing.T) {
 
 			// Set up test config
 			cfg := cm.GetConfig()
-			cfg.Integration.Github.DefaultRemote = tt.defaultRemote
+			cfg.Git.DefaultRemote = tt.defaultRemote
 
 			// Step 2: Set version getter
 			cmd.SetVersionGetter(GetVersionInfo)
@@ -677,7 +677,7 @@ func TestMain_InitializationOrder(t *testing.T) {
 		// Step 4: Default remote setup (requires config to be loaded)
 		cfg := cm.GetConfig()
 		if cfg != nil {
-			if r := strings.TrimSpace(cfg.Integration.Github.DefaultRemote); r != "" {
+			if r := strings.TrimSpace(cfg.Git.DefaultRemote); r != "" {
 				c.SetDefaultRemote(r)
 				t.Logf("Default remote set to: %s", r)
 			}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -157,8 +157,8 @@ func TestGetDefaultConfig(t *testing.T) {
 		t.Error("Expected stash-before-switch to be true")
 	}
 
-	if config.Integration.Github.DefaultRemote != "origin" {
-		t.Errorf("Expected default remote to be 'origin', got %s", config.Integration.Github.DefaultRemote)
+	if config.Git.DefaultRemote != "origin" {
+		t.Errorf("Expected default remote to be 'origin', got %s", config.Git.DefaultRemote)
 	}
 }
 
@@ -244,12 +244,8 @@ behavior:
 aliases:
   s: "status"
   c: "commit"
-integration:
-  github:
-    token: "test-token"
-    default-remote: "upstream"
-  gitlab:
-    token: "gitlab-token"
+git:
+  default-remote: "upstream"
 `
 
 	err := os.WriteFile(configPath, []byte(testConfig), 0644)
@@ -278,8 +274,8 @@ integration:
 	if cm.config.Aliases["s"] != "status" {
 		t.Errorf("Expected alias 's' to be 'status', got %s", cm.config.Aliases["s"])
 	}
-	if cm.config.Integration.Github.Token != "test-token" {
-		t.Errorf("Expected github token to be 'test-token', got %s", cm.config.Integration.Github.Token)
+	if cm.config.Git.DefaultRemote != "upstream" {
+		t.Errorf("Expected git default remote to be 'upstream', got %s", cm.config.Git.DefaultRemote)
 	}
 }
 
@@ -400,7 +396,7 @@ func TestGetValueByPath(t *testing.T) {
 		{"default.editor", "vim"},
 		{"ui.color", true},
 		{"behavior.auto-push", false},
-		{"integration.github.default-remote", "origin"},
+		{"git.default-remote", "origin"},
 	}
 
 	for _, tc := range testCases {
@@ -543,7 +539,7 @@ func TestList(t *testing.T) {
 		"default.editor",
 		"ui.color",
 		"behavior.auto-push",
-		"integration.github.default-remote",
+		"git.default-remote",
 	}
 
 	for _, key := range expectedKeys {
@@ -745,9 +741,7 @@ func TestConfig_Validate(t *testing.T) {
 		cfg.Behavior.AutoFetch = true
 		cfg.Behavior.StashBeforeSwitch = true
 		cfg.Aliases = map[string]any{"st": "status"}
-		cfg.Integration.Github.Token = "ghp_1234567890asdflkasfdasf"
-		cfg.Integration.Github.DefaultRemote = "origin"
-		cfg.Integration.Gitlab.Token = "glpat-abc123asdlfkasjdflasfdasdf"
+		cfg.Git.DefaultRemote = "origin"
 
 		err := cfg.Validate()
 		if err != nil {
@@ -776,38 +770,6 @@ func TestConfig_Validate(t *testing.T) {
 		cfg.Default.Editor = "vim"
 		cfg.Default.Branch = "main"
 		cfg.Aliases = map[string]any{"invalid alias": "status"}
-
-		err := cfg.Validate()
-		if err == nil {
-			t.Fatal("expected error, got nil")
-		}
-		if !strings.Contains(err.Error(), "invalid value") {
-			t.Errorf("unexpected error: %v", err)
-		}
-	})
-
-	t.Run("Invalid GitHub token", func(t *testing.T) {
-		cfg := &Config{}
-		cfg.Behavior.ConfirmDestructive = "always"
-		cfg.Default.Editor = "vim"
-		cfg.Integration.Github.Token = "bad-token"
-		cfg.Default.Branch = "main"
-
-		err := cfg.Validate()
-		if err == nil {
-			t.Fatal("expected error, got nil")
-		}
-		if !strings.Contains(err.Error(), "invalid value") {
-			t.Errorf("unexpected error: %v", err)
-		}
-	})
-
-	t.Run("Invalid GitLab token", func(t *testing.T) {
-		cfg := &Config{}
-		cfg.Behavior.ConfirmDestructive = "always"
-		cfg.Default.Editor = "vim"
-		cfg.Integration.Gitlab.Token = "bad-token"
-		cfg.Default.Branch = "main"
 
 		err := cfg.Validate()
 		if err == nil {


### PR DESCRIPTION
## Description of Changes
Remove unused integration configuration section and relocate `default-remote` to a new `git` section.

### Removed:
- `integration.github.token` - Never used (no GitHub API calls)
- `integration.github.default-remote` - Moved to `git.default-remote`
- `integration.gitlab.token` - Never used (no GitLab API calls)
- Related validation functions and regex patterns

### New config format:
```yaml
# Before
integration:
  github:
    token: ""
    default-remote: "upstream"
  gitlab:
    token: ""

# After
git:
  default-remote: "upstream"
```

## Related Issue
close #309 
close https://github.com/bmf-san/ggc/issues/278

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/bmf-san/ggc/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests
- [x] I have updated the documentation (if required)
- [x] Code is formatted with make fmt
- [x] Code passes linter checks via make lint
- [x] All tests are passing
- [x] If commands were added/modified: I have run make docs to update README.md
- [x] I have run make demos to regenerate demo assets (if applicable)

## Screenshots (if appropriate)
N/A

## Additional Context
Breaking Change: Users with old config format need to manually update their configuration files. The integration section will be silently ignored.