### PR TITLE
docs(site): scaffold MkDocs-Material site + GitHub Pages workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,49 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: docs-pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.4.0
+        with:
+          python-version: '3.12'
+      - name: Install MkDocs
+        run: pip install mkdocs-material==9.5.44
+      - name: Build
+        run: mkdocs build --strict
+      - name: Configure Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        with:
+          path: site/
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,11 @@ on:
       - 'docs/**'
       - 'mkdocs.yml'
       - '.github/workflows/docs.yml'
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
   workflow_dispatch:
 
 permissions:
@@ -39,6 +44,7 @@ jobs:
 
   deploy:
     needs: build
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,17 @@
+# Contributing
+
+We love contributions! See the canonical [`CONTRIBUTING.md`](https://github.com/bmf-san/ggc/blob/main/CONTRIBUTING.md) in the repository for the full guide. In short:
+
+1. Fork and clone the repo.
+2. `make test` before you push.
+3. Follow [Conventional Commits](https://www.conventionalcommits.org/) for commit messages and PR titles — the CI enforces it.
+4. Every third-party GitHub Action must be pinned to a full commit SHA with a trailing `# vX.Y.Z` comment, per OSSF Scorecard.
+
+## Building the docs site locally
+
+```bash
+pip install mkdocs-material
+mkdocs serve
+```
+
+Then open <http://127.0.0.1:8000>.

--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -1,0 +1,36 @@
+# Commands
+
+!!! info "Auto-generated"
+    The full, up-to-date command table is generated from the registry and lives in [`README.md`](https://github.com/bmf-san/ggc/blob/main/README.md#commands).
+
+    Run `ggc help` locally for the same list, and `ggc help <command>` for usage and examples. The docs site will grow per-command pages over time; for now this page pulls the authoritative list into the docs build.
+
+## Top-level commands
+
+For each command, the canonical reference is:
+
+```bash
+ggc help <command>
+```
+
+Examples:
+
+```bash
+ggc help branch
+ggc help rebase
+ggc help stash
+```
+
+The renderer reads from the same registry that feeds shell completions and README.md, so it is always in sync with the actual CLI behavior.
+
+## Planned
+
+Per-command pages will be progressively added here, each with:
+
+- one-line summary
+- usage syntax
+- subcommands
+- worked examples
+- edge cases and pitfalls
+
+See [issue tracker](https://github.com/bmf-san/ggc/issues) for the doc expansion milestone.

--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -1,0 +1,52 @@
+# Configuration & aliases
+
+ggc reads configuration from one of:
+
+1. `$XDG_CONFIG_HOME/ggc/config.yaml`
+2. `~/.config/ggc/config.yaml` (default on Linux/macOS)
+3. `~/.ggcconfig.yaml` (legacy path; still respected for older installs)
+
+The first file that exists wins. If none exists, built-in defaults are used.
+
+## Anatomy
+
+```yaml
+meta:
+  version: v8.3.0     # auto-maintained
+  commit: abcdef1     # auto-maintained
+  created-at: 2025-01-15_12:34:56
+
+ui:
+  color: true
+
+git:
+  default-remote: origin
+  default-branch: main
+
+aliases:
+  ship: status && commit amend --no-edit && push force
+  cleanup: branch delete merged
+```
+
+## Aliases
+
+An alias is a named sequence of `ggc` commands separated by `&&`. Anything you can type in the prompt you can put behind an alias.
+
+```bash
+ggc ship
+```
+
+runs the three commands above in order, stopping at the first failure.
+
+See [alias validation](https://github.com/bmf-san/ggc/blob/main/internal/config/alias_validate.go) for the exact grammar.
+
+## Keybindings
+
+The interactive prompt's keybindings are defined in code and not yet user-configurable. See [#issue tracker](https://github.com/bmf-san/ggc/issues) for progress on making them user-override-able.
+
+## Editing
+
+```bash
+ggc config edit   # opens the config file in $EDITOR
+ggc config path   # prints the resolved path
+```

--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -42,7 +42,7 @@ See [alias validation](https://github.com/bmf-san/ggc/blob/main/internal/config/
 
 ## Keybindings
 
-The interactive prompt's keybindings are defined in code and not yet user-configurable. See [#issue tracker](https://github.com/bmf-san/ggc/issues) for progress on making them user-override-able.
+The interactive prompt's keybindings are defined in code and not yet user-configurable. See [issue tracker](https://github.com/bmf-san/ggc/issues) for progress on making them user-override-able.
 
 ## Editing
 

--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -1,0 +1,52 @@
+# Installation
+
+## Homebrew (macOS / Linux)
+
+```bash
+brew install bmf-san/tap/ggc
+```
+
+## Go
+
+Requires Go 1.25 or newer:
+
+```bash
+go install github.com/bmf-san/ggc/v8@latest
+```
+
+## Pre-built binaries
+
+Download the archive for your OS/arch from the [releases page](https://github.com/bmf-san/ggc/releases) and drop `ggc` on your `$PATH`.
+
+macOS universal binaries (one file that runs on both Intel and Apple Silicon) are published starting with v8.3.0.
+
+## Shell completions
+
+After installing, generate and install the completion script for your shell:
+
+=== "bash"
+
+    ```bash
+    ggc completion bash | sudo tee /etc/bash_completion.d/ggc
+    ```
+
+=== "zsh"
+
+    ```bash
+    ggc completion zsh > ~/.zsh/completions/_ggc
+    # add '~/.zsh/completions' to fpath in your .zshrc
+    ```
+
+=== "fish"
+
+    ```bash
+    ggc completion fish > ~/.config/fish/completions/ggc.fish
+    ```
+
+## Verify
+
+```bash
+ggc doctor
+```
+
+Should print a green checklist. If something is WARN or FAIL, the output explains what to fix.

--- a/docs/guide/interactive.md
+++ b/docs/guide/interactive.md
@@ -1,0 +1,21 @@
+# Interactive mode
+
+Running `ggc` with no arguments drops you into the interactive prompt. From there you can:
+
+- type a few letters and the command list narrows via fuzzy match
+- press <kbd>Enter</kbd> to execute
+- press <kbd>Tab</kbd> to complete a partial command
+- press <kbd>Ctrl</kbd>+<kbd>C</kbd> to cancel
+- press <kbd>Ctrl</kbd>+<kbd>D</kbd> to exit
+
+## Fuzzy pickers
+
+Commands that take a branch, file, or stash entry open a fuzzy picker:
+
+- <kbd>↑</kbd>/<kbd>↓</kbd> or <kbd>Ctrl</kbd>+<kbd>P</kbd>/<kbd>Ctrl</kbd>+<kbd>N</kbd> — move selection
+- <kbd>Enter</kbd> — accept
+- <kbd>Esc</kbd> — cancel
+
+## Custom keybindings
+
+See [Configuration & aliases](config.md#keybindings).

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -1,0 +1,56 @@
+# Quick start
+
+This is a 10-minute tour of the commands you'll reach for every day. Each example assumes you're already inside a Git working tree.
+
+## 1. See what's going on
+
+```bash
+ggc status
+```
+
+Like `git status` but grouped and colored.
+
+## 2. Stage and commit
+
+```bash
+ggc add             # pick files interactively
+ggc commit          # opens your $EDITOR like git commit
+ggc commit amend    # amend the last commit
+```
+
+One-shot:
+
+```bash
+ggc s "fix: off-by-one in parser"
+```
+
+is equivalent to `git add -A && git commit -m "fix: off-by-one in parser"`.
+
+## 3. Switch branches
+
+```bash
+ggc branch                # fuzzy-pick a local branch
+ggc branch new feature/x  # create and switch
+ggc branch delete         # fuzzy-pick a branch to delete
+```
+
+## 4. Rebase
+
+```bash
+ggc rebase i 5            # interactive rebase 5 commits back
+ggc rebase continue       # resume after fixing conflicts
+```
+
+## 5. Push / pull
+
+```bash
+ggc pull
+ggc push
+ggc push force            # force-with-lease
+```
+
+## Where to next?
+
+- Full command reference: [Commands](commands.md)
+- Interactive pickers and keybindings: [Interactive mode](interactive.md)
+- Aliases and defaults: [Configuration & aliases](config.md)

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -1,0 +1,42 @@
+# Troubleshooting
+
+## `ggc doctor`
+
+The fastest way to diagnose a ggc installation:
+
+```bash
+ggc doctor
+```
+
+It prints a checklist like:
+
+```
+[OK  ] Go runtime: go1.25.0 (darwin/arm64)
+[OK  ] git binary: /usr/bin/git (git version 2.46.0)
+[OK  ] ggc config: /Users/you/.config/ggc/config.yaml loaded
+[WARN] bash completions: not installed in a well-known location
+[OK  ] zsh completions: /opt/homebrew/share/zsh/site-functions/_ggc
+[OK  ] stdin TTY: stdin is a TTY
+
+Everything looks good.
+```
+
+- `[OK  ]` — nothing to do
+- `[WARN]` — usable but suboptimal (e.g. completions not picked up by your shell)
+- `[FAIL]` — ggc cannot work until this is fixed (e.g. `git` not in `$PATH`)
+
+## Verbose error messages
+
+ggc prints a compact error by default. To see the exact git command that produced the failure, set `GGC_VERBOSE=1`:
+
+```bash
+GGC_VERBOSE=1 ggc pull
+```
+
+## Reporting a bug
+
+Please paste the output of `ggc doctor` and the verbose error into the issue. Without those two the maintainers usually can't reproduce the problem.
+
+## Opening an issue
+
+See the [issue forms](https://github.com/bmf-san/ggc/issues/new/choose).

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ $ ggc
 
 ## Why ggc?
 
-- **Typed less, done more.** `ggc s` stages + commits in one step, `ggc branch` opens a fuzzy picker over local branches, `ggc rebase i 3` starts an interactive rebase 3 commits back.
+- **Type less, do more.** `ggc s` stages + commits in one step, `ggc branch` opens a fuzzy picker over local branches, `ggc rebase i 3` starts an interactive rebase 3 commits back.
 - **Unified syntax.** No `-`/`--` flag soup. Every command is a verb followed by plain words.
 - **Scripts stay scripts.** `ggc` is a thin layer over `git`: anything you can't express in `ggc` you can always fall back to.
 - **Safe by default.** Destructive operations ask for confirmation unless you pass `--yes`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,36 @@
+# ggc
+
+**ggc** is an interactive Git CLI written in Go. It gives you short, memorable subcommands and a fuzzy-finder UI for the everyday workflows that `git` makes too verbose.
+
+```console
+$ ggc
+> status       show what's changed
+  commit       commit staged changes
+  branch       switch, create, delete branches
+  rebase       interactive rebase helper
+  stash        push/pop/apply/clear the stash
+  ...
+```
+
+## Why ggc?
+
+- **Typed less, done more.** `ggc s` stages + commits in one step, `ggc branch` opens a fuzzy picker over local branches, `ggc rebase i 3` starts an interactive rebase 3 commits back.
+- **Unified syntax.** No `-`/`--` flag soup. Every command is a verb followed by plain words.
+- **Scripts stay scripts.** `ggc` is a thin layer over `git`: anything you can't express in `ggc` you can always fall back to.
+- **Safe by default.** Destructive operations ask for confirmation unless you pass `--yes`.
+
+## Get it
+
+See [Installation](guide/install.md). Quickest path:
+
+```bash
+go install github.com/bmf-san/ggc/v8@latest
+```
+
+## Next steps
+
+1. [Quick start](guide/quickstart.md) — the 10-minute tour
+2. [Commands](guide/commands.md) — reference of every `ggc` command
+3. [Interactive mode](guide/interactive.md) — fuzzy finders and keybindings
+4. [Configuration & aliases](guide/config.md) — `~/.config/ggc/config.yaml`
+5. [Troubleshooting](guide/troubleshooting.md) — `ggc doctor` and common issues

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,61 @@
+site_name: ggc
+site_description: A Go-based interactive Git CLI with powerful shortcuts and fuzzy finders.
+site_url: https://bmf-san.github.io/ggc/
+repo_url: https://github.com/bmf-san/ggc
+repo_name: bmf-san/ggc
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  logo: icon.png
+  favicon: icon.png
+  features:
+    - navigation.sections
+    - navigation.top
+    - content.code.copy
+    - content.action.edit
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: black
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: black
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+
+nav:
+  - Home: index.md
+  - Getting started:
+      - Installation: guide/install.md
+      - Quick start: guide/quickstart.md
+  - Commands: guide/commands.md
+  - Interactive mode: guide/interactive.md
+  - Configuration & aliases: guide/config.md
+  - Troubleshooting: guide/troubleshooting.md
+  - Contributing: contributing.md
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - def_list
+  - toc:
+      permalink: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.details
+
+plugins:
+  - search
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/bmf-san/ggc


### PR DESCRIPTION
## What

Scaffolds a standalone **MkDocs Material** docs site and a `.github/workflows/docs.yml` that builds it with `mkdocs build --strict` and deploys to GitHub Pages on every push to `main`.

Tree added:

```
mkdocs.yml
docs/
├── index.md
├── contributing.md
└── guide/
    ├── install.md
    ├── quickstart.md
    ├── commands.md
    ├── interactive.md
    ├── config.md
    └── troubleshooting.md
.github/workflows/docs.yml
```

## Why

README.md is where first-time users land, but it's already the longest file in the repo (auto-generated command table + install + interactive + aliases + keybindings + ...). A docs site gives us:

- navigation / search / dark mode
- room for per-command pages, screenshots, asciinema casts, tutorials
- a stable URL to link from issues and blog posts
- versioned docs (future, via `mike`) so users on v7 / v8 / v9 can each read the right thing

## Keeping README as source of truth

`make docs` regenerates the command table directly from the command registry into `README.md`. The MkDocs site **links to** that table rather than duplicating it, so there is only one place to update when commands change.

## Local build

```bash
pip install mkdocs-material
mkdocs serve     # live reload on :8000
mkdocs build --strict   # same as CI
```

## Required one-time setup (not in this PR)

GitHub Pages must be enabled in the repo Settings under *Pages → Build and deployment → Source: GitHub Actions*. Until that is flipped, the `deploy` job will fail but the `build` job will still verify every doc renders with `--strict` on every push.

## Not in this PR

- per-command pages (`docs/guide/commands/<name>.md`) — planned next
- asciinema recordings of interactive mode
- versioning via `mike`

## Pins

`actions/checkout`, `actions/setup-python`, `actions/configure-pages`, `actions/upload-pages-artifact`, `actions/deploy-pages` — all pinned to full commit SHAs per OSSF Scorecard.