### PR TITLE
build: sign checksums with cosign keyless on tagged releases

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -27,4 +27,6 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --snapshot
+          # Skip signing in the dry run: cosign keyless needs a real
+          # GitHub OIDC token, which is only minted on tagged releases.
+          args: release --snapshot --skip=sign

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: write
+  # Required for cosign keyless signing via GitHub's OIDC provider.
+  id-token: write
 
 jobs:
   goreleaser:
@@ -25,6 +27,8 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Install Syft (SBOM)
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -52,6 +52,23 @@ checksum:
 sboms:
   - artifacts: archive
 
+# Sign the checksum file with cosign in keyless mode (via GitHub OIDC).
+# Signing only the checksum file keeps the release page small while still
+# covering every archive: verifying the checksum verifies each artifact.
+signs:
+  - id: cosign-checksum
+    cmd: cosign
+    signature: "${artifact}.sig"
+    certificate: "${artifact}.pem"
+    args:
+      - "sign-blob"
+      - "--output-certificate=${certificate}"
+      - "--output-signature=${signature}"
+      - "${artifact}"
+      - "--yes"
+    artifacts: checksum
+    output: true
+
 changelog:
   sort: asc
   use: github


### PR DESCRIPTION
## Why

Release artifacts currently have SBOMs and checksums but no cryptographic signature. Anyone who downloads a `ggc_*.tar.gz` has to trust that the CDN / GitHub haven't been tampered with. Cosign keyless signing (via Sigstore/Fulcio + GitHub OIDC) closes that gap without requiring us to manage long-lived signing keys.

## What

### `.goreleaser.yml`

Adds a `signs:` block:

```yaml
signs:
  - id: cosign-checksum
    cmd: cosign
    signature: "${artifact}.sig"
    certificate: "${artifact}.pem"
    args:
      - "sign-blob"
      - "--output-certificate=${certificate}"
      - "--output-signature=${signature}"
      - "${artifact}"
      - "--yes"
    artifacts: checksum
    output: true
```

Design choice: sign **`checksums.txt` only**, not each archive.

- The checksum file already covers every per-OS/arch archive — if you verify the signature on `checksums.txt` and then `sha256sum -c`, every artifact is transitively attested.
- Halves the number of `.sig`/`.pem` files on every release page (2 vs ~14).
- Still lets Homebrew / Scoop / third-party installers pin releases against Sigstore.

### `.github/workflows/release.yml`

- Adds `id-token: write` permission — required for GitHub's OIDC provider to hand a token to cosign, which exchanges it with Fulcio for a short-lived signing certificate. No secret to rotate.
- Installs `sigstore/cosign-installer@v3.9.2` (SHA-pinned).

### `.github/workflows/release-dry-run.yml`

- Passes `--skip=sign` to goreleaser. Dry runs fire on every push, don't carry an OIDC token we should abuse, and shouldn't be writing to the Rekor transparency log.

## Verification (local)

```console
$ goreleaser check
  • 1 configuration file(s) validated

$ goreleaser release --snapshot --clean --skip=sign,publish,sbom
  • release succeeded after 1s
```

All archives build; checksum file is produced; sign step is correctly skipped in snapshot/dry-run modes.

## Verifying a real release (for end users)

```bash
TAG=v8.2.0
curl -sSLO "https://github.com/bmf-san/ggc/releases/download/${TAG}/checksums.txt"
curl -sSLO "https://github.com/bmf-san/ggc/releases/download/${TAG}/checksums.txt.sig"
curl -sSLO "https://github.com/bmf-san/ggc/releases/download/${TAG}/checksums.txt.pem"

cosign verify-blob \
  --certificate checksums.txt.pem \
  --signature   checksums.txt.sig \
  --certificate-identity-regexp "^https://github.com/bmf-san/ggc/\\.github/workflows/release\\.yml@" \
  --certificate-oidc-issuer     "https://token.actions.githubusercontent.com" \
  checksums.txt

sha256sum -c --ignore-missing checksums.txt
```

## Follow-ups (intentionally not in this PR)

- Document the verification recipe on the docs site (will do in a dedicated docs PR so it sits next to the install guide).
- Publish a Sigstore Scorecard entry if/when we set up reproducible-builds promises.
