### PR TITLE
refactor: simplify workflow mode by removing focus-based design

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,8 +213,9 @@ ggc
 - `n`: Create a new workflow
 - `d` / `Ctrl+d`: Delete the active workflow
 - `x`: Execute the active workflow
-- `Ctrl+n/p`: Navigate workflows
-- `Ctrl+t`: Return to Search Mode
+- `Tab` / `Shift+Tab`: Cycle between workflows
+- `↑/↓` / `Ctrl+n/p`: Navigate workflow list
+- `Enter` / `Esc`: Return to Search Mode
 - `Ctrl+c`: Exit interactive mode
 
 **Command Execution:**

--- a/internal/interactive/interactive_test.go
+++ b/internal/interactive/interactive_test.go
@@ -1917,7 +1917,6 @@ func TestKeyHandler_HandleWorkflowKeys(t *testing.T) {
 
 	t.Run("Tab adds command to workflow in search mode", func(t *testing.T) {
 		ui.state.mode = ModeSearch
-		ui.state.FocusInput()
 		ui.state.input = "add"
 		ui.state.filtered = []CommandInfo{{Command: "add .", Description: "Add all changes"}}
 		ui.state.selected = 0
@@ -2224,7 +2223,6 @@ func TestWorkflowRendererActiveList(t *testing.T) {
 	gitClient := testutil.NewMockGitClient()
 	ui := NewUI(gitClient)
 	ui.state.mode = ModeWorkflow
-	ui.state.FocusWorkflowList()
 	ui.gitStatus = nil
 
 	active := ui.workflowMgr.GetActiveID()
@@ -2268,7 +2266,6 @@ func TestWorkflowListScrollOffset(t *testing.T) {
 	gitClient := testutil.NewMockGitClient()
 	ui := NewUI(gitClient)
 	ui.state.mode = ModeWorkflow
-	ui.state.FocusWorkflowList()
 	ui.gitStatus = nil
 
 	for _, summary := range ui.listWorkflows() {
@@ -2307,7 +2304,6 @@ func TestWorkflowRendererEmptyState(t *testing.T) {
 	gitClient := testutil.NewMockGitClient()
 	ui := NewUI(gitClient)
 	ui.state.mode = ModeWorkflow
-	ui.state.FocusWorkflowList()
 	ui.gitStatus = nil
 
 	active := ui.workflowMgr.GetActiveID()


### PR DESCRIPTION
## Description of Changes

Simplifies the Workflow Mode UI by removing the complex focus-switching system (Input ↔ WorkflowList) in favor of a streamlined single-focus design.

### Key Changes

**Code Cleanup:**
- Removed `WorkflowFocus` type and constants (`FocusInput`, `FocusWorkflowList`)
- Removed `workflowFocus` field from `UIState`
- Removed `FocusInput()`, `FocusWorkflowList()`, `IsInputFocused()` methods
- Removed dead code: `handleWorkflowModeBindings`, `handleWorkflowAdd`, `handleWorkflowClear`
- Replaced `IsInputFocused()` checks with `IsWorkflowMode()` for cursor movement

**New Functionality:**
- Added `Tab` key handling to cycle between workflows in Workflow Mode
- Added `cycleActiveWorkflow` helper method

**Workflow Mode Keybindings:**
- `n`: Create a new workflow
- `d` / `Ctrl+D`: Delete active workflow
- `x`: Execute active workflow
- `Tab` / `Shift+Tab`: Cycle between workflows
- `↑/↓` / `Ctrl+n/p`: Navigate workflow list
- `Enter` / `Esc`: Return to Search Mode
- `Ctrl+c`: Exit interactive mode

## Related Issue

Closes #273

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation (README updated).
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Additional Context

This refactoring removes ~80 lines of dead/unused code and makes Workflow Mode behavior more intuitive and consistent.