### PR TITLE
[bug] prevent config overwrite on malformed yaml

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -60,6 +60,8 @@ func (v *Versioner) displayVersionInfo() {
 	if loadErr == nil {
 		v.ensureCreatedAtSet(configManager, loadedConfig)
 		v.updateVersionInfoFromBuild(configManager, loadedConfig)
+	} else {
+		_, _ = fmt.Fprintf(v.outputWriter, "failed to load config: %v\n", loadErr)
 	}
 	v.printVersionInfo(loadedConfig)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -724,8 +724,13 @@ func TestLoadConfigDoesNotOverwriteMalformedFile(t *testing.T) {
 	}()
 
 	cm := NewConfigManager(testutil.NewMockGitClient())
-	cm.gitClient = testutil.NewMockGitClient()
-	cm.LoadConfig()
+	err := cm.LoadConfig()
+	if err == nil {
+		t.Fatal("expected LoadConfig to fail for malformed YAML")
+	}
+	if cm.configPath != configPath {
+		t.Fatalf("expected configPath %q, got %q", configPath, cm.configPath)
+	}
 
 	got, err := os.ReadFile(configPath)
 	if err != nil {


### PR DESCRIPTION
## Summary
This change fixes a startup data-loss bug where a malformed `~/.ggcconfig.yaml` could be silently replaced by a generated default config.

## Issue Being Solved
When users had invalid YAML in their existing config file, running startup paths (including `ggc version`) printed a load error but still wrote a fresh config file. That destroyed the original malformed file contents.

## Cause and Effect on Users
- Cause: startup code path called `LoadConfig()` and always executed `Save()` even if parsing failed.
- Effect: user-managed config content was overwritten after a parse failure, making recovery/debugging harder.

## Root Cause
Two write paths were active after parse failure:
1. `pkg/config.Manager.LoadConfig()` called `Save()` unconditionally.
2. `cmd/version` continued metadata updates (`Set`) after failed load, which also persisted defaults.

## Fix Implemented
- Changed `LoadConfig()` to return an error and short-circuit on load failure so no save occurs.
- Updated `cmd/version` to skip metadata write-backs (`created-at`, build info updates) unless config load succeeds.
- Added a regression test to ensure malformed config files are preserved.

## Validation
- Reproduced original bug with malformed YAML config under temporary `HOME`.
- Confirmed stderr still reports parse failure.
- Confirmed config file remains unchanged after `go run . version`.
- Ran tests:
  - `go test ./pkg/config ./cmd -run 'TestLoadConfigDoesNotOverwriteMalformedFile|TestVersioner_Version|TestLoadConfig|TestManagerLoadConfig'`
  - `go test ./...`
