### PR TITLE
feat(doctor): add 'ggc doctor' environment diagnostic command

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ ggc
 | `debug-keys` | Show current keybindings |
 | `debug-keys raw` | Capture key sequences interactively |
 | `debug-keys raw <file>` | Capture key sequences and save them to a file |
+| `doctor` | Diagnose the local ggc installation |
 | `quit` | Exit interactive mode |
 | `version` | Display current ggc version |
 ### Unified Syntax and "--" Separator

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -49,6 +49,7 @@ type Cmd struct {
 	fetcher       *Fetcher
 	cmdRouter     *commandRouter
 	debugger      *Debugger
+	doctor        *Doctor
 }
 
 // GitDeps is a composite for wiring commands that depend on git operations.
@@ -126,6 +127,7 @@ func NewCmd(client GitDeps, cm *config.Manager) (*Cmd, error) {
 		differ:        NewDiffer(client),
 		restorer:      NewRestorer(client),
 		fetcher:       NewFetcher(client),
+		doctor:        NewDoctor(),
 		debugger:      NewDebugger(),
 	}
 	router, err := newCommandRouter(cmd)

--- a/cmd/command/utility.go
+++ b/cmd/command/utility.go
@@ -13,6 +13,15 @@ func utility() []Info {
 			},
 		},
 		{
+			Name:     "doctor",
+			Category: CategoryUtility,
+			Summary:  "Diagnose the local ggc installation",
+			Usage:    []string{"ggc doctor"},
+			Examples: []string{
+				"ggc doctor   # Check git binary, config, shell completions, TTY, etc.",
+			},
+		},
+		{
 			Name:     "debug-keys",
 			Category: CategoryUtility,
 			Summary:  "Debug keybinding issues and capture raw key sequences",

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 
 	"github.com/bmf-san/ggc/v8/internal/config"
+
+	"go.yaml.in/yaml/v3"
 )
 
 // Doctor inspects the local environment and reports anything that could
