### PR TITLE
feat(doctor): add PATH, TERM, git-version, and fish-completion checks

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/bmf-san/ggc/v8/internal/config"
@@ -57,9 +58,12 @@ func (d *Doctor) Doctor(args []string) {
 	results := []diagResult{
 		d.checkGoRuntime(),
 		d.checkGitBinary(),
+		d.checkGgcOnPATH(),
 		d.checkGgcConfig(),
 		d.checkCompletions("bash"),
 		d.checkCompletions("zsh"),
+		d.checkCompletions("fish"),
+		d.checkTerm(),
 		d.checkTTY(),
 	}
 	d.printReport(results)
@@ -108,7 +112,83 @@ func (d *Doctor) checkGitBinary() diagResult {
 	if err != nil {
 		return diagResult{name: "git binary", ok: false, detail: fmt.Sprintf("%s: %v", path, err)}
 	}
-	return diagResult{name: "git binary", ok: true, detail: fmt.Sprintf("%s (%s)", path, strings.TrimSpace(string(out)))}
+	trimmed := strings.TrimSpace(string(out))
+	if major, minor, ok := parseGitVersion(trimmed); ok {
+		if major < minGitMajor || (major == minGitMajor && minor < minGitMinor) {
+			return diagResult{
+				name:   "git binary",
+				ok:     false,
+				warn:   true,
+				detail: fmt.Sprintf("%s (%s) is older than the recommended %d.%d; some subcommands may not work", path, trimmed, minGitMajor, minGitMinor),
+			}
+		}
+	}
+	return diagResult{name: "git binary", ok: true, detail: fmt.Sprintf("%s (%s)", path, trimmed)}
+}
+
+// minGit{Major,Minor} is the lowest Git version we actively test against.
+// Older Git ships without the porcelain flags several ggc subcommands rely on.
+const (
+	minGitMajor = 2
+	minGitMinor = 30
+)
+
+// parseGitVersion extracts the major+minor number from a `git --version`
+// line such as "git version 2.44.0" or "git version 2.39.3 (Apple Git-146)".
+func parseGitVersion(s string) (int, int, bool) {
+	const prefix = "git version "
+	if !strings.HasPrefix(s, prefix) {
+		return 0, 0, false
+	}
+	rest := strings.TrimPrefix(s, prefix)
+	if idx := strings.IndexAny(rest, " \t"); idx != -1 {
+		rest = rest[:idx]
+	}
+	parts := strings.SplitN(rest, ".", 3)
+	if len(parts) < 2 {
+		return 0, 0, false
+	}
+	major, err1 := strconv.Atoi(parts[0])
+	minor, err2 := strconv.Atoi(parts[1])
+	if err1 != nil || err2 != nil {
+		return 0, 0, false
+	}
+	return major, minor, true
+}
+
+// checkGgcOnPATH verifies that a user invoking `ggc` from an arbitrary
+// directory gets the same binary that is currently running. Shadowing by
+// an old Homebrew install or a stale `go install` copy is a common silent
+// failure mode.
+func (d *Doctor) checkGgcOnPATH() diagResult {
+	self, selfErr := os.Executable()
+	resolved, lookErr := d.lookPath("ggc")
+	switch {
+	case lookErr != nil && selfErr == nil:
+		return diagResult{
+			name:   "ggc on PATH",
+			ok:     false,
+			warn:   true,
+			detail: fmt.Sprintf("running %s but 'ggc' is not on PATH; add its directory to PATH to use shell completions", self),
+		}
+	case lookErr != nil:
+		return diagResult{name: "ggc on PATH", ok: false, warn: true, detail: "'ggc' not found on PATH"}
+	case selfErr != nil:
+		return diagResult{name: "ggc on PATH", ok: true, detail: resolved}
+	}
+	// Compare by resolved symlink target so /opt/homebrew/bin/ggc ->
+	// /opt/homebrew/Cellar/ggc/…/bin/ggc still counts as a match.
+	selfReal, _ := filepath.EvalSymlinks(self)
+	resolvedReal, _ := filepath.EvalSymlinks(resolved)
+	if selfReal != "" && resolvedReal != "" && selfReal != resolvedReal {
+		return diagResult{
+			name:   "ggc on PATH",
+			ok:     false,
+			warn:   true,
+			detail: fmt.Sprintf("running %s but PATH resolves 'ggc' to %s; an older install may shadow this one", self, resolved),
+		}
+	}
+	return diagResult{name: "ggc on PATH", ok: true, detail: resolved}
 }
 
 // configCandidatePaths mirrors (manager).getConfigPaths without exposing it.
@@ -188,6 +268,13 @@ func (d *Doctor) checkCompletions(shell string) diagResult {
 			"/opt/homebrew/share/zsh/site-functions/_ggc",
 			filepath.Join(home, ".zsh/completions/_ggc"),
 		}
+	case "fish":
+		candidates = []string{
+			"/usr/share/fish/vendor_completions.d/ggc.fish",
+			"/usr/local/share/fish/vendor_completions.d/ggc.fish",
+			"/opt/homebrew/share/fish/vendor_completions.d/ggc.fish",
+			filepath.Join(home, ".config/fish/completions/ggc.fish"),
+		}
 	default:
 		return diagResult{name: shell + " completions", ok: true}
 	}
