### PR TITLE
refactor: replace remaining error output patterns with WriteError (Phase 2)

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -32,12 +32,12 @@ func (a *Adder) Add(args []string) {
 
 	if len(args) == 1 && (args[0] == "interactive" || args[0] == "patch") {
 		if err := a.gitClient.AddInteractive(); err != nil {
-			_, _ = fmt.Fprintf(a.outputWriter, "Error: %v\n", err)
+			WriteError(a.outputWriter, err)
 		}
 		return
 	}
 
 	if err := a.gitClient.Add(args...); err != nil {
-		_, _ = fmt.Fprintf(a.outputWriter, "Error: %v\n", err)
+		WriteError(a.outputWriter, err)
 	}
 }

--- a/cmd/branch.go
+++ b/cmd/branch.go
@@ -70,7 +70,7 @@ func (b *Brancher) handleBranchCommand(cmd string, args []string) {
 func (b *Brancher) handleCurrentBranch() {
 	branch, err := b.gitClient.GetCurrentBranch()
 	if err != nil {
-		_, _ = fmt.Fprintf(b.outputWriter, "Error: %v\n", err)
+		WriteError(b.outputWriter, err)
 		return
 	}
 	_, _ = fmt.Fprintln(b.outputWriter, branch)

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -2,7 +2,6 @@
 package cmd
 
 import (
-	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -49,7 +48,7 @@ func (c *Committer) Commit(args []string) {
 func (c *Committer) handleAllowCommand(args []string) {
 	if len(args) >= 1 && args[0] == "empty" {
 		if err := c.gitClient.CommitAllowEmpty(); err != nil {
-			_, _ = fmt.Fprintf(c.outputWriter, "Error: %v\n", err)
+			WriteError(c.outputWriter, err)
 		}
 		return
 	}
@@ -61,16 +60,16 @@ func (c *Committer) handleAmendCommand(args []string) {
 	switch {
 	case len(args) == 0:
 		if err := c.gitClient.CommitAmend(); err != nil {
-			_, _ = fmt.Fprintf(c.outputWriter, "Error: %v\n", err)
+			WriteError(c.outputWriter, err)
 		}
 	case args[0] == "no-edit":
 		if err := c.gitClient.CommitAmendNoEdit(); err != nil {
-			_, _ = fmt.Fprintf(c.outputWriter, "Error: %v\n", err)
+			WriteError(c.outputWriter, err)
 		}
 	default:
 		msg := strings.Join(args, " ")
 		if err := c.gitClient.CommitAmendWithMessage(msg); err != nil {
-			_, _ = fmt.Fprintf(c.outputWriter, "Error: %v\n", err)
+			WriteError(c.outputWriter, err)
 		}
 	}
 }
@@ -79,6 +78,6 @@ func (c *Committer) handleAmendCommand(args []string) {
 func (c *Committer) handleDefaultCommit(args []string) {
 	msg := strings.Join(args, " ")
 	if err := c.gitClient.Commit(msg); err != nil {
-		_, _ = fmt.Fprintf(c.outputWriter, "Error: %v\n", err)
+		WriteError(c.outputWriter, err)
 	}
 }

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -80,20 +80,20 @@ func (d *Differ) Diff(args []string) {
 		var usageErr *diffUsageError
 		if errors.As(err, &usageErr) {
 			if usageErr.message != "" {
-				_, _ = fmt.Fprintf(d.outputWriter, "Error: %s\n", usageErr.message)
+				WriteErrorf(d.outputWriter, "%s", usageErr.message)
 			}
 			d.helper.ShowDiffHelp()
 			return
 		}
 
-		_, _ = fmt.Fprintf(d.outputWriter, "Error: %v\n", err)
+		WriteError(d.outputWriter, err)
 		return
 	}
 
 	gitArgs := buildDiffArgs(opts)
 	output, err := d.gitClient.DiffWith(gitArgs)
 	if err != nil {
-		_, _ = fmt.Fprintf(d.outputWriter, "Error: %v\n", err)
+		WriteError(d.outputWriter, err)
 		return
 	}
 

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"io"
 	"os"
 
@@ -34,7 +33,7 @@ func (f *Fetcher) Fetch(args []string) {
 	switch args[0] {
 	case "prune":
 		if err := f.gitClient.Fetch(true); err != nil {
-			_, _ = fmt.Fprintf(f.outputWriter, "Error: %v\n", err)
+			WriteError(f.outputWriter, err)
 		}
 	default:
 		f.helper.ShowFetchHelp()

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -36,7 +36,7 @@ func NewHelper(registry ...*commandregistry.Registry) *Helper {
 func (h *Helper) ShowHelp() {
 	helpMsg, err := templates.RenderMainHelp(h.registry)
 	if err != nil {
-		_, _ = fmt.Fprintf(h.outputWriter, "Error: %v\n", err)
+		WriteError(h.outputWriter, err)
 		return
 	}
 	_, _ = fmt.Fprint(h.outputWriter, helpMsg)
@@ -46,7 +46,7 @@ func (h *Helper) ShowHelp() {
 func (h *Helper) ShowCommandHelp(data templates.HelpData) {
 	helpMsg, err := templates.RenderCommandHelp(data)
 	if err != nil {
-		_, _ = fmt.Fprintf(h.outputWriter, "Error: %v\n", err)
+		WriteError(h.outputWriter, err)
 		return
 	}
 	_, _ = fmt.Fprint(h.outputWriter, helpMsg)

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -55,7 +55,7 @@ func (h *Hooker) Hook(args []string) {
 func (h *Hooker) withName(f func(string)) func([]string) {
 	return func(rest []string) {
 		if len(rest) < 1 {
-			_, _ = fmt.Fprintf(h.outputWriter, "Error: hook name required\n")
+			WriteErrorf(h.outputWriter, "hook name required")
 			h.helper.ShowHookHelp()
 			return
 		}

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -2,7 +2,6 @@
 package cmd
 
 import (
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -40,11 +39,11 @@ func (l *Logger) Log(args []string) {
 	switch args[0] {
 	case "simple":
 		if err := l.gitClient.LogSimple(); err != nil {
-			_, _ = fmt.Fprintf(l.outputWriter, "Error: %v\n", err)
+			WriteError(l.outputWriter, err)
 		}
 	case "graph":
 		if err := l.gitClient.LogGraph(); err != nil {
-			_, _ = fmt.Fprintf(l.outputWriter, "Error: %v\n", err)
+			WriteError(l.outputWriter, err)
 		}
 	default:
 		l.helper.ShowLogHelp()

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -2,7 +2,6 @@
 package cmd
 
 import (
-	"fmt"
 	"io"
 	"os"
 
@@ -37,11 +36,11 @@ func (p *Puller) Pull(args []string) {
 	switch args[0] {
 	case "current":
 		if err := p.gitClient.Pull(false); err != nil {
-			_, _ = fmt.Fprintf(p.outputWriter, "Error: %v\n", err)
+			WriteError(p.outputWriter, err)
 		}
 	case "rebase":
 		if err := p.gitClient.Pull(true); err != nil {
-			_, _ = fmt.Fprintf(p.outputWriter, "Error: %v\n", err)
+			WriteError(p.outputWriter, err)
 		}
 	default:
 		p.helper.ShowPullHelp()

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -2,7 +2,6 @@
 package cmd
 
 import (
-	"fmt"
 	"io"
 	"os"
 
@@ -37,11 +36,11 @@ func (p *Pusher) Push(args []string) {
 	switch args[0] {
 	case "current":
 		if err := p.gitClient.Push(false); err != nil {
-			_, _ = fmt.Fprintf(p.outputWriter, "Error: %v\n", err)
+			WriteError(p.outputWriter, err)
 		}
 	case "force":
 		if err := p.gitClient.Push(true); err != nil {
-			_, _ = fmt.Fprintf(p.outputWriter, "Error: %v\n", err)
+			WriteError(p.outputWriter, err)
 		}
 	default:
 		p.helper.ShowPushHelp()

--- a/cmd/remote.go
+++ b/cmd/remote.go
@@ -62,13 +62,13 @@ func (r *Remoter) Remote(args []string) {
 
 func (r *Remoter) remoteList() {
 	if err := r.gitClient.RemoteList(); err != nil {
-		_, _ = fmt.Fprintf(r.outputWriter, "Error: %v\n", err)
+		WriteError(r.outputWriter, err)
 	}
 }
 
 func (r *Remoter) remoteAdd(name, url string) {
 	if err := r.gitClient.RemoteAdd(name, url); err != nil {
-		_, _ = fmt.Fprintf(r.outputWriter, "Error: %v\n", err)
+		WriteError(r.outputWriter, err)
 		return
 	}
 	_, _ = fmt.Fprintf(r.outputWriter, "Remote '%s' added\n", name)
@@ -76,7 +76,7 @@ func (r *Remoter) remoteAdd(name, url string) {
 
 func (r *Remoter) remoteRemove(name string) {
 	if err := r.gitClient.RemoteRemove(name); err != nil {
-		_, _ = fmt.Fprintf(r.outputWriter, "Error: %v\n", err)
+		WriteError(r.outputWriter, err)
 		return
 	}
 	_, _ = fmt.Fprintf(r.outputWriter, "Remote '%s' removed\n", name)
@@ -84,7 +84,7 @@ func (r *Remoter) remoteRemove(name string) {
 
 func (r *Remoter) remoteSetURL(name, url string) {
 	if err := r.gitClient.RemoteSetURL(name, url); err != nil {
-		_, _ = fmt.Fprintf(r.outputWriter, "Error: %v\n", err)
+		WriteError(r.outputWriter, err)
 		return
 	}
 	_, _ = fmt.Fprintf(r.outputWriter, "Remote '%s' URL updated\n", name)

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -31,12 +31,12 @@ func (r *Resetter) Reset(args []string) {
 		// Default: reset to origin
 		branch, err := r.gitClient.GetCurrentBranch()
 		if err != nil {
-			_, _ = fmt.Fprintf(r.outputWriter, "Error: failed to get current branch: %v\n", err)
+			WriteErrorf(r.outputWriter, "failed to get current branch: %v", err)
 			return
 		}
 
 		if err := r.gitClient.ResetHardAndClean(); err != nil {
-			_, _ = fmt.Fprintf(r.outputWriter, "Error: %v\n", err)
+			WriteError(r.outputWriter, err)
 			return
 		}
 		_, _ = fmt.Fprintf(r.outputWriter, "Reset to origin/%s successful\n", branch)
@@ -46,14 +46,14 @@ func (r *Resetter) Reset(args []string) {
 	switch args[0] {
 	case "hard":
 		if len(args) < 2 {
-			_, _ = fmt.Fprintf(r.outputWriter, "Error: commit hash required for hard reset\n")
+			WriteErrorf(r.outputWriter, "commit hash required for hard reset")
 			r.helper.ShowResetHelp()
 			return
 		}
 
 		commit := args[1]
 		if err := r.gitClient.ResetHard(commit); err != nil {
-			_, _ = fmt.Fprintf(r.outputWriter, "Error: %v\n", err)
+			WriteError(r.outputWriter, err)
 			return
 		}
 		_, _ = fmt.Fprintf(r.outputWriter, "Reset to %s successful\n", commit)

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -52,7 +51,7 @@ func (r *Restorer) restoreStaged(paths []string) {
 		return
 	}
 	if err := r.gitClient.RestoreStaged(paths...); err != nil {
-		_, _ = fmt.Fprintf(r.outputWriter, "Error: %v\n", err)
+		WriteError(r.outputWriter, err)
 	}
 }
 
@@ -61,12 +60,12 @@ func (r *Restorer) restoreCommitOrWorking(args []string) {
 		commit := args[0]
 		paths := args[1:]
 		if err := r.gitClient.RestoreFromCommit(commit, paths...); err != nil {
-			_, _ = fmt.Fprintf(r.outputWriter, "Error: %v\n", err)
+			WriteError(r.outputWriter, err)
 		}
 		return
 	}
 	if err := r.gitClient.RestoreWorkingDir(args...); err != nil {
-		_, _ = fmt.Fprintf(r.outputWriter, "Error: %v\n", err)
+		WriteError(r.outputWriter, err)
 	}
 }
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -87,7 +87,7 @@ func (s *Statuser) Status(args []string) {
 		_, _ = fmt.Fprintf(s.outputWriter, "\n")
 
 		if output, err := s.gitClient.StatusWithColor(); err != nil {
-			_, _ = fmt.Fprintf(s.outputWriter, "Error: %v\n", err)
+			WriteError(s.outputWriter, err)
 		} else {
 			_, _ = fmt.Fprint(s.outputWriter, output)
 		}
@@ -97,7 +97,7 @@ func (s *Statuser) Status(args []string) {
 	switch args[0] {
 	case "short":
 		if output, err := s.gitClient.StatusShortWithColor(); err != nil {
-			_, _ = fmt.Fprintf(s.outputWriter, "Error: %v\n", err)
+			WriteError(s.outputWriter, err)
 		} else {
 			_, _ = fmt.Fprint(s.outputWriter, output)
 		}

--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -39,7 +39,7 @@ func NewTagger(client interface {
 func (t *Tagger) Tag(args []string) {
 	if len(args) == 0 {
 		if err := t.gitClient.TagList(nil); err != nil {
-			_, _ = fmt.Fprintf(t.outputWriter, "Error: %v\n", err)
+			WriteError(t.outputWriter, err)
 		}
 		return
 	}
@@ -69,14 +69,14 @@ func (t *Tagger) Tag(args []string) {
 // listTags lists tags with optional pattern matching
 func (t *Tagger) listTags(args []string) {
 	if err := t.gitClient.TagList(args); err != nil {
-		_, _ = fmt.Fprintf(t.outputWriter, "Error: %v\n", err)
+		WriteError(t.outputWriter, err)
 	}
 }
 
 // createTag creates a new tag
 func (t *Tagger) createTag(args []string) {
 	if len(args) == 0 {
-		_, _ = fmt.Fprintf(t.outputWriter, "Error: tag name is required\n")
+		WriteErrorf(t.outputWriter, "tag name is required")
 		return
 	}
 
@@ -85,13 +85,13 @@ func (t *Tagger) createTag(args []string) {
 	if len(args) == 1 {
 		// tag current commit
 		if err := t.gitClient.TagCreate(tagName, ""); err != nil {
-			_, _ = fmt.Fprintf(t.outputWriter, "Error: %v\n", err)
+			WriteError(t.outputWriter, err)
 			return
 		}
 	} else {
 		// tag specific commit
 		if err := t.gitClient.TagCreate(tagName, args[1]); err != nil {
-			_, _ = fmt.Fprintf(t.outputWriter, "Error: %v\n", err)
+			WriteError(t.outputWriter, err)
 			return
 		}
 	}
@@ -102,12 +102,12 @@ func (t *Tagger) createTag(args []string) {
 // deleteTags deletes one or more tags
 func (t *Tagger) deleteTags(args []string) {
 	if len(args) == 0 {
-		_, _ = fmt.Fprintf(t.outputWriter, "Error: at least one tag name is required\n")
+		WriteErrorf(t.outputWriter, "at least one tag name is required")
 		return
 	}
 
 	if err := t.gitClient.TagDelete(args); err != nil {
-		_, _ = fmt.Fprintf(t.outputWriter, "Error: %v\n", err)
+		WriteError(t.outputWriter, err)
 		return
 	}
 
@@ -127,7 +127,7 @@ func (t *Tagger) pushTags(args []string) {
 	if len(args) == 0 {
 		// push all tags
 		if err := t.gitClient.TagPushAll(remote); err != nil {
-			_, _ = fmt.Fprintf(t.outputWriter, "Error: %v\n", err)
+			WriteError(t.outputWriter, err)
 			return
 		}
 		_, _ = fmt.Fprintf(t.outputWriter, "All tags pushed to %s\n", remote)
@@ -141,14 +141,14 @@ func (t *Tagger) pushTags(args []string) {
 			// git-compatible ordering: remote first, tag second
 			candidate := strings.TrimSpace(args[0])
 			if candidate == "" {
-				_, _ = fmt.Fprintf(t.outputWriter, "Error: remote name cannot be empty or whitespace\n")
+				WriteErrorf(t.outputWriter, "remote name cannot be empty or whitespace")
 				return
 			}
 			remote = candidate
 			tagName = args[1]
 		}
 		if err := t.gitClient.TagPush(remote, tagName); err != nil {
-			_, _ = fmt.Fprintf(t.outputWriter, "Error: %v\n", err)
+			WriteError(t.outputWriter, err)
 			return
 		}
 		_, _ = fmt.Fprintf(t.outputWriter, "Tag '%s' pushed to %s\n", tagName, remote)
@@ -158,13 +158,13 @@ func (t *Tagger) pushTags(args []string) {
 // showTag shows information about a tag
 func (t *Tagger) showTag(args []string) {
 	if len(args) == 0 {
-		_, _ = fmt.Fprintf(t.outputWriter, "Error: tag name is required\n")
+		WriteErrorf(t.outputWriter, "tag name is required")
 		return
 	}
 
 	tagName := args[0]
 	if err := t.gitClient.TagShow(tagName); err != nil {
-		_, _ = fmt.Fprintf(t.outputWriter, "Error: %v\n", err)
+		WriteError(t.outputWriter, err)
 	}
 }
 
@@ -186,7 +186,7 @@ func (t *Tagger) GetTagCommit(tagName string) (string, error) {
 // CreateAnnotatedTag creates an annotated tag
 func (t *Tagger) CreateAnnotatedTag(args []string) {
 	if len(args) == 0 {
-		_, _ = fmt.Fprintf(t.outputWriter, "Error: tag name is required\n")
+		WriteErrorf(t.outputWriter, "tag name is required")
 		return
 	}
 
@@ -195,13 +195,13 @@ func (t *Tagger) CreateAnnotatedTag(args []string) {
 		// Use provided message
 		message := strings.Join(args[1:], " ")
 		if err := t.gitClient.TagCreateAnnotated(tagName, message); err != nil {
-			_, _ = fmt.Fprintf(t.outputWriter, "Error: %v\n", err)
+			WriteError(t.outputWriter, err)
 			return
 		}
 	} else {
 		// Open editor for message
 		if err := t.gitClient.TagCreateAnnotated(tagName, ""); err != nil {
-			_, _ = fmt.Fprintf(t.outputWriter, "Error: %v\n", err)
+			WriteError(t.outputWriter, err)
 			return
 		}
 	}


### PR DESCRIPTION
## Description of Changes
Apply `WriteError` helper function to remaining 15 cmd/*.go files and remove unused `fmt` imports where applicable.

This is a continuation of #330 (Phase 1).

**Modified files:**
- add.go, branch.go, commit.go, diff.go, fetch.go
- help.go, hook.go, log.go, pull.go, push.go
- remote.go, reset.go, restore.go, status.go, tag.go

## Related Issue
Related to #330

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/bmf-san/ggc/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests
- [x] I have updated the documentation (if required)
- [x] Code is formatted with `make fmt`
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing
- [ ] If commands were added/modified: I have run `make docs` to update README.md
- [ ] I have run `make demos` to regenerate demo assets (if applicable)

## Screenshots (if appropriate)
N/A - refactoring only

## Additional Context
No new commands or features added. This is a pure refactoring to reduce code duplication by using the `WriteError` helper function introduced in #330.