### PR TITLE
feat(version): add `ggc version json` for machine-readable output

### DIFF
--- a/cmd/command/utility.go
+++ b/cmd/command/utility.go
@@ -7,9 +7,20 @@ func utility() []Info {
 			Name:     "version",
 			Category: CategoryUtility,
 			Summary:  "Display current ggc version",
-			Usage:    []string{"ggc version"},
+			Usage: []string{
+				"ggc version",
+				"ggc version json",
+			},
 			Examples: []string{
-				"ggc version   # Shows build time, latest commit and version number",
+				"ggc version        # Human-readable version, commit, build time, os/arch",
+				"ggc version json   # Same info as a JSON document for scripting",
+			},
+			Subcommands: []SubcommandInfo{
+				{
+					Name:    "version json",
+					Summary: "Emit the version information as a JSON document",
+					Usage:   []string{"ggc version json"},
+				},
 			},
 		},
 		{

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -53,22 +54,26 @@ func (v *Versioner) withConfigManager(cm *config.Manager) *Versioner {
 
 // Version returns the ggc version with the given arguments.
 func (v *Versioner) Version(args []string) {
-	if len(args) == 0 {
-		v.displayVersionInfo()
-	} else {
+	switch {
+	case len(args) == 0:
+		v.displayVersionInfo(false)
+	case len(args) == 1 && args[0] == "json":
+		v.displayVersionInfo(true)
+	default:
 		v.helper.ShowVersionHelp()
 	}
 }
 
-// displayVersionInfo displays the version information
-func (v *Versioner) displayVersionInfo() {
+// displayVersionInfo displays the version information.
+// When asJSON is true the output is a machine-readable JSON document.
+func (v *Versioner) displayVersionInfo(asJSON bool) {
 	// Reuse the shared config manager when available to skip a redundant
 	// Load+Save round-trip that otherwise costs ~80ms per `ggc version`.
 	if v.configManager != nil {
 		loadedConfig := v.configManager.GetConfig()
 		v.ensureCreatedAtSet(v.configManager, loadedConfig)
 		v.updateVersionInfoFromBuild(v.configManager, loadedConfig)
-		v.printVersionInfo(loadedConfig)
+		v.emitVersionInfo(loadedConfig, asJSON)
 		return
 	}
 
@@ -81,6 +86,16 @@ func (v *Versioner) displayVersionInfo() {
 		v.updateVersionInfoFromBuild(configManager, loadedConfig)
 	} else {
 		_, _ = fmt.Fprintf(v.outputWriter, "failed to load config: %v\n", loadErr)
+	}
+	v.emitVersionInfo(loadedConfig, asJSON)
+}
+
+// emitVersionInfo writes the version information in either plain-text or
+// JSON form, depending on asJSON.
+func (v *Versioner) emitVersionInfo(loadedConfig *config.Config, asJSON bool) {
+	if asJSON {
+		v.printVersionInfoJSON(loadedConfig)
+		return
 	}
 	v.printVersionInfo(loadedConfig)
 }
@@ -202,6 +217,35 @@ func (v *Versioner) printVersionInfo(loadedConfig *config.Config) {
 	_, _ = fmt.Fprintf(v.outputWriter, "built: %s\n", loadedConfig.Meta.CreatedAt)
 	_, _ = fmt.Fprintf(v.outputWriter, "config version: %s\n", loadedConfig.Meta.ConfigVersion)
 	_, _ = fmt.Fprintf(v.outputWriter, "os/arch: %s/%s\n", runtime.GOOS, runtime.GOARCH)
+}
+
+// printVersionInfoJSON prints the version information as a JSON document.
+// The schema is intentionally flat and stable so tooling can depend on it.
+func (v *Versioner) printVersionInfoJSON(loadedConfig *config.Config) {
+	payload := struct {
+		Version       string `json:"version"`
+		Commit        string `json:"commit"`
+		Built         string `json:"built"`
+		ConfigVersion string `json:"configVersion"`
+		GoVersion     string `json:"goVersion"`
+		OS            string `json:"os"`
+		Arch          string `json:"arch"`
+	}{
+		Version:       v.getVersionString(loadedConfig.Meta.Version),
+		Commit:        v.getCommitString(loadedConfig.Meta.Commit),
+		Built:         loadedConfig.Meta.CreatedAt,
+		ConfigVersion: loadedConfig.Meta.ConfigVersion,
+		GoVersion:     runtime.Version(),
+		OS:            runtime.GOOS,
+		Arch:          runtime.GOARCH,
+	}
+
+	encoded, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		_, _ = fmt.Fprintf(v.outputWriter, "failed to marshal version info: %v\n", err)
+		return
+	}
+	_, _ = fmt.Fprintln(v.outputWriter, string(encoded))
 }
 
 // getVersionString returns a formatted version string

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -480,5 +481,52 @@ func TestVersioner_UpdateConfigValue_Error(t *testing.T) {
 
 	if !strings.Contains(buf.String(), "warn: failed to set") {
 		t.Errorf("expected warn in output, got: %q", buf.String())
+	}
+}
+
+// ─── version json: machine-readable output ─────────────────────────────────────
+
+func TestVersioner_VersionJSON(t *testing.T) {
+	originalGetter := getVersionInfo
+	SetVersionGetter(func() (string, string) { return "v1.2.3", "deadbeef" })
+	t.Cleanup(func() { getVersionInfo = originalGetter })
+
+	tempDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	if err := os.Setenv("HOME", tempDir); err != nil {
+		t.Fatalf("Setenv HOME: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Setenv("HOME", originalHome) })
+
+	var buf bytes.Buffer
+	v := &Versioner{
+		gitClient:    testutil.NewMockGitClient(),
+		outputWriter: &buf,
+		helper:       NewHelper(),
+		execCommand:  exec.Command,
+	}
+	v.helper.outputWriter = &buf
+	v.Version([]string{"json"})
+
+	var payload struct {
+		Version       string `json:"version"`
+		Commit        string `json:"commit"`
+		Built         string `json:"built"`
+		ConfigVersion string `json:"configVersion"`
+		GoVersion     string `json:"goVersion"`
+		OS            string `json:"os"`
+		Arch          string `json:"arch"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
+		t.Fatalf("version json did not produce valid JSON: %v\noutput: %q", err, buf.String())
+	}
+	if payload.Version != "v1.2.3" {
+		t.Errorf("version mismatch: want v1.2.3, got %q", payload.Version)
+	}
+	if payload.Commit != "deadbeef" {
+		t.Errorf("commit mismatch: want deadbeef, got %q", payload.Commit)
+	}
+	if payload.GoVersion == "" || payload.OS == "" || payload.Arch == "" {
+		t.Errorf("runtime fields must be populated, got %+v", payload)
 	}
 }

--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -711,11 +711,19 @@ Display current ggc version.
 
 ```bash
 ggc version
+ggc version json
 ```
+
+**Subcommands:**
+
+| Subcommand | Description |
+|---|---|
+| `version json` | Emit the version information as a JSON document |
 
 **Examples:**
 
 ```bash
-ggc version   # Shows build time, latest commit and version number
+ggc version        # Human-readable version, commit, build time, os/arch
+ggc version json   # Same info as a JSON document for scripting
 ```
 

--- a/tools/completions/ggc.bash
+++ b/tools/completions/ggc.bash
@@ -100,6 +100,11 @@ _ggc()
             COMPREPLY=( $(compgen -W "${subopts}" -- ${cur}) )
             return 0
             ;;
+        version)
+            subopts="json"
+            COMPREPLY=( $(compgen -W "${subopts}" -- ${cur}) )
+            return 0
+            ;;
     esac
 
     if [[ ${COMP_CWORD} == 1 ]]; then

--- a/tools/completions/ggc.fish
+++ b/tools/completions/ggc.fish
@@ -35,6 +35,7 @@ complete -c ggc -f -n "__fish_seen_subcommand_from stash" -a "apply branch clear
 complete -c ggc -f -n "__fish_seen_subcommand_from stash; and __fish_seen_subcommand_from push" -a "-m"
 complete -c ggc -f -n "__fish_seen_subcommand_from status" -a "short"
 complete -c ggc -f -n "__fish_seen_subcommand_from tag" -a "annotated create delete list push show"
+complete -c ggc -f -n "__fish_seen_subcommand_from version" -a "json"
 
 # Branch checkout needs both keyword and dynamic branch names
 complete -c ggc -f -n "__fish_seen_subcommand_from branch; and __fish_seen_subcommand_from checkout" -a "remote (__ggc_complete_branches)"

--- a/tools/completions/ggc.zsh
+++ b/tools/completions/ggc.zsh
@@ -69,6 +69,9 @@ _ggc() {
                 tag)
                     _ggc_tag
                     ;;
+                version)
+                    _ggc_version
+                    ;;
             esac
             ;;
     esac
@@ -394,6 +397,15 @@ _ggc_tag() {
     )
     if (( CURRENT == 2 )); then
         _describe 'tag subcommands' subcommands
+    fi
+}
+_ggc_version() {
+    local subcommands
+    subcommands=(
+        'json:Emit the version information as a JSON document'
+    )
+    if (( CURRENT == 2 )); then
+        _describe 'version subcommands' subcommands
     fi
 }
 


### PR DESCRIPTION
## Why

Part of the general docs/UX cleanup. Several CI/automation tasks want a stable, machine-readable version of `ggc version`:

- Release notes / changelog generation consuming `goVersion`
- Install scripts that want to refuse to upgrade across incompatible `configVersion`s
- Extensions / wrappers checking that `ggc` is at least version X

Parsing the current human-readable output (`ggc version v8.1.0\n commit: …`) works but is brittle across locales and future formatting tweaks.

## What

New subcommand: `ggc version json`

```console
$ ggc version json
{
  "version": "v8.1.0",
  "commit": "abc123",
  "built": "2025-07-14_16:37:09",
  "configVersion": "1.0",
  "goVersion": "go1.25.0",
  "os": "darwin",
  "arch": "arm64"
}
```

The schema is deliberately flat so jq-style tooling stays trivial:

```bash
ggc version json | jq -r .version
```

All values come from the exact same code path as the human output (`displayVersionInfo` → {config manager, build info reconciliation, …}); only the final formatter differs.

## Design notes

- Follows ggc's flagless/space-separated convention, so it's `ggc version json`, not `ggc version --json`.
- `configVersion` and `goVersion` use lowerCamelCase for consistency; `os`/`arch` stay short to match the human form's `os/arch:` line.
- Registry entry (`cmd/command/utility.go`) lists the new subcommand so `gendocs` includes it in the docs reference and `gencompletions` ships it in bash/zsh/fish completion scripts.
- No change to the plain `ggc version` output — existing scripts/tooling keep working unchanged.

## Verification

- `go test ./...` clean (new `TestVersioner_VersionJSON` covers the schema).
- `golangci-lint run ./...` clean.
- `make docs` regenerates `docs/guide/commands.md` idempotently with the new subcommand.
- `make completions` regenerates the three shell scripts.
- Manual check: `ggc version json | jq .` returns the expected keys.
