### PR TITLE
build(release): add macOS universal binary via goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,6 +37,15 @@ archives:
       - LICENSE
       - README.md
 
+universal_binaries:
+  - id: ggc-universal
+    ids: [ggc]
+    name_template: "ggc"
+    # Keep the per-arch Darwin archives as well so existing download links
+    # and any downstream automation continues to work; homebrew-core picks
+    # up whichever archive matches the runner arch.
+    replace: false
+
 checksum:
   name_template: "checksums.txt"
 


### PR DESCRIPTION
## What

Adds a macOS **universal binary** (amd64 + arm64 fat binary via `lipo`) to goreleaser output.

## Why

Users who download from Releases manually currently have to know whether their Mac is Intel or Apple Silicon. A universal `ggc_X.Y.Z_darwin_all.tar.gz` runs on both, and `brew install ggc` (homebrew-core) keeps using the per-arch bottle that already exists.

## Config

```yaml
universal_binaries:
  - id: ggc-universal
    ids: [ggc]
    name_template: "ggc"
    replace: false
```

`replace: false` keeps the separate `_darwin_amd64` / `_darwin_arm64` archives so nothing downstream breaks.

## Validation

- `goreleaser check` → passes.
- Dry-run workflow (`release-dry-run.yml`) will verify the actual build on this PR.