### PR TITLE
docs: stop duplicating the command table and quick-start in README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,9 +75,8 @@ test-and-lint: test lint
 .PHONY: docs completions
 
 docs:
-	@echo "Updating README.md command table..."
+	@echo "Regenerating docs/guide/commands.md from registry..."
 	@go run tools/cmd/gendocs/main.go
-	@echo "README.md command table updated from registry"
 	@$(MAKE) completions
 	@echo "Documentation, completions updated successfully"
 

--- a/README.md
+++ b/README.md
@@ -32,18 +32,16 @@ Click any GIF to view full size.
 
 ggc is a Git tool written in Go, offering both a traditional CLI and an interactive TUI with incremental search and multi-command workflows. Run `ggc <subcommand>` directly, or type `ggc` on its own to open the fuzzy picker.
 
-Full docs: **<https://bmf-san.github.io/ggc/>**
+Supported: macOS (amd64 / arm64 / universal), Linux (amd64 / arm64), Windows (amd64). Requires Git and Go 1.25+ to build.
 
-## Features
+Full documentation lives at **<https://bmf-san.github.io/ggc/>**:
 
-- **Flagless CLI** — every command is verb + words (`ggc branch delete merged`, `ggc commit amend no-edit`). No `-m`/`--flag` juggling.
-- **Interactive mode** — fuzzy-search every command, pipe commands into workflows with <kbd>Tab</kbd>, and run the pipeline with <kbd>Ctrl</kbd>+<kbd>T</kbd>.
-- **Pickers when arguments are omitted** — `ggc branch checkout`, `ggc stash pop`, `ggc restore` all prompt for the target.
-- **Composite helpers** — `ggc pull rebase`, `ggc push force`, `ggc rebase autosquash`, `ggc fetch prune`, and more.
-- **User aliases** — define simple or multi-step aliases in `~/.config/ggc/config.yaml`.
-- **Customizable keybindings** — 4 built-in profiles (default, emacs, vi, readline) plus per-OS / per-terminal / per-context overrides.
-- **Shell completion** — pre-built scripts for Bash, Zsh, and Fish.
-- **Supported:** macOS (amd64 / arm64 / universal), Linux (amd64 / arm64), Windows (amd64). Requires Git and Go 1.25+ to build.
+- [Why ggc? + feature highlights](https://bmf-san.github.io/ggc/#why-ggc)
+- [Quick start](https://bmf-san.github.io/ggc/guide/quickstart/)
+- [Command reference](https://bmf-san.github.io/ggc/guide/commands/) — auto-generated from the registry
+- [Interactive mode & workflows](https://bmf-san.github.io/ggc/guide/interactive/)
+- [Configuration, aliases, keybindings](https://bmf-san.github.io/ggc/guide/config/)
+- [Troubleshooting](https://bmf-san.github.io/ggc/guide/troubleshooting/)
 
 ## Install
 
@@ -60,135 +58,6 @@ go install github.com/bmf-san/ggc/v8@latest
 
 Windows binaries, pre-built archives, and source builds are covered in the [installation guide](https://bmf-san.github.io/ggc/guide/install/). After installing, run `ggc doctor` to verify.
 
-## Quick start
-
-```bash
-ggc status                           # working tree status
-ggc add .                            # stage everything
-ggc commit "fix: off-by-one"         # no -m required
-ggc log graph                        # prettier git log
-ggc branch checkout                  # list + pick a local branch
-ggc rebase interactive               # interactive rebase
-```
-
-Run `ggc` with no arguments to enter interactive mode. See the [quick start](https://bmf-san.github.io/ggc/guide/quickstart/) and [interactive mode guide](https://bmf-san.github.io/ggc/guide/interactive/) for more.
-
-### Unified syntax and `--` separator
-
-ggc uses a flagless, space-separated syntax. To pass a literal that starts with `-`, use the standard `--` separator:
-
-```bash
-ggc commit -- - fix leading dash
-```
-
-Everything after `--` is treated as data, never as subcommands.
-
-## Command reference
-
-### Available Commands
-
-| Command | Description |
-|--------|-------------|
-| `add .` | Add all changes to the index |
-| `add <file>` | Add a specific file to the index |
-| `add interactive` | Add changes interactively |
-| `add patch` | Add changes interactively (patch mode) |
-| `help` | Show main help message |
-| `help <command>` | Show help for a specific command |
-| `reset` | Hard reset to origin/<branch> and clean working directory |
-| `reset hard <commit>` | Hard reset to specified commit |
-| `reset soft <commit>` | Soft reset: move HEAD but keep changes staged |
-| `branch checkout` | Switch to an existing branch |
-| `branch checkout remote` | Create and checkout a local branch from the remote |
-| `branch contains <commit>` | Show branches containing a commit |
-| `branch create` | Create and checkout a new branch |
-| `branch current` | Show current branch name |
-| `branch delete` | Delete local branch |
-| `branch delete merged` | Delete local merged branch |
-| `branch info <branch>` | Show detailed branch information |
-| `branch list local` | List local branches |
-| `branch list remote` | List remote branches |
-| `branch list verbose` | Show detailed branch listing |
-| `branch move <branch> <commit>` | Move branch to specified commit |
-| `branch rename <old> <new>` | Rename a branch |
-| `branch set upstream <branch> <upstream>` | Set upstream for a branch |
-| `branch sort [date|name]` | List branches sorted by date or name |
-| `commit <message>` | Create commit with a message |
-| `commit allow empty` | Create an empty commit |
-| `commit amend` | Amend previous commit (editor) |
-| `commit amend no-edit` | Amend without editing commit message |
-| `commit fixup <commit>` | Create a fixup commit targeting <commit> |
-| `log graph` | Show log with graph |
-| `log simple` | Show simple historical log |
-| `fetch` | Fetch from the remote |
-| `fetch prune` | Fetch and clean stale references |
-| `pull current` | Pull current branch from remote repository |
-| `pull rebase` | Pull and rebase |
-| `push current` | Push current branch to remote repository |
-| `push force` | Force push current branch |
-| `remote add <name> <url>` | Add remote repository |
-| `remote list` | List all remote repositories |
-| `remote remove <name>` | Remove remote repository |
-| `remote set-url <name> <url>` | Change remote URL |
-| `status` | Show working tree status |
-| `status short` | Show concise status (porcelain format) |
-| `clean dirs` | Clean untracked directories |
-| `clean files` | Clean untracked files |
-| `clean interactive` | Clean files interactively |
-| `restore .` | Restore all files in working directory from index |
-| `restore <commit> <file>` | Restore file from specific commit |
-| `restore <file>` | Restore file in working directory from index |
-| `restore staged .` | Unstage all files |
-| `restore staged <file>` | Unstage file (restore from HEAD to index) |
-| `diff` | Show changes (git diff HEAD) |
-| `diff head` | Alias for default diff against HEAD |
-| `diff staged` | Show staged changes |
-| `diff unstaged` | Show unstaged changes |
-| `tag annotated <tag> <message>` | Create annotated tag |
-| `tag create <tag>` | Create tag |
-| `tag delete <tag>` | Delete tag |
-| `tag list` | List all tags |
-| `tag push` | Push tags to remote |
-| `tag show <tag>` | Show tag information |
-| `config get <key>` | Get a specific config value |
-| `config list` | List all configuration |
-| `config set <key> <value>` | Set a configuration value |
-| `hook disable <hook>` | Disable a hook |
-| `hook edit <hook>` | Edit a hook's contents |
-| `hook enable <hook>` | Enable a hook |
-| `hook install <hook>` | Install a hook |
-| `hook list` | List all hooks |
-| `hook uninstall <hook>` | Uninstall an existing hook |
-| `rebase <upstream>` | Rebase current branch onto <upstream> |
-| `rebase abort` | Abort an in-progress rebase |
-| `rebase autosquash` | Interactive rebase with --autosquash |
-| `rebase continue` | Continue an in-progress rebase |
-| `rebase interactive` | Interactive rebase |
-| `rebase skip` | Skip current patch and continue |
-| `stash` | Stash current changes |
-| `stash apply` | Apply stash without removing it |
-| `stash apply <stash>` | Apply specific stash without removing it |
-| `stash branch <branch>` | Create branch from stash |
-| `stash branch <branch> <stash>` | Create branch from specific stash |
-| `stash clear` | Remove all stashes |
-| `stash create` | Create stash and return object name |
-| `stash drop` | Remove the latest stash |
-| `stash drop <stash>` | Remove specific stash |
-| `stash list` | List all stashes |
-| `stash pop` | Apply and remove the latest stash |
-| `stash pop <stash>` | Apply and remove specific stash |
-| `stash push` | Save changes to new stash |
-| `stash push -m <message>` | Save changes to new stash with message |
-| `stash save <message>` | Save changes to new stash with message |
-| `stash show` | Show changes in stash |
-| `stash show <stash>` | Show changes in specific stash |
-| `stash store <object>` | Store stash object |
-| `debug-keys` | Show current keybindings |
-| `debug-keys raw` | Capture key sequences interactively |
-| `debug-keys raw <file>` | Capture key sequences and save them to a file |
-| `doctor` | Diagnose the local ggc installation |
-| `quit` | Exit interactive mode |
-| `version` | Display current ggc version |
 ## References
 
 - [ggc documentation site](https://bmf-san.github.io/ggc/) - Full user guide, install notes, configuration reference, and troubleshooting

--- a/tools/cmd/gendocs/main.go
+++ b/tools/cmd/gendocs/main.go
@@ -2,7 +2,6 @@
 package main
 
 import (
-	"bufio"
 	"fmt"
 	"os"
 	"sort"
@@ -11,171 +10,14 @@ import (
 	"github.com/bmf-san/ggc/v8/cmd/command"
 )
 
+const commandsReferencePath = "docs/guide/commands.md"
+
 func main() {
-	lines, err := readREADME()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error reading README: %v\n", err)
-		os.Exit(1)
-	}
-
-	startIdx, endIdx, err := findCommandSection(lines)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error finding command section: %v\n", err)
-		os.Exit(1)
-	}
-
-	tableStartIdx, tableEndIdx, err := findCommandTable(lines, startIdx, endIdx)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error finding command table: %v\n", err)
-		os.Exit(1)
-	}
-
-	newTable := generateCommandTable()
-
-	if err := writeUpdatedREADME(lines, tableStartIdx, tableEndIdx, newTable); err != nil {
-		fmt.Fprintf(os.Stderr, "Error writing README: %v\n", err)
-		os.Exit(1)
-	}
-
-	fmt.Println("README.md command table updated successfully")
-
-	if err := writeCommandsReference("docs/guide/commands.md"); err != nil {
+	if err := writeCommandsReference(commandsReferencePath); err != nil {
 		fmt.Fprintf(os.Stderr, "Error writing commands reference: %v\n", err)
 		os.Exit(1)
 	}
-	fmt.Println("docs/guide/commands.md regenerated from registry")
-}
-
-func readREADME() ([]string, error) {
-	file, err := os.Open("README.md")
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		_ = file.Close()
-	}()
-
-	var lines []string
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		lines = append(lines, scanner.Text())
-	}
-
-	return lines, scanner.Err()
-}
-
-func findCommandSection(lines []string) (int, int, error) {
-	startIdx := -1
-	endIdx := -1
-
-	for i, line := range lines {
-		if strings.Contains(line, "### Available Commands") {
-			startIdx = i
-		}
-		if startIdx != -1 && startIdx < i && strings.HasPrefix(line, "### ") && !strings.Contains(line, "Available Commands") {
-			endIdx = i
-			break
-		}
-	}
-
-	if startIdx == -1 {
-		return 0, 0, fmt.Errorf("could not find '### Available Commands' section")
-	}
-
-	return startIdx, endIdx, nil
-}
-
-func findCommandTable(lines []string, startIdx, endIdx int) (int, int, error) {
-	tableStartIdx := findTableStart(lines, startIdx, endIdx)
-	if tableStartIdx == -1 {
-		return 0, 0, fmt.Errorf("could not find command table")
-	}
-
-	tableEndIdx := findTableEnd(lines, tableStartIdx, endIdx)
-	return tableStartIdx, tableEndIdx, nil
-}
-
-func findTableStart(lines []string, startIdx, endIdx int) int {
-	for i := startIdx; i < len(lines) && (endIdx == -1 || i < endIdx); i++ {
-		if strings.HasPrefix(lines[i], "| Command | Description |") {
-			return i
-		}
-	}
-	return -1
-}
-
-func findTableEnd(lines []string, tableStartIdx, endIdx int) int {
-	for i := tableStartIdx + 2; i < len(lines); i++ { // Skip header and separator
-		if (endIdx != -1 && i >= endIdx) ||
-			(!strings.HasPrefix(lines[i], "|") && strings.TrimSpace(lines[i]) != "") {
-			return i
-		}
-	}
-	return len(lines)
-}
-
-func writeUpdatedREADME(lines []string, tableStartIdx, tableEndIdx int, newTable []string) error {
-	var newLines []string
-	newLines = append(newLines, lines[:tableStartIdx]...)
-	newLines = append(newLines, newTable...)
-	newLines = append(newLines, lines[tableEndIdx:]...)
-
-	output, err := os.Create("README.md")
-	if err != nil {
-		return err
-	}
-	defer func() {
-		_ = output.Close()
-	}()
-
-	for _, line := range newLines {
-		if _, err := fmt.Fprintln(output, line); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func generateCommandTable() []string {
-	registry := command.NewRegistry()
-	commands := registry.VisibleCommands()
-
-	// Sort commands by category, then by name
-	sort.Slice(commands, func(i, j int) bool {
-		if commands[i].Category != commands[j].Category {
-			return command.CategoryOrder(commands[i].Category) < command.CategoryOrder(commands[j].Category)
-		}
-		return commands[i].Name < commands[j].Name
-	})
-
-	var table []string
-	table = append(table, "| Command | Description |")
-	table = append(table, "|--------|-------------|")
-
-	for i := range commands {
-		cmd := &commands[i]
-		if len(cmd.Subcommands) == 0 {
-			table = append(table, fmt.Sprintf("| `%s` | %s |", cmd.Name, cmd.Summary))
-		} else {
-			// Sort subcommands by name
-			subcommands := make([]command.SubcommandInfo, 0, len(cmd.Subcommands))
-			for _, sub := range cmd.Subcommands {
-				if !sub.Hidden {
-					subcommands = append(subcommands, sub)
-				}
-			}
-			sort.Slice(subcommands, func(i, j int) bool {
-				return subcommands[i].Name < subcommands[j].Name
-			})
-
-			for _, sub := range subcommands {
-				table = append(table, fmt.Sprintf("| `%s` | %s |", sub.Name, sub.Summary))
-			}
-		}
-	}
-
-	return table
+	fmt.Printf("%s regenerated from registry\n", commandsReferencePath)
 }
 
 func writeCommandsReference(path string) error {


### PR DESCRIPTION
Follows up on #401. After that slim pass, the README was still carrying content that now lives on the docs site:

- The 100-row **Available Commands** table was in both README.md and `docs/guide/commands.md` (and the docs-site version, added in #402, is the richer one — summary + aliases + usage + subcommands + examples per command).
- The **Quick start** snippet and **Unified syntax and `--` separator** note were in both README.md and `docs/guide/quickstart.md`.
- The README **Features** bullet list restated what `docs/index.md` already says under "Why ggc?".
- **References** showed up twice after the last slim pass (header left behind in one of the intermediate edits).

### README changes

- Drop Features, Quick start (with Unified syntax subsection), Command reference (the whole table), and the duplicate References block.
- Replace with a 6-link bullet list pointing at the docs site (Why ggc / Quick start / Command reference / Interactive mode / Configuration / Troubleshooting).
- Keep everything only the repo front page should own: badges, logo, demo GIFs, overview, install snippet, References, contributing, sponsor, stargazers, license.

Net: 218 → 88 lines.

### `tools/cmd/gendocs/main.go`

`make docs` previously updated both `README.md`'s command table *and* `docs/guide/commands.md`. Now that the README no longer has a table, the README machinery goes away entirely:

- Remove `readREADME`, `findCommandSection`, `findCommandTable`, `findTableStart`, `findTableEnd`, `writeUpdatedREADME`, `generateCommandTable`.
- `main()` just calls `writeCommandsReference("docs/guide/commands.md")`.
- File shrinks from ~300 to ~130 lines.

### `Makefile`

Update the `docs:` target's log line to match ("regenerating `docs/guide/commands.md`" instead of "updating README.md command table").

### Test

- `go build ./...` clean.
- `golangci-lint run ./tools/...` clean.
- `make docs` regenerates `docs/guide/commands.md` and the completion scripts; re-running leaves the tree clean.
