### PR TITLE
ci(bench): add benchstat regression report on every PR

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.0.0
@@ -31,7 +32,9 @@ jobs:
           go-version: '1.25.0'
 
       - name: Install benchstat
-        run: go install golang.org/x/perf/cmd/benchstat@latest
+        # Pin to a reviewed revision of golang.org/x/perf so PR-to-PR results
+        # stay reproducible as the upstream evolves.
+        run: go install golang.org/x/perf/cmd/benchstat@8e83ce0f7b1c6c5d6eab4763f10b9322cbe4cecb
 
       - name: Run PR benchmarks
         run: |
@@ -59,6 +62,10 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Comment on PR
+        # Fork PRs receive a read-only GITHUB_TOKEN and cannot post comments.
+        # Skip the comment step for them; the raw results are still uploaded
+        # as an artifact below.
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: benchstat

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,80 @@
+name: Benchmarks
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/bench.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  bench:
+    name: benchstat (base vs PR)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.0.0
+        with:
+          go-version: '1.25.0'
+
+      - name: Install benchstat
+        run: go install golang.org/x/perf/cmd/benchstat@latest
+
+      - name: Run PR benchmarks
+        run: |
+          mkdir -p bench-results
+          go test ./... -run='^$' -bench=. -benchmem -count=6 \
+            | tee bench-results/pr.txt
+
+      - name: Checkout base
+        run: git checkout ${{ github.event.pull_request.base.sha }}
+
+      - name: Run base benchmarks
+        run: |
+          go test ./... -run='^$' -bench=. -benchmem -count=6 \
+            | tee bench-results/base.txt
+
+      - name: Compare with benchstat
+        id: benchstat
+        run: |
+          benchstat bench-results/base.txt bench-results/pr.txt \
+            | tee bench-results/compare.txt
+          {
+            echo 'report<<BENCHSTAT_EOF'
+            cat bench-results/compare.txt
+            echo 'BENCHSTAT_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Comment on PR
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: benchstat
+          message: |
+            ## benchstat (base vs PR, `count=6`)
+
+            ```text
+            ${{ steps.benchstat.outputs.report }}
+            ```
+
+            _Posted by `.github/workflows/bench.yml`. Investigate any p<0.05 regression; benchmarks run on a shared GitHub runner and have some inherent noise._
+
+      - name: Upload raw results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: bench-results
+          path: bench-results/
+          retention-days: 14


### PR DESCRIPTION
## What

Adds `.github/workflows/bench.yml` that on every PR touching Go source:

1. Runs `go test ./... -bench=. -benchmem -count=6` on the PR head
2. Checks out the PR base and runs the same
3. Compares with `benchstat` and posts a **sticky PR comment** with the delta table

## Why

The repo now has `_bench_test.go` files but nothing watches them for regression. A sticky comment means the latest numbers are always one click away on the PR page.

## Noise

GitHub runners are shared VMs so single-run numbers are meaningless. `count=6` is the lowest value `benchstat` treats as statistically comparable. Comment header notes this so reviewers don't chase p>=0.05 "regressions".

## Paths filter

Only triggers on Go source / `go.mod` / `go.sum` / the workflow itself, so README-only PRs don't burn ~10 min of runner time.

## Artifacts

Raw `base.txt`, `pr.txt`, `compare.txt` uploaded for 14 days — useful for disputed results.

## Pins

All actions pinned to full-commit SHAs per OSSF Scorecard.