### PR TITLE
fix: implement Windows pendingInput using GetNumberOfConsoleInputEvents

### DIFF
--- a/internal/termio/pending_windows.go
+++ b/internal/termio/pending_windows.go
@@ -2,7 +2,53 @@
 
 package termio
 
-// pendingInput is a stub on Windows; console APIs require a different strategy.
-func pendingInput(uintptr) (int, error) {
+import (
+	"syscall"
+	"unsafe"
+)
+
+var (
+	kernel32         = syscall.NewLazyDLL("kernel32.dll")
+	peekConsoleInput = kernel32.NewProc("PeekConsoleInputW")
+)
+
+// inputRecord represents a Windows INPUT_RECORD structure.
+// We only need the EventType field to filter for keyboard events.
+type inputRecord struct {
+	EventType uint16
+	_         uint16 // padding
+	Event     [16]byte
+}
+
+// keyEvent is the Windows KEY_EVENT constant.
+const keyEvent = 0x0001
+
+// pendingInput returns whether there are pending keyboard input events on Windows.
+// This uses PeekConsoleInputW to check for KEY_EVENT type events only,
+// filtering out mouse, window resize, and other non-keyboard events.
+func pendingInput(fd uintptr) (int, error) {
+	var inputRecords [16]inputRecord
+	var numEventsRead uint32
+
+	ret, _, err := peekConsoleInput.Call(
+		fd,
+		uintptr(unsafe.Pointer(&inputRecords[0])),
+		uintptr(len(inputRecords)),
+		uintptr(unsafe.Pointer(&numEventsRead)),
+	)
+
+	if ret == 0 {
+		return 0, err
+	}
+
+	// Count only keyboard events.
+	// Return 1 if any keyboard event is found, for consistency with Unix
+	// implementation which also returns 1 (not actual count) when input is available.
+	for i := uint32(0); i < numEventsRead; i++ {
+		if inputRecords[i].EventType == keyEvent {
+			return 1, nil
+		}
+	}
+
 	return 0, nil
 }

--- a/internal/termio/pending_windows_test.go
+++ b/internal/termio/pending_windows_test.go
@@ -2,14 +2,61 @@
 
 package termio
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
 
-func TestPendingInputStub(t *testing.T) {
+func TestPendingInputWindows(t *testing.T) {
+	// Test with an invalid handle - should return error or 0
+	n, err := PendingInput(0)
+	// Invalid handle may return an error or 0, both are acceptable
+	if err != nil {
+		t.Logf("PendingInput with invalid handle returned error (expected): %v", err)
+	} else if n != 0 {
+		t.Logf("PendingInput with invalid handle returned %d", n)
+	}
+}
+
+func TestPendingInputWithStdin(t *testing.T) {
+	// Test with actual stdin handle
+	// Note: This test may behave differently depending on whether
+	// stdin is connected to a console or redirected
+	fd := os.Stdin.Fd()
+	n, err := PendingInput(fd)
+	// We don't assert specific values since behavior depends on console state
+	// Just verify the function doesn't panic
+	t.Logf("PendingInput(stdin): n=%d, err=%v", n, err)
+}
+
+func TestPendingInputHookWithPendingEvents(t *testing.T) {
+	// Test using hook to simulate pending input
+	restore := SetPendingInputFunc(func(fd uintptr) (int, error) {
+		return 1, nil // Simulate pending input
+	})
+	defer restore()
+
 	n, err := PendingInput(0)
 	if err != nil {
-		t.Fatalf("PendingInput returned error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("expected 1 pending event, got %d", n)
+	}
+}
+
+func TestPendingInputHookWithNoPendingEvents(t *testing.T) {
+	// Test using hook to simulate no pending input
+	restore := SetPendingInputFunc(func(fd uintptr) (int, error) {
+		return 0, nil // Simulate no pending input
+	})
+	defer restore()
+
+	n, err := PendingInput(0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 	if n != 0 {
-		t.Fatalf("PendingInput returned %d, want 0", n)
+		t.Errorf("expected 0 pending events, got %d", n)
 	}
 }


### PR DESCRIPTION
## Description of Changes
Replace the stub `pendingInput` implementation on Windows with a proper Windows Console API call using `PeekConsoleInputW`. This fixes escape key handling and escape sequence detection on Windows.

### Changes
- `internal/termio/pending_windows.go`: Implement using `PeekConsoleInputW` from kernel32.dll
- `internal/termio/pending_windows_test.go`: Update tests for the new implementation

### Implementation Details
Uses `PeekConsoleInputW` (Option A from issue) which can filter for `KEY_EVENT` type events only, providing more accurate keyboard input detection compared to `GetNumberOfConsoleInputEvents`.

## Related Issue
close #293

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/bmf-san/ggc/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests
- [ ] I have updated the documentation (if required)
- [x] Code is formatted with `make fmt`
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing
- [ ] If commands were added/modified: I have run `make docs` to update README.md
- [ ] I have run `make demos` to regenerate demo assets (if applicable)

## Screenshots (if appropriate)
N/A - Internal implementation change

## Additional Context
This fixes the following issues on Windows:
- Standalone Escape key now correctly triggers soft cancel
- Arrow keys (ESC[A) now correctly continue reading the escape sequence