### PR TITLE
docs(readme): lead with interactive demo, add demo captions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,12 @@ This logo was created by [gopherize.me](https://gopherize.me/gopher/d654ddf2b81c
 
 ## Demo
 
-| Branch Management | CLI Workflow | Interactive Overview |
+Click any GIF to view full size.
+
+| Interactive & Workflow mode | CLI workflow | Branch management |
 | --- | --- | --- |
-| <img src="docs/demos/generated/branch-management.gif" alt="Branch management demo" width="320"> | <img src="docs/demos/generated/cli-workflow.gif" alt="CLI workflow demo" width="320"> | <img src="docs/demos/generated/interactive-overview.gif" alt="Interactive overview demo" width="320"> |
+| [<img src="docs/demos/generated/interactive-overview.gif" alt="Interactive overview demo" width="320">](docs/demos/generated/interactive-overview.gif) | [<img src="docs/demos/generated/cli-workflow.gif" alt="CLI workflow demo" width="320">](docs/demos/generated/cli-workflow.gif) | [<img src="docs/demos/generated/branch-management.gif" alt="Branch management demo" width="320">](docs/demos/generated/branch-management.gif) |
+| Fuzzy-search every `ggc` command, then press <kbd>Tab</kbd> to queue them into a workflow and <kbd>Ctrl</kbd>+<kbd>T</kbd> to run the pipeline. | Traditional one-shot commands: `ggc status`, `ggc add`, `ggc commit "<msg>"`, `ggc log simple`. | Create and switch branches with plain verbs; interactive pickers appear when arguments are omitted. |
 
 ## Overview
 


### PR DESCRIPTION
## Description of Changes

Quick, low-risk tweaks to the README demo table:

- **Reorder** so the interactive + Workflow-mode demo — the real differentiator from plain `git` — appears first. Today `branch-management.gif` (the weakest clip) leads, so a skimmer sees "ggc branch list" and thinks this is just a verb wrapper.
- **Link each thumbnail to the full-resolution GIF**, so readers aren't stuck trying to read terminal text at 320px width.
- **Add one-line captions** under each column explaining what to watch for.

## Related

Follow-up to #394 / #397. A separate issue will track regenerating the GIFs to showcase `ggc s "<msg>"`, fuzzy pickers, and smaller file sizes (currently `interactive-overview.gif` is 3.1MB).

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/bmf-san/ggc/blob/main/CONTRIBUTING.md)
- [ ] I have added or updated tests — N/A (docs only)
- [x] I have updated the documentation (if required)
- [x] Code is formatted with `make fmt` — N/A
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing
- [x] If commands were added/modified: I have run `make docs` — N/A, no registry changes
- [ ] I have run `make demos` — intentionally not, see the follow-up issue

## Additional Context

No GIFs were regenerated in this PR. Changing the underlying `.tape` scripts (e.g. to add `ggc s "<msg>"` and fuzzy-picker scenes) requires VHS to be installed locally and is more involved; that work is deferred to a tracking issue.