### PR TITLE
refactor: rename prompt.Interface to Prompter and add WithCancelMessage

### DIFF
--- a/cmd/branch.go
+++ b/cmd/branch.go
@@ -18,7 +18,7 @@ const errMsgBranchNameEmpty = "Error: branch name cannot be empty."
 // Brancher provides functionality for the branch command.
 type Brancher struct {
 	gitClient    git.BranchOps
-	prompter     prompt.Interface
+	prompter     prompt.Prompter
 	outputWriter io.Writer
 	helper       *Helper
 }

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -16,7 +16,7 @@ import (
 type Cleaner struct {
 	gitClient    git.CleanOps
 	outputWriter io.Writer
-	prompter     prompt.Interface
+	prompter     prompt.Prompter
 	helper       *Helper
 }
 

--- a/cmd/rebase.go
+++ b/cmd/rebase.go
@@ -17,7 +17,7 @@ type Rebaser struct {
 	gitClient    git.RebaseOps
 	outputWriter io.Writer
 	helper       *Helper
-	prompter     prompt.Interface
+	prompter     prompt.Prompter
 }
 
 // NewRebaser creates a new Rebaser instance.

--- a/internal/prompt/prompt_unix_test.go
+++ b/internal/prompt/prompt_unix_test.go
@@ -25,7 +25,7 @@ func TestInputCtrlCCancelsWithoutEnter(t *testing.T) {
 		_ = slave.Close()
 	})
 
-	prompter := New(slave, slave).(*Prompter)
+	prompter := New(slave, slave).(*StandardPrompter)
 
 	type result struct {
 		line     string


### PR DESCRIPTION
## Description of Changes

Refactor the prompt package to follow Go naming conventions and properly expose `WithCancelMessage` in the interface.

### Changes:
1. **Rename `Interface` to `Prompter`** - More idiomatic Go naming
2. **Rename struct `Prompter` to `StandardPrompter`** - Implementation name
3. **Add `WithCancelMessage` to `Prompter` interface** - Fixes the abstraction issue
4. **Update all usages** in cmd package

### Before:
```go
type Interface interface {
    Input(prompt string) (string, bool, error)
    Select(title string, items []string, prompt string) (int, bool, error)
    Confirm(prompt string) (bool, bool, error)
    // WithCancelMessage was NOT in interface!
}

type Prompter struct { ... }

func (p *Prompter) WithCancelMessage(message string) *Prompter
```

### After:
```go
type Prompter interface {
    Input(prompt string) (string, bool, error)
    Select(title string, items []string, prompt string) (int, bool, error)
    Confirm(prompt string) (bool, bool, error)
    WithCancelMessage(message string) Prompter
}

type StandardPrompter struct { ... }

func (p *StandardPrompter) WithCancelMessage(message string) Prompter
```

## Related Issue

close #294

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/bmf-san/ggc/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests
- [x] I have updated the documentation (if required)
- [x] Code is formatted with `make fmt`
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing

## Additional Context

This change properly follows Go interface naming conventions where the interface has the clean name (`Prompter`) and the implementation has a more specific name (`StandardPrompter`).