### PR TITLE
refactor(cmd): extract commandRouter into its own file

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"os/signal"
-	"sort"
 	"strings"
 
 	commandregistry "github.com/bmf-san/ggc/v8/cmd/command"
@@ -341,86 +340,6 @@ func (c *Cmd) routeCommand(cmd string, args []string) error {
 	}
 
 	return fmt.Errorf("unknown command: %q", cmd)
-}
-
-type commandRouter struct {
-	registry *commandregistry.Registry
-	handlers map[string]func([]string)
-}
-
-func newCommandRouter(cmd *Cmd) (*commandRouter, error) {
-	if err := cmd.registry.Validate(); err != nil {
-		return nil, fmt.Errorf("command registry validation failed: %w", err)
-	}
-
-	handlers := map[string]func([]string){
-		"help":       func(args []string) { cmd.Help(args) },
-		"add":        func(args []string) { cmd.Add(args) },
-		"branch":     func(args []string) { cmd.Branch(args) },
-		"commit":     func(args []string) { cmd.Commit(args) },
-		"log":        func(args []string) { cmd.Log(args) },
-		"pull":       func(args []string) { cmd.Pull(args) },
-		"push":       func(args []string) { cmd.Push(args) },
-		"reset":      func(args []string) { cmd.Reset(args) },
-		"clean":      func(args []string) { cmd.Clean(args) },
-		"version":    func(args []string) { cmd.Version(args) },
-		"remote":     func(args []string) { cmd.Remote(args) },
-		"rebase":     func(args []string) { cmd.Rebase(args) },
-		"stash":      func(args []string) { cmd.Stash(args) },
-		"config":     func(args []string) { cmd.Config(args) },
-		"hook":       func(args []string) { cmd.Hook(args) },
-		"tag":        func(args []string) { cmd.Tag(args) },
-		"status":     func(args []string) { cmd.Status(args) },
-		"fetch":      func(args []string) { cmd.Fetch(args) },
-		"diff":       func(args []string) { cmd.Diff(args) },
-		"restore":    func(args []string) { cmd.Restore(args) },
-		"debug-keys": func(args []string) { cmd.DebugKeys(args) },
-		interactiveQuitCommand: func([]string) {
-			_, _ = fmt.Fprintln(cmd.outputWriter, "The 'quit' command is only available in interactive mode.")
-		},
-	}
-
-	available := make(map[string]struct{}, len(handlers))
-	for key := range handlers {
-		available[key] = struct{}{}
-	}
-
-	missing := missingHandlers(cmd.registry, available)
-	if len(missing) > 0 {
-		sort.Strings(missing)
-		return nil, fmt.Errorf("no handler registered for commands: %s", strings.Join(missing, ", "))
-	}
-
-	return &commandRouter{registry: cmd.registry, handlers: handlers}, nil
-}
-
-func (r *commandRouter) route(cmd string, args []string) bool {
-	info, ok := r.registry.Find(cmd)
-	if !ok {
-		return false
-	}
-	// Use the canonical command name from the registry as the handler key.
-	handler, ok := r.handlers[info.Name]
-	if !ok {
-		return false
-	}
-	handler(args)
-	return true
-}
-
-func missingHandlers(registry *commandregistry.Registry, available map[string]struct{}) []string {
-	var missing []string
-	allCommands := registry.All()
-	for i := range allCommands {
-		info := &allCommands[i]
-		if info.Hidden {
-			continue
-		}
-		if _, ok := available[info.Name]; !ok {
-			missing = append(missing, info.Name)
-		}
-	}
-	return missing
 }
 
 // waitForContinue waits for user input to continue

--- a/cmd/router.go
+++ b/cmd/router.go
@@ -16,10 +16,10 @@ type commandRouter struct {
 	handlers map[string]func([]string)
 }
 
