### PR TITLE
ci(fuzz): cache corpus across runs, lengthen nightly, archive failing seeds

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -32,9 +32,33 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.0.0
         with:
           go-version: '1.25.0'
+      - name: Restore fuzz corpus cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.0
+        with:
+          path: ~/.cache/go-build/fuzz
+          key: fuzz-corpus-${{ matrix.target.fuzz }}-${{ github.run_id }}
+          restore-keys: |
+            fuzz-corpus-${{ matrix.target.fuzz }}-
+      - name: Pick fuzztime
+        id: t
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "fuzztime=60s" >> "$GITHUB_OUTPUT"
+          else
+            echo "fuzztime=300s" >> "$GITHUB_OUTPUT"
+          fi
       - name: Run ${{ matrix.target.fuzz }}
         run: |
           go test ${{ matrix.target.path }} \
             -run='^$' \
             -fuzz='^${{ matrix.target.fuzz }}$' \
-            -fuzztime=60s
+            -fuzztime=${{ steps.t.outputs.fuzztime }}
+      - name: Upload fuzz failure corpus
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: fuzz-failure-${{ matrix.target.fuzz }}
+          path: |
+            **/testdata/fuzz/**
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -36,8 +36,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.0
         with:
           path: ~/.cache/go-build/fuzz
-          key: fuzz-corpus-${{ matrix.target.fuzz }}-${{ github.run_id }}
+          key: fuzz-corpus-${{ matrix.target.fuzz }}-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
+            fuzz-corpus-${{ matrix.target.fuzz }}-${{ runner.os }}-
             fuzz-corpus-${{ matrix.target.fuzz }}-
       - name: Pick fuzztime
         id: t


### PR DESCRIPTION
Follow-up to #387. Makes the fuzz workflow actually useful as a regression detector.

## What

- **Cache the corpus** (`actions/cache` on `~/.cache/go-build/fuzz`) keyed by fuzz target. Interesting inputs that Go's fuzzer saves are no longer thrown away at end of job, so coverage improves monotonically across runs.
- **Pick fuzztime by event**: PRs stay at 60s for fast feedback; scheduled / manual runs bump to 300s to exercise more input.
- **Upload crash seeds on failure** (`actions/upload-artifact`, 14-day retention) so any future regression can be downloaded and committed into `testdata/fuzz/<FuzzName>/` as a permanent corpus entry.

## Why this matters

A fuzzer without corpus persistence effectively restarts from seeds every run, so 60s of runtime rediscovers the same trivial cases. With caching, each run builds on the last.

## Validation

Workflow syntax is unchanged except for additive steps; existing jobs still run identically on PR. The new `Upload fuzz failure corpus` step is `if: failure()` gated, so it only runs on crash.