### PR TITLE
refactor: move interactive constants to cmd package

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -15,13 +15,11 @@ import (
 	"github.com/bmf-san/ggc/v7/pkg/git"
 )
 
-// Interactive mode special return values
-// These constants are used to signal special states when returning from interactive mode
+// Interactive mode command constants.
+// These are used to signal special states when returning from interactive mode.
 const (
-	// InteractiveQuitCommand signals that the user wants to quit the interactive mode
-	InteractiveQuitCommand = interactive.InteractiveQuitCommand
-	// InteractiveWorkflowCommand signals that a workflow has been executed and the interactive mode should restart
-	InteractiveWorkflowCommand = interactive.InteractiveWorkflowCommand
+	interactiveQuitCommand     = "quit"
+	interactiveWorkflowCommand = "workflow-executed"
 )
 
 // Executer is an interface for executing commands.
@@ -279,12 +277,12 @@ func (c *Cmd) Interactive() {
 		}
 
 		// Check for "quit" command
-		if len(args) >= 2 && args[1] == InteractiveQuitCommand {
+		if len(args) >= 2 && args[1] == interactiveQuitCommand {
 			break
 		}
 
 		// Check for workflow execution
-		if len(args) >= 2 && args[1] == InteractiveWorkflowCommand {
+		if len(args) >= 2 && args[1] == interactiveWorkflowCommand {
 			// Workflow was executed, wait for user to continue
 			c.waitForContinue()
 			ui.ResetToSearchMode()
@@ -365,7 +363,7 @@ func newCommandRouter(cmd *Cmd) (*commandRouter, error) {
 		"diff":       func(args []string) { cmd.Diff(args) },
 		"restore":    func(args []string) { cmd.Restore(args) },
 		"debug-keys": func(args []string) { cmd.DebugKeys(args) },
-		InteractiveQuitCommand: func([]string) {
+		interactiveQuitCommand: func([]string) {
 			_, _ = fmt.Fprintln(cmd.outputWriter, "The 'quit' command is only available in interactive mode.")
 		},
 	}

--- a/internal/interactive/constants.go
+++ b/internal/interactive/constants.go
@@ -1,9 +1,0 @@
-// Package interactive houses interactive UI types and helpers shared across the application.
-package interactive
-
-const (
-	// InteractiveQuitCommand instructs the interactive UI to exit.
-	InteractiveQuitCommand = "quit"
-	// InteractiveWorkflowCommand signals that an interactive workflow has been executed.
-	InteractiveWorkflowCommand = "workflow-executed"
-)

--- a/internal/interactive/controller.go
+++ b/internal/interactive/controller.go
@@ -1,3 +1,4 @@
+// Package interactive houses interactive UI types and helpers shared across the application.
 package interactive
 
 import (


### PR DESCRIPTION
## Summary
- Remove unnecessary constant re-exports in cmd package
- Move interactive constants from `internal/interactive/constants.go` to `cmd/cmd.go`
- Delete `internal/interactive/constants.go` as it only contained constants used by cmd
- Use unexported (lowercase) constants since they are package-private

Closes #287
Closes #289

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./cmd/... ./internal/interactive/...` passes
- [x] No new lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)