### PR TITLE
docs(site): fill in install, quickstart, interactive, config pages

### DIFF
--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -6,6 +6,167 @@ ggc reads configuration from one of:
 2. `~/.config/ggc/config.yaml` (default on Linux/macOS)
 3. `~/.ggcconfig.yaml` (legacy path; still respected for older installs)
 
+The first file that exists wins. If none exists, built-in defaults are used. On Windows the path resolves via `%APPDATA%\ggc\config.yaml`.
+
+## Anatomy
+
+```yaml
+meta:
+  version: v8.3.0     # auto-maintained by ggc
+  commit: abcdef1     # auto-maintained by ggc
+  created-at: 2025-01-15_12:34:56
+
+ui:
+  color: true
+
+git:
+  default-remote: origin
+  default-branch: main
+
+aliases:
+  ship: status && commit amend --no-edit && push force
+  cleanup: branch delete merged
+
+interactive:
+  profile: default   # one of: default | emacs | vi | readline
+```
+
+`meta.*` is rewritten by ggc on startup; don't edit it by hand.
+
+## Aliases
+
+An alias is a named sequence of `ggc` commands separated by `&&`. Anything you can type in the prompt you can put behind an alias.
+
+```bash
+ggc ship
+```
+
+runs the three commands above in order, stopping at the first failure.
+
+### Placeholders
+
+Numeric placeholders let an alias accept arguments:
+
+```yaml
+aliases:
+  commit-msg: "commit -m '{0}'"
+  feature:    ["branch checkout {0}", "push {0}"]
+```
+
+Then:
+
+```bash
+ggc commit-msg "Fix bug"
+ggc feature main
+```
+
+See the [alias validation grammar](https://github.com/bmf-san/ggc/blob/main/internal/config/alias_validate.go) for the exact rules (nesting, escaping, reserved names).
+
+## Keybindings
+
+### Profiles
+
+Pick a profile in one line:
+
+```yaml
+interactive:
+  profile: emacs
+```
+
+| Profile     | Feel                                      |
+|-------------|-------------------------------------------|
+| `default`   | Curated ggc defaults (recommended)        |
+| `emacs`     | GNU readline-style                        |
+| `vi`        | Modal, `hjkl` navigation                  |
+| `readline`  | Strict GNU readline compatibility         |
+
+### Overriding individual keys
+
+Under `interactive.keybindings` you can override any binding by its logical name:
+
+```yaml
+interactive:
+  keybindings:
+    move_up: "ctrl+p"
+    move_down: "ctrl+n"
+    accept: "enter"
+    cancel: "esc"
+    toggle_workflow: "ctrl+w"
+```
+
+### Supported key notations
+
+Three equivalent forms are accepted; pick whichever reads best:
+
+| Notation     | Example               |
+|--------------|-----------------------|
+| `ctrl+`      | `ctrl+p`              |
+| `C-`         | `C-p`                 |
+| raw caret    | `^P`                  |
+
+`alt+` / `M-` and `shift+` work the same way. Function keys (`f1`..`f12`), arrow keys (`up`, `down`, `left`, `right`), and named keys (`enter`, `esc`, `tab`, `space`, `backspace`) are all recognized.
+
+### Layered overrides
+
+The config is evaluated in this order, later layers winning:
+
+1. `interactive.profile` baseline
+2. `interactive.keybindings` (global)
+3. `interactive.<os>` — `darwin` / `linux` / `windows`
+4. `interactive.contexts.<ctx>` — e.g. `contexts.picker`, `contexts.search`
+5. `interactive.terminals.<term>` — e.g. `terminals.alacritty`, `terminals.iterm2`
+
+Example: use emacs everywhere, but tweak `move_up` on macOS only:
+
+```yaml
+interactive:
+  profile: emacs
+  darwin:
+    keybindings:
+      move_up: "ctrl+p"
+```
+
+### Inspecting the resolved keymap
+
+```bash
+ggc config list
+ggc config get interactive.keybindings
+ggc config get interactive.darwin.keybindings
+```
+
+If you're unsure what key your terminal is sending, run:
+
+```bash
+ggc debug-keys
+```
+
+and press keys — it prints the raw escape sequences.
+
+## Editing
+
+```bash
+ggc config edit   # opens the config file in $EDITOR
+ggc config path   # prints the resolved path
+ggc config list   # print the fully-merged config
+```
+
+## tmux
+
+Under tmux, most terminals mangle the modifier prefix unless `xterm-keys` is on. Add to `~/.tmux.conf`:
+
+```tmux
+set -g xterm-keys on
+```
+
+Then reload tmux. Without this, `ctrl+arrow` / `alt+...` will arrive as bare arrow keys.
+# Configuration & aliases
+
+ggc reads configuration from one of:
+
+1. `$XDG_CONFIG_HOME/ggc/config.yaml`
+2. `~/.config/ggc/config.yaml` (default on Linux/macOS)
+3. `~/.ggcconfig.yaml` (legacy path; still respected for older installs)
+
 The first file that exists wins. If none exists, built-in defaults are used.
 
 ## Anatomy

--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -1,5 +1,105 @@
 # Installation
 
+## Quick install (macOS / Linux)
+
+The fastest way — the install script picks the right binary for your OS/arch, installs it under `/usr/local/bin/`, and verifies it runs:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/bmf-san/ggc/main/install.sh | bash
+```
+
+## Homebrew (macOS / Linux)
+
+```bash
+brew install ggc
+# later:
+brew upgrade ggc
+```
+
+Formula: <https://formulae.brew.sh/formula/ggc>.
+
+## `go install`
+
+Requires Go 1.25 or newer:
+
+```bash
+go install github.com/bmf-san/ggc/v8@latest
+```
+
+The binary lands in `$GOBIN` (usually `$HOME/go/bin`). Make sure it's on your `PATH`.
+
+!!! warning "No version metadata with `go install`"
+    Release notes, commit hash and build date are baked in via ldflags during `make build` / CI. `go install` skips that, so `ggc version` will only print `dev`. Prefer the script, Homebrew, or pre-built binaries if you care about version info.
+
+## Pre-built binaries
+
+Download the archive for your OS/arch from the [releases page](https://github.com/bmf-san/ggc/releases) and drop `ggc` on your `PATH`.
+
+Supported targets:
+
+- macOS: `darwin_amd64`, `darwin_arm64`, and a universal binary (one file for both) starting from v8.3.0
+- Linux: `linux_amd64`, `linux_arm64`
+- Windows: `windows_amd64`
+
+## Windows
+
+Windows binaries are published to the [releases page](https://github.com/bmf-san/ggc/releases) as `ggc_Windows_x86_64.zip`. Steps:
+
+1. Download and unzip the archive.
+2. Move `ggc.exe` to a folder on your `PATH` (e.g. `%USERPROFILE%\bin`).
+3. In PowerShell, check: `ggc version`.
+
+If you use Git Bash or WSL the Linux instructions above also work unchanged.
+
+## Build from source
+
+```bash
+git clone https://github.com/bmf-san/ggc.git
+cd ggc
+make build
+sudo mv ggc /usr/local/bin/
+```
+
+`make build` stamps the binary with the current tag / commit so `ggc version` reports real values.
+
+## Shell completions
+
+After installing, generate and install the completion script for your shell:
+
+=== "bash"
+
+    ```bash
+    ggc completion bash | sudo tee /etc/bash_completion.d/ggc
+    ```
+
+=== "zsh"
+
+    ```bash
+    ggc completion zsh > ~/.zsh/completions/_ggc
+    # add '~/.zsh/completions' to fpath in your .zshrc
+    ```
+
+=== "fish"
+
+    ```bash
+    ggc completion fish > ~/.config/fish/completions/ggc.fish
+    ```
+
+=== "PowerShell"
+
+    ```powershell
+    ggc completion powershell | Out-String | Invoke-Expression
+    ```
+
+## Verify
+
+```bash
+ggc doctor
+```
+
+Should print a green checklist. If anything is `WARN` or `FAIL`, the output explains what to fix. See [Troubleshooting](troubleshooting.md) for details.
+# Installation
+
 ## Homebrew (macOS / Linux)
 
 ```bash

--- a/docs/guide/interactive.md
+++ b/docs/guide/interactive.md
@@ -1,21 +1,54 @@
 # Interactive mode
 
-Running `ggc` with no arguments drops you into the interactive prompt. From there you can:
+Running `ggc` with no arguments drops you into the interactive prompt. There are two modes:
 
-- type a few letters and the command list narrows via fuzzy match
-- press <kbd>Enter</kbd> to execute
-- press <kbd>Tab</kbd> to complete a partial command
-- press <kbd>Ctrl</kbd>+<kbd>C</kbd> to cancel
-- press <kbd>Ctrl</kbd>+<kbd>D</kbd> to exit
+- **Search mode** (default) — fuzzy-search over all `ggc` commands and run one.
+- **Workflow mode** — build a queue of commands, then execute them in sequence with one keystroke.
 
-## Fuzzy pickers
+## Search mode
 
-Commands that take a branch, file, or stash entry open a fuzzy picker:
+From the prompt:
 
+- type a few letters → the command list narrows via fuzzy match
+- <kbd>Enter</kbd> — execute the highlighted command
+- <kbd>Tab</kbd> — add the highlighted command to the workflow queue and stay in search
 - <kbd>↑</kbd>/<kbd>↓</kbd> or <kbd>Ctrl</kbd>+<kbd>P</kbd>/<kbd>Ctrl</kbd>+<kbd>N</kbd> — move selection
-- <kbd>Enter</kbd> — accept
-- <kbd>Esc</kbd> — cancel
+- <kbd>Ctrl</kbd>+<kbd>C</kbd> — cancel the current input
+- <kbd>Ctrl</kbd>+<kbd>D</kbd> — exit
 
-## Custom keybindings
+### Fuzzy pickers
 
-See [Configuration & aliases](config.md#keybindings).
+Commands that take a branch, file, or stash entry open a nested picker using the same keys (<kbd>↑</kbd>/<kbd>↓</kbd>, <kbd>Enter</kbd> to accept, <kbd>Esc</kbd> to cancel).
+
+## Workflow mode
+
+Workflow mode turns the interactive prompt into a command pipeline builder. Typical use: stage → commit → push in one go without re-typing anything.
+
+1. In search mode, highlight a command and press <kbd>Tab</kbd>. The command is appended to the workflow queue and the prompt stays in search mode so you can add the next one.
+2. Press <kbd>Ctrl</kbd>+<kbd>W</kbd> to switch to workflow view. You see the queued commands in order.
+3. <kbd>Enter</kbd> in workflow view runs the queue; execution stops on the first failure.
+4. <kbd>Esc</kbd> returns to search mode without clearing the queue; <kbd>Ctrl</kbd>+<kbd>X</kbd> clears the queue.
+
+Commands with placeholders (e.g. aliases like `commit-msg: "commit -m '{0}'"`) will prompt for the placeholder value when they run, not when they're queued.
+
+## Keybinding profiles
+
+The interactive prompt ships with four profiles:
+
+- `default` — curated ggc defaults
+- `emacs` — GNU readline-style
+- `vi` — modal, `hjkl` navigation
+- `readline` — strict readline compatibility
+
+Pick one in `~/.config/ggc/config.yaml`:
+
+```yaml
+interactive:
+  profile: emacs
+```
+
+Fine-grained overrides (per-OS, per-context, per-terminal, custom key combos) are documented in [Configuration & aliases → Keybindings](config.md#keybindings).
+
+## Exiting
+
+From search mode: <kbd>Ctrl</kbd>+<kbd>D</kbd> or type `quit` + <kbd>Enter</kbd>. `quit` only works inside interactive mode; invoking `ggc quit` from a shell is a no-op.

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -10,6 +10,12 @@ ggc status
 
 Like `git status` but grouped and colored.
 
+```bash
+ggc log
+ggc diff            # staged + unstaged
+ggc diff --staged   # staged only
+```
+
 ## 2. Stage and commit
 
 ```bash
@@ -34,14 +40,23 @@ ggc branch new feature/x  # create and switch
 ggc branch delete         # fuzzy-pick a branch to delete
 ```
 
-## 4. Rebase
+## 4. Save work in progress
+
+```bash
+ggc stash              # stash current changes
+ggc stash pop          # reapply the most recent stash
+ggc stash list         # browse stashes (fuzzy picker)
+```
+
+## 5. Rebase
 
 ```bash
 ggc rebase i 5            # interactive rebase 5 commits back
 ggc rebase continue       # resume after fixing conflicts
+ggc rebase abort          # give up and restore pre-rebase state
 ```
 
-## 5. Push / pull
+## 6. Push / pull
 
 ```bash
 ggc pull
@@ -49,8 +64,26 @@ ggc push
 ggc push force            # force-with-lease
 ```
 
+## 7. Tag a release
+
+```bash
+ggc tag                  # list tags
+ggc tag create v1.2.0    # create (and sign, if configured)
+ggc tag push v1.2.0      # push a single tag to origin
+```
+
+## 8. Try interactive mode
+
+Run `ggc` by itself to drop into the fuzzy-search prompt:
+
+```bash
+ggc
+```
+
+Type a few letters, hit <kbd>Enter</kbd>, and you're off. See [Interactive mode](interactive.md) for the full key list and Workflow mode.
+
 ## Where to next?
 
 - Full command reference: [Commands](commands.md)
-- Interactive pickers and keybindings: [Interactive mode](interactive.md)
+- Interactive pickers, Workflow mode, keybindings: [Interactive mode](interactive.md)
 - Aliases and defaults: [Configuration & aliases](config.md)


### PR DESCRIPTION
## Description of Changes

The MkDocs site scaffolded in #394 delegated a lot of content to the README. This PR fills the four thinnest pages so readers visiting https://bmf-san.github.io/ggc/ don't have to bounce back to GitHub for core information.

### install.md
- Add **Windows (PowerShell)** steps.
- Add **`install.sh` quick-install** (the script that's shipped in-repo).
- Add **build-from-source via `make build`** with a note that it stamps real version metadata.
- Add **PowerShell completions** tab.
- Call out that `go install` drops `ldflags`-stamped version metadata.

### quickstart.md
- Add sections for **`stash`** and **`tag`** (both common day-to-day commands that were missing).
- Add `ggc log` and `ggc diff --staged` examples.
- Add a step that points at interactive mode.

### interactive.md
- Document **Workflow mode** — the Tab/Ctrl+W/Enter/Ctrl+X cycle that was not explained anywhere on the site.
- Add an overview of the four keybinding profiles (default / emacs / vi / readline).
- Add exit keys and clarify that `quit` is interactive-only.

### config.md
- Flesh out **Keybindings**:
  - profile table
  - three supported key notations (`ctrl+p` / `C-p` / `^P`)
  - layered override order (profile → global → os → context → terminal) with a worked example
  - inspection commands (`ggc config list`, `ggc config get`, `ggc debug-keys`)
- Add a **tmux `xterm-keys`** note (common gotcha when `ctrl+arrow` arrives bare).
- Add Windows path resolution (`%APPDATA%`).

## Verification

```bash
mkdocs build --strict
```

completes cleanly; only the pre-existing INFO messages about demo-workspace README pages not being in `nav` remain (unchanged by this PR).

## Related Issue

Follow-up to #394.

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/bmf-san/ggc/blob/main/CONTRIBUTING.md)
- [ ] I have added or updated tests — N/A (docs only)
- [x] I have updated the documentation (if required)
- [x] Code is formatted with `make fmt` — N/A
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing
- [x] If commands were added/modified: I have run `make docs` — N/A, no registry changes
- [ ] I have run `make demos` to regenerate demo assets (if applicable) — N/A

## Additional Context

I deliberately **did not** duplicate everything from the README onto the site — the README stays authoritative for the command table (it's registry-generated). What's on the site now is the subset of information that a first-time visitor actually needs, plus the Workflow-mode section that was missing entirely.