### PR TITLE
docs(readme): link to the bmf-san.github.io/ggc docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 
 A Go Git CLI.
 
+📖 **Full documentation:** https://bmf-san.github.io/ggc/
+
 <img src="./docs/icon.png" alt="ggc" title="ggc" width="100px">
 
 This logo was created by [gopherize.me](https://gopherize.me/gopher/d654ddf2b81c2b4123684f93071af0cf559eb0b5).
@@ -676,6 +678,7 @@ This setup will automatically find the completion script regardless of the insta
 
 # References
 
+- [ggc documentation site](https://bmf-san.github.io/ggc/) - Full user guide, install notes, configuration reference, and troubleshooting
 - [Git Documentation](https://git-scm.com/docs) - Complete Git reference documentation
 - [Git Tutorial](https://git-scm.com/docs/gittutorial) - Official Git tutorial for beginners
 - [Git User Manual](https://git-scm.com/docs/user-manual) - Comprehensive Git user guide


### PR DESCRIPTION
## Description of Changes

The MkDocs-Material docs site went live with #394 (https://bmf-san.github.io/ggc/), but the README doesn't advertise it. This PR adds:

1. A one-line pointer right under the tagline near the top of the README, so the link is the first thing someone sees after "A Go Git CLI."
2. A bullet in the existing `# References` section so readers scanning for docs find it there too.

Both edits are plain Markdown and don't touch the registry-driven command table, so `make docs` remains a no-op on them.

## Related Issue

n/a — follow-up to #394.

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/bmf-san/ggc/blob/main/CONTRIBUTING.md)
- [ ] I have added or updated tests — N/A (docs only)
- [x] I have updated the documentation (if required)
- [x] Code is formatted with `make fmt` — N/A
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing
- [x] If commands were added/modified: I have run `make docs` to update README.md — verified `make docs` leaves these edits alone
- [ ] I have run `make demos` to regenerate demo assets (if applicable) — N/A

## Screenshots

n/a

## Additional Context

Kept the wording minimal on purpose so we don't fork README content and the docs site — the site is the source of truth for the user guide; README stays focused on install/quickstart and points at it.