@@ -46,6 +48,9 @@ type diagResult struct {
 // Doctor runs diagnostics. Any arg prints help (stub for future --json etc).
 func (d *Doctor) Doctor(args []string) {
 	if len(args) > 0 {
+		// Keep the helper's writer in sync so callers/tests that redirect
+		// d.outputWriter see the help output too.
+		d.helper.outputWriter = d.outputWriter
 		d.helper.ShowDoctorHelp()
 		return
 	}
@@ -97,7 +102,9 @@ func (d *Doctor) checkGitBinary() diagResult {
 	if err != nil {
 		return diagResult{name: "git binary", ok: false, detail: "'git' not found on PATH"}
 	}
-	out, err := d.execCommand("git", "--version").Output()
+	// Invoke the resolved path so the reported binary is exactly the one
+	// we measured, even if PATH changes between LookPath and exec.
+	out, err := d.execCommand(path, "--version").Output()
 	if err != nil {
 		return diagResult{name: "git binary", ok: false, detail: fmt.Sprintf("%s: %v", path, err)}
 	}
@@ -135,11 +142,27 @@ func (d *Doctor) checkGgcConfig() diagResult {
 			detail: fmt.Sprintf("no config yet (defaults in use; will be created at %s)", paths[0]),
 		}
 	}
-	m := config.NewConfigManager(nil)
-	if err := m.Load(); err != nil {
+	// Parse the YAML directly: config.NewConfigManager requires a non-nil
+	// git.ConfigOps (getDefaultConfig calls methods on it), and the doctor
+	// runs at diagnose time without that dependency wired in. We only need
+	// to know whether the file is a syntactically valid ggc config.
+	if err := parseConfigFile(found); err != nil {
 		return diagResult{name: "ggc config", ok: false, detail: fmt.Sprintf("%s: %v", found, err)}
 	}
 	return diagResult{name: "ggc config", ok: true, detail: fmt.Sprintf("%s loaded", found)}
+}
+
+// parseConfigFile validates that the given path is a YAML file that matches
+// the ggc config schema. It does not apply defaults or perform any git
+// lookups, which makes it safe to call from the doctor without wiring up a
+// full config.Manager.
+func parseConfigFile(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	var cfg config.Config
+	return yaml.Unmarshal(data, &cfg)
 }
 
 // checkCompletions looks for an installed completion script in well-known

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -1,0 +1,197 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/bmf-san/ggc/v8/internal/config"
+)
+
+// Doctor inspects the local environment and reports anything that could
+// prevent ggc from working correctly.
+type Doctor struct {
+	outputWriter io.Writer
+	helper       *Helper
+	execCommand  func(string, ...string) *exec.Cmd
+	lookPath     func(string) (string, error)
+	userHomeDir  func() (string, error)
+	stdinStat    func() (os.FileInfo, error)
+}
+
+// NewDoctor creates a new Doctor instance.
+func NewDoctor() *Doctor {
+	return &Doctor{
+		outputWriter: os.Stdout,
+		helper:       NewHelper(),
+		execCommand:  exec.Command,
+		lookPath:     exec.LookPath,
+		userHomeDir:  os.UserHomeDir,
+		stdinStat:    func() (os.FileInfo, error) { return os.Stdin.Stat() },
+	}
+}
+
+// diagResult captures one check's outcome.
+type diagResult struct {
+	name   string
+	ok     bool
+	warn   bool
+	detail string
+}
+
+// Doctor runs diagnostics. Any arg prints help (stub for future --json etc).
+func (d *Doctor) Doctor(args []string) {
+	if len(args) > 0 {
+		d.helper.ShowDoctorHelp()
+		return
+	}
+	results := []diagResult{
+		d.checkGoRuntime(),
+		d.checkGitBinary(),
+		d.checkGgcConfig(),
+		d.checkCompletions("bash"),
+		d.checkCompletions("zsh"),
+		d.checkTTY(),
+	}
+	d.printReport(results)
+}
+
+func (d *Doctor) printReport(results []diagResult) {
+	hardFailures := 0
+	for _, r := range results {
+		prefix := "OK  "
+		switch {
+		case !r.ok && r.warn:
+			prefix = "WARN"
+		case !r.ok:
+			prefix = "FAIL"
+			hardFailures++
+		}
+		if r.detail == "" {
+			_, _ = fmt.Fprintf(d.outputWriter, "[%s] %s\n", prefix, r.name)
+		} else {
+			_, _ = fmt.Fprintf(d.outputWriter, "[%s] %s: %s\n", prefix, r.name, r.detail)
+		}
+	}
+	if hardFailures > 0 {
+		_, _ = fmt.Fprintf(d.outputWriter, "\n%d hard failure(s). ggc may not work correctly.\n", hardFailures)
+	} else {
+		_, _ = fmt.Fprintln(d.outputWriter, "\nEverything looks good.")
+	}
+}
+
+func (d *Doctor) checkGoRuntime() diagResult {
+	return diagResult{
+		name:   "Go runtime",
+		ok:     true,
+		detail: fmt.Sprintf("%s (%s/%s)", runtime.Version(), runtime.GOOS, runtime.GOARCH),
+	}
+}
+
+func (d *Doctor) checkGitBinary() diagResult {
+	path, err := d.lookPath("git")
+	if err != nil {
+		return diagResult{name: "git binary", ok: false, detail: "'git' not found on PATH"}
+	}
+	out, err := d.execCommand("git", "--version").Output()
+	if err != nil {
+		return diagResult{name: "git binary", ok: false, detail: fmt.Sprintf("%s: %v", path, err)}
+	}
+	return diagResult{name: "git binary", ok: true, detail: fmt.Sprintf("%s (%s)", path, strings.TrimSpace(string(out)))}
+}
+
+// configCandidatePaths mirrors (manager).getConfigPaths without exposing it.
+func (d *Doctor) configCandidatePaths() []string {
+	home, err := d.userHomeDir()
+	if err != nil {
+		return nil
+	}
+	return []string{
+		filepath.Join(home, ".ggcconfig.yaml"),
+		filepath.Join(home, ".config", "ggc", "config.yaml"),
+	}
+}
+
+func (d *Doctor) checkGgcConfig() diagResult {
+	paths := d.configCandidatePaths()
+	if len(paths) == 0 {
+		return diagResult{name: "ggc config", ok: false, warn: true, detail: "cannot resolve $HOME"}
+	}
+	var found string
+	for _, p := range paths {
+		if _, err := os.Stat(p); err == nil {
+			found = p
+			break
+		}
+	}
+	if found == "" {
+		return diagResult{
+			name:   "ggc config",
+			ok:     true,
+			detail: fmt.Sprintf("no config yet (defaults in use; will be created at %s)", paths[0]),
+		}
+	}
+	m := config.NewConfigManager(nil)
+	if err := m.Load(); err != nil {
+		return diagResult{name: "ggc config", ok: false, detail: fmt.Sprintf("%s: %v", found, err)}
+	}
+	return diagResult{name: "ggc config", ok: true, detail: fmt.Sprintf("%s loaded", found)}
+}
+
+// checkCompletions looks for an installed completion script in well-known
+// locations. Missing is WARN, not FAIL: ggc works without shell completion.
+func (d *Doctor) checkCompletions(shell string) diagResult {
+	home, err := d.userHomeDir()
+	if err != nil {
+		return diagResult{name: shell + " completions", ok: false, warn: true, detail: fmt.Sprintf("cannot resolve $HOME: %v", err)}
+	}
+	var candidates []string
+	switch shell {
+	case "bash":
+		candidates = []string{
+			"/etc/bash_completion.d/ggc",
+			"/usr/local/etc/bash_completion.d/ggc",
+			"/opt/homebrew/etc/bash_completion.d/ggc",
+			filepath.Join(home, ".local/share/bash-completion/completions/ggc"),
+		}
+	case "zsh":
+		candidates = []string{
+			"/usr/share/zsh/site-functions/_ggc",
+			"/usr/local/share/zsh/site-functions/_ggc",
+			"/opt/homebrew/share/zsh/site-functions/_ggc",
+			filepath.Join(home, ".zsh/completions/_ggc"),
+		}
+	default:
+		return diagResult{name: shell + " completions", ok: true}
+	}
+	for _, c := range candidates {
+		if _, err := os.Stat(c); err == nil {
+			return diagResult{name: shell + " completions", ok: true, detail: c}
+		}
+	}
+	return diagResult{
+		name:   shell + " completions",
+		ok:     false,
+		warn:   true,
+		detail: "not installed in a well-known location (see tools/completions/ in the repo)",
+	}
+}
+
+func (d *Doctor) checkTTY() diagResult {
+	fi, err := d.stdinStat()
+	if err != nil {
+		return diagResult{name: "stdin TTY", ok: false, warn: true, detail: err.Error()}
+	}
+	if fi.Mode()&os.ModeCharDevice == 0 {
+		return diagResult{
+			name:   "stdin TTY",
+			ok:     true,
+			detail: "stdin is not a TTY; interactive mode and `debug-keys raw` will not work in this shell",
+		}
+	}
+	return diagResult{name: "stdin TTY", ok: true, detail: "stdin is a TTY"}
+}

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func newTestDoctor(out *bytes.Buffer) *Doctor {
+	d := NewDoctor()
+	d.outputWriter = out
+	return d
+}
+
+func TestDoctor_GoRuntime_AlwaysOK(t *testing.T) {
+	d := newTestDoctor(&bytes.Buffer{})
+	r := d.checkGoRuntime()
+	if !r.ok {
+		t.Fatalf("Go runtime check should always be OK, got %+v", r)
+	}
+	if r.detail == "" {
+		t.Fatal("Go runtime detail should not be empty")
+	}
+}
+
+func TestDoctor_GitBinary_NotFound(t *testing.T) {
+	d := newTestDoctor(&bytes.Buffer{})
+	d.lookPath = func(string) (string, error) { return "", errors.New("not found") }
+	r := d.checkGitBinary()
+	if r.ok || !strings.Contains(r.detail, "not found") {
+		t.Fatalf("want not-OK with 'not found', got %+v", r)
+	}
+}
+
+func TestDoctor_GitBinary_Works(t *testing.T) {
+	d := newTestDoctor(&bytes.Buffer{})
+	d.lookPath = func(string) (string, error) { return "/usr/bin/git", nil }
+	// Spawn a command that prints a predictable line and succeeds.
+	d.execCommand = func(_ string, _ ...string) *exec.Cmd {
+		return exec.Command("echo", "git version 2.99.9")
+	}
+	r := d.checkGitBinary()
+	if !r.ok || !strings.Contains(r.detail, "2.99.9") {
+		t.Fatalf("want OK with version, got %+v", r)
+	}
+}
+
+func TestDoctor_Config_NoFile(t *testing.T) {
+	tmp := t.TempDir()
+	d := newTestDoctor(&bytes.Buffer{})
+	d.userHomeDir = func() (string, error) { return tmp, nil }
+	r := d.checkGgcConfig()
+	if !r.ok {
+		t.Fatalf("missing config should be OK (defaults), got %+v", r)
+	}
+	if !strings.Contains(r.detail, "no config yet") {
+		t.Fatalf("unexpected detail: %s", r.detail)
+	}
+}
+
+func TestDoctor_Completions_MissingIsWarn(t *testing.T) {
+	tmp := t.TempDir()
+	d := newTestDoctor(&bytes.Buffer{})
+	d.userHomeDir = func() (string, error) { return tmp, nil }
+	r := d.checkCompletions("zsh")
+	// Missing completion is WARN (not a hard failure).
+	if r.ok || !r.warn {
+		t.Fatalf("missing completions should be WARN, got %+v", r)
+	}
+}
+
+func TestDoctor_TTY_NonTTY(t *testing.T) {
+	d := newTestDoctor(&bytes.Buffer{})
+	// A regular file stat has no ModeCharDevice.
+	f, err := os.CreateTemp(t.TempDir(), "stdin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	d.stdinStat = func() (os.FileInfo, error) { return os.Stat(f.Name()) }
+	r := d.checkTTY()
+	if !r.ok || !strings.Contains(r.detail, "not a TTY") {
+		t.Fatalf("want OK with 'not a TTY', got %+v", r)
+	}
+}
+
+func TestDoctor_FullReport_NoHardFailures(t *testing.T) {
+	var buf bytes.Buffer
+	d := newTestDoctor(&buf)
+	tmp := t.TempDir()
+	d.userHomeDir = func() (string, error) { return tmp, nil }
+	d.lookPath = func(string) (string, error) { return "/usr/bin/git", nil }
+	d.execCommand = func(_ string, _ ...string) *exec.Cmd {
+		return exec.Command("echo", "git version 2.99.9")
+	}
+	// Pipe-like stat (non-TTY is not a failure).
+	f, _ := os.CreateTemp(tmp, "stdin")
+	defer f.Close()
+	d.stdinStat = func() (os.FileInfo, error) { return os.Stat(f.Name()) }
+
+	d.Doctor(nil)
+	out := buf.String()
+	if strings.Contains(out, "hard failure") {
+		t.Fatalf("should not report hard failures, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Everything looks good.") {
+		t.Fatalf("expected success footer, got:\n%s", out)
+	}
+}

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -79,7 +79,7 @@ func TestDoctor_TTY_NonTTY(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	d.stdinStat = func() (os.FileInfo, error) { return os.Stat(f.Name()) }
 	r := d.checkTTY()
 	if !r.ok || !strings.Contains(r.detail, "not a TTY") {
@@ -98,7 +98,7 @@ func TestDoctor_FullReport_NoHardFailures(t *testing.T) {
 	}
 	// Pipe-like stat (non-TTY is not a failure).
 	f, _ := os.CreateTemp(tmp, "stdin")
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	d.stdinStat = func() (os.FileInfo, error) { return os.Stat(f.Name()) }
 
 	d.Doctor(nil)

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -58,6 +59,42 @@ func TestDoctor_Config_NoFile(t *testing.T) {
 	}
 	if !strings.Contains(r.detail, "no config yet") {
 		t.Fatalf("unexpected detail: %s", r.detail)
+	}
+}
+
+func TestDoctor_Config_ValidFileLoads(t *testing.T) {
+	tmp := t.TempDir()
+	// Exercise the ~/.ggcconfig.yaml candidate.
+	path := filepath.Join(tmp, ".ggcconfig.yaml")
+	if err := os.WriteFile(path, []byte("meta:\n  version: v8.0.0\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	d := newTestDoctor(&bytes.Buffer{})
+	d.userHomeDir = func() (string, error) { return tmp, nil }
+	r := d.checkGgcConfig()
+	if !r.ok {
+		t.Fatalf("valid config should be OK, got %+v", r)
+	}
+	if !strings.Contains(r.detail, "loaded") {
+		t.Fatalf("detail should mention loaded, got %q", r.detail)
+	}
+}
+
+func TestDoctor_Config_InvalidYAMLFails(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, ".ggcconfig.yaml")
+	// Emit YAML that the parser rejects outright.
+	if err := os.WriteFile(path, []byte("meta: [this is not a map\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	d := newTestDoctor(&bytes.Buffer{})
+	d.userHomeDir = func() (string, error) { return tmp, nil }
+	r := d.checkGgcConfig()
+	if r.ok {
+		t.Fatalf("malformed config should be FAIL, got %+v", r)
+	}
+	if !strings.Contains(r.detail, path) {
+		t.Fatalf("detail should mention the failing path, got %q", r.detail)
 	}
 }
 

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -256,6 +256,11 @@ func (h *Helper) ShowVersionHelp() {
 	h.renderCommandFromRegistry("version", nil, "Show current ggc version")
 }
 
+// ShowDoctorHelp shows help message for Doctor command.
+func (h *Helper) ShowDoctorHelp() {
+	h.renderCommandFromRegistry("doctor", nil, "Diagnose the local ggc installation")
+}
+
 // ShowRebaseHelp shows help message for rebase command.
 func (h *Helper) ShowRebaseHelp() {
 	h.renderCommandFromRegistry("rebase", []string{"ggc rebase [interactive | <upstream> | continue | abort | skip]"}, "Rebase current branch onto another branch; supports interactive and common workflows")

--- a/cmd/router.go
+++ b/cmd/router.go
@@ -46,6 +46,7 @@ func newCommandRouter(cmd *Cmd) (*commandRouter, error) {
 		"fetch":      func(args []string) { cmd.Fetch(args) },
 		"diff":       func(args []string) { cmd.Diff(args) },
 		"restore":    func(args []string) { cmd.Restore(args) },
+		"doctor":     func(args []string) { cmd.doctor.Doctor(args) },
 		"debug-keys": func(args []string) { cmd.DebugKeys(args) },
 		interactiveQuitCommand: func([]string) {
 			_, _ = fmt.Fprintln(cmd.outputWriter, "The 'quit' command is only available in interactive mode.")

--- a/tools/completions/ggc.bash
+++ b/tools/completions/ggc.bash
@@ -8,7 +8,7 @@ _ggc()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    opts="add branch clean commit config debug-keys diff fetch help hook log pull push quit rebase remote reset restore stash status tag version"
+    opts="add branch clean commit config debug-keys diff doctor fetch help hook log pull push quit rebase remote reset restore stash status tag version"
     case ${prev} in
         branch)
             subopts="checkout contains create current delete info list move rename set sort"

--- a/tools/completions/ggc.fish
+++ b/tools/completions/ggc.fish
@@ -10,7 +10,7 @@ function __ggc_complete_files
 end
 
 # Main commands
-complete -c ggc -f -a "add branch clean commit config debug-keys diff fetch help hook log pull push quit rebase remote reset restore stash status tag version"
+complete -c ggc -f -a "add branch clean commit config debug-keys diff doctor fetch help hook log pull push quit rebase remote reset restore stash status tag version"
 complete -c ggc -f -n "__fish_seen_subcommand_from branch" -a "checkout contains create current delete info list move rename set sort"
 complete -c ggc -f -n "__fish_seen_subcommand_from branch; and __fish_seen_subcommand_from delete" -a "merged"
 complete -c ggc -f -n "__fish_seen_subcommand_from branch; and __fish_seen_subcommand_from list" -a "local remote verbose"

--- a/tools/completions/ggc.zsh
+++ b/tools/completions/ggc.zsh
@@ -84,6 +84,7 @@ _ggc_commands() {
         'config:Get and set ggc configuration'
         'debug-keys:Debug keybinding issues and capture raw key sequences'
         'diff:Inspect changes between commits, the index, and the working tree'
+        'doctor:Diagnose the local ggc installation'
         'fetch:Download objects and refs from remotes'
         'help:Show help information for commands'
         'hook:Manage Git hooks'


### PR DESCRIPTION
## What

Adds `ggc doctor`: a single command that prints a checklist of everything that has to be right for ggc to work on the user's machine.

```
[OK  ] Go runtime: go1.25.0 (darwin/arm64)
[OK  ] git binary: /usr/bin/git (git version 2.46.0)
[OK  ] ggc config: /Users/you/.config/ggc/config.yaml loaded
[WARN] bash completions: not installed in a well-known location
[OK  ] zsh completions: /opt/homebrew/share/zsh/site-functions/_ggc
[OK  ] stdin TTY: stdin is a TTY

Everything looks good.
```

## Why

Most "ggc doesn't work" issues come down to: PATH, missing `git`, stale config, completion script not picked up, or running in a non-TTY. Asking a user to run `ggc doctor` and paste the output is far cheaper than a back-and-forth on an issue.

## Scope of checks

| Check | OK / FAIL | Notes |
|---|---|---|
| Go runtime | always OK | just reports version / GOOS/GOARCH |
| git binary | FAIL if missing or `--version` errors | hard dep |
| ggc config | OK if absent (defaults used), FAIL if present but unparseable | |
| bash / zsh completions | WARN if not found in well-known dirs | not required for CLI |
| stdin TTY | info-only; non-TTY is noted, not failed | |

## Design notes

Functions on `Doctor` are wired via indirection (`lookPath`, `execCommand`, `userHomeDir`, `stdinStat`) so unit tests can simulate each environment state without touching the host machine. 6 tests exercise the happy-path + every failure branch.

## Follow-ups (not this PR)

- `ggc doctor --json` for CI / issue-form automation
- Recommend specific remediation commands per WARN (e.g. print the exact `mkdir -p … && cp …` for completions)