-// newCommandRouter builds the handler map and validates that every command
-// in the registry has a handler. The map-key is the canonical command name
-// as exposed by the registry; this keeps shell completions, README.md and
-// the router in strict lockstep.
+// newCommandRouter builds the handler map and validates that every
+// non-hidden command in the registry has a handler. The map-key is the
+// canonical command name as exposed by the registry; this keeps shell
+// completions, README.md and the router in strict lockstep.
 func newCommandRouter(cmd *Cmd) (*commandRouter, error) {
 	if err := cmd.registry.Validate(); err != nil {
 		return nil, fmt.Errorf("command registry validation failed: %w", err)
@@ -68,7 +68,9 @@ func newCommandRouter(cmd *Cmd) (*commandRouter, error) {
 
 // route looks up cmd in the registry (which handles aliases and canonical
 // names), then dispatches to the registered handler. It returns false when
-// the command is unknown so the caller can fall back to alias or error paths.
+// the command is unknown to the registry, or when no handler is registered
+// for the canonical name, so the caller can fall back to alias or error
+// paths.
 func (r *commandRouter) route(cmd string, args []string) bool {
 	info, ok := r.registry.Find(cmd)
 	if !ok {

--- a/cmd/router.go
+++ b/cmd/router.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	commandregistry "github.com/bmf-san/ggc/v8/cmd/command"
+)
+
+// commandRouter dispatches a command name (plus its args) to the matching
+// handler on Cmd. It is initialized once at NewCmd time and then consulted
+// for every command the user types, both in scripted and interactive mode.
+type commandRouter struct {
+	registry *commandregistry.Registry
+	handlers map[string]func([]string)
+}
+
+// newCommandRouter builds the handler map and validates that every command
+// in the registry has a handler. The map-key is the canonical command name
+// as exposed by the registry; this keeps shell completions, README.md and
+// the router in strict lockstep.
+func newCommandRouter(cmd *Cmd) (*commandRouter, error) {
+	if err := cmd.registry.Validate(); err != nil {
+		return nil, fmt.Errorf("command registry validation failed: %w", err)
+	}
+
+	handlers := map[string]func([]string){
+		"help":       func(args []string) { cmd.Help(args) },
+		"add":        func(args []string) { cmd.Add(args) },
+		"branch":     func(args []string) { cmd.Branch(args) },
+		"commit":     func(args []string) { cmd.Commit(args) },
+		"log":        func(args []string) { cmd.Log(args) },
+		"pull":       func(args []string) { cmd.Pull(args) },
+		"push":       func(args []string) { cmd.Push(args) },
+		"reset":      func(args []string) { cmd.Reset(args) },
+		"clean":      func(args []string) { cmd.Clean(args) },
+		"version":    func(args []string) { cmd.Version(args) },
+		"remote":     func(args []string) { cmd.Remote(args) },
+		"rebase":     func(args []string) { cmd.Rebase(args) },
+		"stash":      func(args []string) { cmd.Stash(args) },
+		"config":     func(args []string) { cmd.Config(args) },
+		"hook":       func(args []string) { cmd.Hook(args) },
+		"tag":        func(args []string) { cmd.Tag(args) },
+		"status":     func(args []string) { cmd.Status(args) },
+		"fetch":      func(args []string) { cmd.Fetch(args) },
+		"diff":       func(args []string) { cmd.Diff(args) },
+		"restore":    func(args []string) { cmd.Restore(args) },
+		"debug-keys": func(args []string) { cmd.DebugKeys(args) },
+		interactiveQuitCommand: func([]string) {
+			_, _ = fmt.Fprintln(cmd.outputWriter, "The 'quit' command is only available in interactive mode.")
+		},
+	}
+
+	available := make(map[string]struct{}, len(handlers))
+	for key := range handlers {
+		available[key] = struct{}{}
+	}
+
+	missing := missingHandlers(cmd.registry, available)
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return nil, fmt.Errorf("no handler registered for commands: %s", strings.Join(missing, ", "))
+	}
+
+	return &commandRouter{registry: cmd.registry, handlers: handlers}, nil
+}
+
+// route looks up cmd in the registry (which handles aliases and canonical
+// names), then dispatches to the registered handler. It returns false when
+// the command is unknown so the caller can fall back to alias or error paths.
+func (r *commandRouter) route(cmd string, args []string) bool {
+	info, ok := r.registry.Find(cmd)
+	if !ok {
+		return false
+	}
+	// Use the canonical command name from the registry as the handler key.
+	handler, ok := r.handlers[info.Name]
+	if !ok {
+		return false
+	}
+	handler(args)
+	return true
+}
+
+// missingHandlers returns every non-hidden registry command that has no
+// matching handler in available. It is used at startup to turn a registry
+// drift into a loud construction error instead of a silent "unknown command"
+// at runtime.
+func missingHandlers(registry *commandregistry.Registry, available map[string]struct{}) []string {
+	var missing []string
+	allCommands := registry.All()
+	for i := range allCommands {
+		info := &allCommands[i]
+		if info.Hidden {
+			continue
+		}
+		if _, ok := available[info.Name]; !ok {
+			missing = append(missing, info.Name)
+		}
+	}
+	return missing
+}


### PR DESCRIPTION
## What

Extracts the command router (type `commandRouter`, constructor `newCommandRouter`, dispatcher `route`, the `missingHandlers` registry-coverage check) from `cmd/cmd.go` into a new `cmd/router.go`.

| File | Before | After |
|---|---|---|
| `cmd/cmd.go` | 430 lines | **349** |
| `cmd/router.go` | — | **103** (new) |

## Why

`cmd/cmd.go` had grown to ~430 lines doing three distinct jobs: the `GitDeps` interface, the `Cmd` struct + `NewCmd` wiring, and the handler map + router validation. Splitting the third concern out means future router changes (per-command help routing, alias pre-expansion, metrics) are diff-noise-free in a small, focused file.

## Nature of the change

**Pure code motion.** Every moved line is verbatim apart from added doc comments on the moved symbols. No exported API changes, no test changes, no behavior changes.

## Verified

```
$ go build ./...
$ go test ./cmd/... -count=1
ok  github.com/bmf-san/ggc/v8/cmd     0.654s
ok  github.com/bmf-san/ggc/v8/cmd/command     0.727s
```

## Why not a deeper split?

Moving each command's handler into its own file (e.g. `cmd/handlers/branch.go`) was considered and rejected: the handlers are already one-line closures that delegate to `Brancher`, `Committer`, etc. Moving them wouldn't reduce coupling, only add indirection. This minimal extraction keeps the win (smaller `cmd.go`) without the churn (big diff, more merge conflicts with in-flight PRs #388–394).