@@ -217,4 +304,27 @@ func (d *Doctor) checkTTY() diagResult {
 		}
 	}
 	return diagResult{name: "stdin TTY", ok: true, detail: "stdin is a TTY"}
+}
+
+// checkTerm warns when $TERM looks like something the interactive TUI
+// cannot fully drive (dumb terminal, unset, or vt52-level).
+func (d *Doctor) checkTerm() diagResult {
+	term := os.Getenv("TERM")
+	switch term {
+	case "":
+		return diagResult{
+			name:   "TERM",
+			ok:     false,
+			warn:   true,
+			detail: "$TERM is unset; interactive mode may render incorrectly",
+		}
+	case "dumb":
+		return diagResult{
+			name:   "TERM",
+			ok:     false,
+			warn:   true,
+			detail: "$TERM=dumb; interactive mode will not work (one-shot subcommands are fine)",
+		}
+	}
+	return diagResult{name: "TERM", ok: true, detail: term}
 }

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -147,3 +147,80 @@ func TestDoctor_FullReport_NoHardFailures(t *testing.T) {
 		t.Fatalf("expected success footer, got:\n%s", out)
 	}
 }
+
+func TestParseGitVersion(t *testing.T) {
+	cases := []struct {
+		in           string
+		major, minor int
+		ok           bool
+	}{
+		{"git version 2.46.0", 2, 46, true},
+		{"git version 2.39.3 (Apple Git-146)", 2, 39, true},
+		{"git version 1.9.1", 1, 9, true},
+		{"git version abc", 0, 0, false},
+		{"not a git version string", 0, 0, false},
+		{"git version 2", 0, 0, false},
+	}
+	for _, tc := range cases {
+		major, minor, ok := parseGitVersion(tc.in)
+		if ok != tc.ok || major != tc.major || minor != tc.minor {
+			t.Errorf("parseGitVersion(%q) = (%d, %d, %v); want (%d, %d, %v)",
+				tc.in, major, minor, ok, tc.major, tc.minor, tc.ok)
+		}
+	}
+}
+
+func TestDoctor_GitBinary_TooOldIsWarn(t *testing.T) {
+	d := newTestDoctor(&bytes.Buffer{})
+	d.lookPath = func(string) (string, error) { return "/usr/bin/git", nil }
+	d.execCommand = func(_ string, _ ...string) *exec.Cmd {
+		// Well below the minimum we care about.
+		return exec.Command("echo", "git version 1.9.1")
+	}
+	r := d.checkGitBinary()
+	if r.ok || !r.warn {
+		t.Fatalf("ancient git should be WARN, got %+v", r)
+	}
+	if !strings.Contains(r.detail, "older than the recommended") {
+		t.Fatalf("detail should explain the warning, got %q", r.detail)
+	}
+}
+
+func TestDoctor_Term_DumbIsWarn(t *testing.T) {
+	d := newTestDoctor(&bytes.Buffer{})
+	t.Setenv("TERM", "dumb")
+	r := d.checkTerm()
+	if r.ok || !r.warn {
+		t.Fatalf("TERM=dumb should be WARN, got %+v", r)
+	}
+	if !strings.Contains(r.detail, "dumb") {
+		t.Fatalf("detail should mention dumb, got %q", r.detail)
+	}
+}
+
+func TestDoctor_Term_UnsetIsWarn(t *testing.T) {
+	d := newTestDoctor(&bytes.Buffer{})
+	t.Setenv("TERM", "")
+	r := d.checkTerm()
+	if r.ok || !r.warn {
+		t.Fatalf("unset TERM should be WARN, got %+v", r)
+	}
+}
+
+func TestDoctor_Term_NormalIsOK(t *testing.T) {
+	d := newTestDoctor(&bytes.Buffer{})
+	t.Setenv("TERM", "xterm-256color")
+	r := d.checkTerm()
+	if !r.ok {
+		t.Fatalf("normal TERM should be OK, got %+v", r)
+	}
+}
+
+func TestDoctor_GgcOnPATH_NotFound(t *testing.T) {
+	d := newTestDoctor(&bytes.Buffer{})
+	d.lookPath = func(string) (string, error) { return "", errors.New("not found") }
+	r := d.checkGgcOnPATH()
+	if r.ok || !r.warn {
+		t.Fatalf("missing ggc on PATH should be WARN, got %+v", r)
+	}
+}


