### PR TITLE
ci: add semantic-pr, auto-assign, and labeler workflows

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,6 @@
+# Configuration for kentaro-m/auto-assign-action
+# Automatically assigns the PR author as the assignee.
+addAssignees: author
+
+# Reviewers are not auto-assigned for this repository.
+addReviewers: false

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,25 @@
+# Configuration for actions/labeler
+# Automatically applies labels to pull requests based on changed file paths.
+# Only labels that already exist in this repository are declared here so that
+# `sync-labels: true` never fails trying to add a missing label.
+# Note: `dependencies` is intentionally omitted because Dependabot attaches it directly.
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - docs/**
+          - "**/*.md"
+          - README*
+          - LICENSE
+
+github-actions:
+  - changed-files:
+      - any-glob-to-any-file:
+          - .github/**
+
+go:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.go"
+          - go.mod
+          - go.sum

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -15,6 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Auto-assign author
-        uses: kentaro-m/auto-assign-action@v2.0.2
+        uses: kentaro-m/auto-assign-action@5c20d0d7e4b0b7ea09852ffb62a1c1d5eee93d9f # v2.0.2
         with:
           configuration-path: .github/auto_assign.yml

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,20 @@
+name: Auto Assign
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  auto-assign:
+    name: Auto-assign PR author
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-assign author
+        uses: kentaro-m/auto-assign-action@v2.0.2
+        with:
+          configuration-path: .github/auto_assign.yml

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -15,6 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Auto-assign author
-        uses: kentaro-m/auto-assign-action@5c20d0d7e4b0b7ea09852ffb62a1c1d5eee93d9f # v2.0.2
+        uses: kentaro-m/auto-assign-action@0a2c53d3721e4c5cfcce6afd4014aecc337979f6 # v2.0.2
         with:
           configuration-path: .github/auto_assign.yml

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Apply labels based on changed files
-        uses: actions/labeler@v6
+        uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,21 @@
+name: Labeler
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: Auto-label PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply labels based on changed files
+        uses: actions/labeler@v6
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: true

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,0 +1,40 @@
+name: Semantic Pull Request
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate PR title (Conventional Commits)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title
+        uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            must start with a lowercase character.

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR title
-        uses: amannn/action-semantic-pull-request@v6
+        uses: amannn/action-semantic-pull-request@<FULL_LENGTH_COMMIT_SHA>
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -34,7 +34,7 @@ jobs:
             chore
             revert
           requireScope: false
-          subjectPattern: ^(?![A-Z]).+$
+          subjectPattern: ^[a-z].*$
           subjectPatternError: |
             The subject "{subject}" found in the pull request title "{title}"
             must start with a lowercase character.

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR title
-        uses: amannn/action-semantic-pull-request@<FULL_LENGTH_COMMIT_SHA>
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Ports three GitHub workflows from [`bmf-san/gohan`](https://github.com/bmf-san/gohan) to this repo.

## Workflows added

### 1. `semantic-pr.yml`
Validates that PR titles follow [Conventional Commits](https://www.conventionalcommits.org/) using [`amannn/action-semantic-pull-request`](https://github.com/amannn/action-semantic-pull-request).
- Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
- Scope is optional
- Subject must start with a lowercase character

### 2. `auto-assign.yml`
Automatically assigns the PR author as assignee on `opened` / `reopened` / `ready_for_review` via [`kentaro-m/auto-assign-action`](https://github.com/kentaro-m/auto-assign-action). Reviewers are not auto-assigned. Config: `.github/auto_assign.yml`.

### 3. `labeler.yml`
Auto-applies labels based on changed files via [`actions/labeler@v6`](https://github.com/actions/labeler). Config: `.github/labeler.yml`.

Scoped to labels that **already exist** in this repository so that `sync-labels: true` does not fail:

| label | paths |
|---|---|
| `documentation` | `docs/**`, `**/*.md`, `README*`, `LICENSE` |
| `github-actions` | `.github/**` |
| `go` | `**/*.go`, `go.mod`, `go.sum` |

`dependencies` is intentionally omitted — Dependabot attaches it directly.

## Permissions
All three workflows use `pull_request_target` with narrowly-scoped permissions (`pull-requests: write` for labeler / auto-assign, `pull-requests: read` for semantic-pr) — no checkout of untrusted code.

## Follow-up (optional)
If we want more granular labels (`test`, `cli`, `interactive`, `config`, `git`, `ci`), those labels need to be created in the repo first, then added to `.github/labeler.yml`.