### PR DESCRIPTION
## Why

`ggc doctor` already checks the essentials (git present, config parseable, bash/zsh completions installed, stdin TTY). Four additional silent-failure modes show up often enough in issues to be worth catching automatically:

- A user has two `ggc` binaries on PATH (`go install` copy vs Homebrew) and edits the wrong one.
- Git is old enough that `push --force-with-lease`, `--autosquash`, etc. don't behave the way ggc expects.
- The interactive TUI renders garbage because `$TERM` is `dumb` or unset (CI runners, remote shells, dockerfiles).
- `fish` users miss completions entirely because the check only knew about bash/zsh.

## What

### 1. `ggc on PATH`
Resolves `ggc` via `exec.LookPath` and compares the result (after `filepath.EvalSymlinks`) against `os.Executable()`. If the two differ, warn — it almost always means an older install is shadowing the current one. Not-on-PATH is also warned.

### 2. Git minimum version
Parses `git --version` and warns when it is below 2.30. The parser handles stock `git version 2.46.0`, Apple Git's `git version 2.39.3 (Apple Git-146)`, and refuses to guess on malformed input.

### 3. `TERM`
Warns on `TERM=dumb` or empty `$TERM`. One-shot subcommands still work in those environments, which is why it is WARN not FAIL.

### 4. fish completions
The existing helper is extended to look in `vendor_completions.d` and `~/.config/fish/completions/`.

## Sample output

```console
$ ggc doctor
[OK  ] Go runtime: go1.25.0 (darwin/arm64)
[OK  ] git binary: /opt/homebrew/bin/git (git version 2.46.0)
[OK  ] ggc on PATH: /opt/homebrew/bin/ggc
[OK  ] ggc config: /Users/you/.ggcconfig.yaml loaded
[WARN] bash completions: not installed in a well-known location (see tools/completions/ in the repo)
[WARN] zsh completions: not installed in a well-known location (see tools/completions/ in the repo)
[WARN] fish completions: not installed in a well-known location (see tools/completions/ in the repo)
[OK  ] TERM: xterm-256color
[OK  ] stdin TTY: stdin is a TTY

Everything looks good.
```

## Verification

- `go test ./...` — all packages green (6 new tests covering the new checks plus `parseGitVersion`).
- `golangci-lint run ./...` clean.
- New checks use the same injection seams (`lookPath`, `execCommand`, `userHomeDir`, `stdinStat`) as the existing checks, so tests stay hermetic.
- No change to the existing result ordering for the checks that were already present — only additions.
