### PR TITLE
feat(completion): add ggc completion install and shellcheck CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,12 @@ jobs:
       - name: Run linter
         run: make lint
 
+      - name: Lint shell scripts (shellcheck)
+        if: matrix.os == 'ubuntu-latest'
+        # install.sh is the user-facing curl|bash installer, so a broken
+        # quote is a supply-chain-grade problem. Fail CI on any finding.
+        run: shellcheck -x install.sh
+
       - name: Check generated artifacts are up to date
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ When implementing new features or modifying existing ones, please ensure to:
 
 #### Shell Completion Scripts:
 - **Auto-generated**: Run `make docs` (or `make completions`) to regenerate the Bash/Zsh/Fish completion scripts from the registry.
-- **Do not edit** files under `tools/completions/` manually—changes will be overwritten by the generator.
+- **Do not edit** files under `cmd/completions/` manually—changes will be overwritten by the generator.
 
 **📋 Checklist for Command Changes:**
 - [ ] cmd/command/registry.go entry added/updated (usage, examples, handler)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -50,6 +50,7 @@ type Cmd struct {
 	cmdRouter     *commandRouter
 	debugger      *Debugger
 	doctor        *Doctor
+	completer     *Completer
 }
 
 // GitDeps is a composite for wiring commands that depend on git operations.
@@ -129,6 +130,7 @@ func NewCmd(client GitDeps, cm *config.Manager) (*Cmd, error) {
 		fetcher:       NewFetcher(client),
 		doctor:        NewDoctor(),
 		debugger:      NewDebugger(),
+		completer:     NewCompleter(),
 	}
 	router, err := newCommandRouter(cmd)
 	if err != nil {

--- a/cmd/command/utility.go
+++ b/cmd/command/utility.go
@@ -33,6 +33,42 @@ func utility() []Info {
 			},
 		},
 		{
+			Name:     "completion",
+			Category: CategoryUtility,
+			Summary:  "Print or install shell completion scripts",
+			Usage: []string{
+				"ggc completion <bash|zsh|fish>",
+				"ggc completion install <bash|zsh|fish>",
+			},
+			Examples: []string{
+				"ggc completion bash                   # Print the bash completion to stdout",
+				"ggc completion install zsh            # Install zsh completion under ~/.zsh/completions/",
+				"ggc completion fish > ~/.config/fish/completions/ggc.fish",
+			},
+			Subcommands: []SubcommandInfo{
+				{
+					Name:    "completion bash",
+					Summary: "Print bash completion script",
+					Usage:   []string{"ggc completion bash"},
+				},
+				{
+					Name:    "completion zsh",
+					Summary: "Print zsh completion script",
+					Usage:   []string{"ggc completion zsh"},
+				},
+				{
+					Name:    "completion fish",
+					Summary: "Print fish completion script",
+					Usage:   []string{"ggc completion fish"},
+				},
+				{
+					Name:    "completion install <shell>",
+					Summary: "Install the completion script for <bash|zsh|fish>",
+					Usage:   []string{"ggc completion install <bash|zsh|fish>"},
+				},
+			},
+		},
+		{
 			Name:     "debug-keys",
 			Category: CategoryUtility,
 			Summary:  "Debug keybinding issues and capture raw key sequences",

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,127 @@
+package cmd
+
+import (
+	"embed"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// embeddedCompletions ships the shell completion scripts inside the ggc
+// binary so `ggc completion install <shell>` works with a stock Homebrew
+// install (no access to the source tree required).
+//
+//go:embed completions/ggc.bash completions/ggc.zsh completions/ggc.fish
+var embeddedCompletions embed.FS
+
+// Completer handles the `ggc completion ...` subcommand.
+type Completer struct {
+	outputWriter io.Writer
+	userHomeDir  func() (string, error)
+	helper       *Helper
+}
+
+// NewCompleter returns a Completer writing to stdout.
+func NewCompleter() *Completer {
+	return &Completer{
+		outputWriter: os.Stdout,
+		userHomeDir:  os.UserHomeDir,
+		helper:       NewHelper(),
+	}
+}
+
+// Completion dispatches the subcommand.
+func (c *Completer) Completion(args []string) {
+	if len(args) == 0 {
+		c.helper.outputWriter = c.outputWriter
+		c.helper.ShowCompletionHelp()
+		return
+	}
+	switch args[0] {
+	case "bash", "zsh", "fish":
+		c.print(args[0])
+	case "install":
+		if len(args) < 2 {
+			_, _ = fmt.Fprintln(c.outputWriter, "usage: ggc completion install <bash|zsh|fish>")
+			return
+		}
+		c.install(args[1])
+	default:
+		c.helper.outputWriter = c.outputWriter
+		c.helper.ShowCompletionHelp()
+	}
+}
+
+// print emits the embedded completion script for the given shell to stdout.
+func (c *Completer) print(shell string) {
+	data, err := embeddedCompletions.ReadFile("completions/ggc." + shell)
+	if err != nil {
+		_, _ = fmt.Fprintf(c.outputWriter, "unknown shell: %s\n", shell)
+		return
+	}
+	_, _ = c.outputWriter.Write(data)
+}
+
+// install writes the completion script to the conventional location for
+// the given shell. It picks the first writable target among a
+// deliberately short list of well-known locations so the behaviour is
+// predictable across distros and package managers.
+func (c *Completer) install(shell string) {
+	home, err := c.userHomeDir()
+	if err != nil {
+		_, _ = fmt.Fprintf(c.outputWriter, "cannot resolve home directory: %v\n", err)
+		return
+	}
+	target, ok := c.targetPath(shell, home)
+	if !ok {
+		_, _ = fmt.Fprintf(c.outputWriter, "unknown shell: %s (supported: bash, zsh, fish)\n", shell)
+		return
+	}
+	data, err := embeddedCompletions.ReadFile("completions/ggc." + shell)
+	if err != nil {
+		_, _ = fmt.Fprintf(c.outputWriter, "no embedded completion for %s: %v\n", shell, err)
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		_, _ = fmt.Fprintf(c.outputWriter, "failed to create %s: %v\n", filepath.Dir(target), err)
+		return
+	}
+	if err := os.WriteFile(target, data, 0o644); err != nil {
+		_, _ = fmt.Fprintf(c.outputWriter, "failed to write %s: %v\n", target, err)
+		return
+	}
+	_, _ = fmt.Fprintf(c.outputWriter, "installed %s completion to %s\n", shell, target)
+	c.printReloadHint(shell)
+}
+
+// targetPath returns the canonical per-user install path for a shell.
+// Returning a per-user location (rather than /etc/... or /usr/share/...)
+// avoids surprising sudo requirements; users who want a system-wide
+// install can pipe `ggc completion <shell>` into the path of their choice.
+func (c *Completer) targetPath(shell, home string) (string, bool) {
+	switch shell {
+	case "bash":
+		return filepath.Join(home, ".local/share/bash-completion/completions/ggc"), true
+	case "zsh":
+		return filepath.Join(home, ".zsh/completions/_ggc"), true
+	case "fish":
+		return filepath.Join(home, ".config/fish/completions/ggc.fish"), true
+	default:
+		return "", false
+	}
+}
+
+// printReloadHint tells the user the one manual step they still need:
+// loading the new completion in their current shell session.
+func (c *Completer) printReloadHint(shell string) {
+	switch shell {
+	case "bash":
+		_, _ = fmt.Fprintln(c.outputWriter, "Restart your shell or `source ~/.bashrc` to activate it.")
+	case "zsh":
+		_, _ = fmt.Fprintln(c.outputWriter,
+			"Ensure ~/.zsh/completions is on $fpath (e.g. add `fpath=(~/.zsh/completions $fpath)` to ~/.zshrc) and restart your shell.")
+	case "fish":
+		_, _ = fmt.Fprintln(c.outputWriter, "Fish will pick up the new completion in any new session.")
+	}
+}

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -65,7 +65,7 @@ func (c *Completer) print(shell string) {
 
 // install writes the completion script to the conventional location for
 // the given shell. It picks the first writable target among a
-// deliberately short list of well-known locations so the behaviour is
+// deliberately short list of well-known locations so the behavior is
 // predictable across distros and package managers.
 func (c *Completer) install(shell string) {
 	home, err := c.userHomeDir()

--- a/cmd/completions/ggc.bash
+++ b/cmd/completions/ggc.bash
@@ -8,7 +8,7 @@ _ggc()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    opts="add branch clean commit config debug-keys diff doctor fetch help hook log pull push quit rebase remote reset restore stash status tag version"
+    opts="add branch clean commit completion config debug-keys diff doctor fetch help hook log pull push quit rebase remote reset restore stash status tag version"
     case ${prev} in
         branch)
             subopts="checkout contains create current delete info list move rename set sort"
@@ -22,6 +22,11 @@ _ggc()
             ;;
         commit)
             subopts="allow amend fixup"
+            COMPREPLY=( $(compgen -W "${subopts}" -- ${cur}) )
+            return 0
+            ;;
+        completion)
+            subopts="bash fish install zsh"
             COMPREPLY=( $(compgen -W "${subopts}" -- ${cur}) )
             return 0
             ;;

--- a/cmd/completions/ggc.fish
+++ b/cmd/completions/ggc.fish
@@ -10,7 +10,7 @@ function __ggc_complete_files
 end
 
 # Main commands
-complete -c ggc -f -a "add branch clean commit config debug-keys diff doctor fetch help hook log pull push quit rebase remote reset restore stash status tag version"
+complete -c ggc -f -a "add branch clean commit completion config debug-keys diff doctor fetch help hook log pull push quit rebase remote reset restore stash status tag version"
 complete -c ggc -f -n "__fish_seen_subcommand_from branch" -a "checkout contains create current delete info list move rename set sort"
 complete -c ggc -f -n "__fish_seen_subcommand_from branch; and __fish_seen_subcommand_from delete" -a "merged"
 complete -c ggc -f -n "__fish_seen_subcommand_from branch; and __fish_seen_subcommand_from list" -a "local remote verbose"
@@ -19,6 +19,7 @@ complete -c ggc -f -n "__fish_seen_subcommand_from clean" -a "dirs files interac
 complete -c ggc -f -n "__fish_seen_subcommand_from commit" -a "allow amend fixup"
 complete -c ggc -f -n "__fish_seen_subcommand_from commit; and __fish_seen_subcommand_from allow" -a "empty"
 complete -c ggc -f -n "__fish_seen_subcommand_from commit; and __fish_seen_subcommand_from amend" -a "no-edit"
+complete -c ggc -f -n "__fish_seen_subcommand_from completion" -a "bash fish install zsh"
 complete -c ggc -f -n "__fish_seen_subcommand_from config" -a "get list set"
 complete -c ggc -f -n "__fish_seen_subcommand_from debug-keys" -a "raw"
 complete -c ggc -f -n "__fish_seen_subcommand_from diff" -a "head staged unstaged"

--- a/cmd/completions/ggc.zsh
+++ b/cmd/completions/ggc.zsh
@@ -24,6 +24,9 @@ _ggc() {
                 commit)
                     _ggc_commit
                     ;;
+                completion)
+                    _ggc_completion
+                    ;;
                 config)
                     _ggc_config
                     ;;
@@ -84,6 +87,7 @@ _ggc_commands() {
         'branch:List, create, and manage branches'
         'clean:Remove untracked files and directories'
         'commit:Create commits from staged changes'
+        'completion:Print or install shell completion scripts'
         'config:Get and set ggc configuration'
         'debug-keys:Debug keybinding issues and capture raw key sequences'
         'diff:Inspect changes between commits, the index, and the working tree'
@@ -208,6 +212,18 @@ _ggc_commit() {
             return
             ;;
     esac
+}
+_ggc_completion() {
+    local subcommands
+    subcommands=(
+        'bash:Print bash completion script'
+        'fish:Print fish completion script'
+        'install:Install the completion script for <bash|zsh|fish>'
+        'zsh:Print zsh completion script'
+    )
+    if (( CURRENT == 2 )); then
+        _describe 'completion subcommands' subcommands
+    fi
 }
 _ggc_config() {
     local subcommands

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -287,7 +287,7 @@ func (d *Doctor) checkCompletions(shell string) diagResult {
 		name:   shell + " completions",
 		ok:     false,
 		warn:   true,
-		detail: "not installed in a well-known location (see tools/completions/ in the repo)",
+		detail: "not installed in a well-known location; try `ggc completion install " + shell + "`",
 	}
 }
 

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -261,6 +261,11 @@ func (h *Helper) ShowDoctorHelp() {
 	h.renderCommandFromRegistry("doctor", nil, "Diagnose the local ggc installation")
 }
 
+// ShowCompletionHelp shows help message for the completion command.
+func (h *Helper) ShowCompletionHelp() {
+	h.renderCommandFromRegistry("completion", nil, "Print or install shell completion scripts")
+}
+
 // ShowRebaseHelp shows help message for rebase command.
 func (h *Helper) ShowRebaseHelp() {
 	h.renderCommandFromRegistry("rebase", []string{"ggc rebase [interactive | <upstream> | continue | abort | skip]"}, "Rebase current branch onto another branch; supports interactive and common workflows")

--- a/cmd/router.go
+++ b/cmd/router.go
@@ -48,6 +48,7 @@ func newCommandRouter(cmd *Cmd) (*commandRouter, error) {
 		"restore":    func(args []string) { cmd.Restore(args) },
 		"doctor":     func(args []string) { cmd.doctor.Doctor(args) },
 		"debug-keys": func(args []string) { cmd.DebugKeys(args) },
+		"completion": func(args []string) { cmd.completer.Completion(args) },
 		interactiveQuitCommand: func([]string) {
 			_, _ = fmt.Fprintln(cmd.outputWriter, "The 'quit' command is only available in interactive mode.")
 		},

--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -643,6 +643,34 @@ ggc stash store <object>               # Store stash object
 
 ## Utility {#cat-utility}
 
+### `ggc completion` {#cmd-completion}
+
+Print or install shell completion scripts.
+
+**Usage:**
+
+```bash
+ggc completion <bash|zsh|fish>
+ggc completion install <bash|zsh|fish>
+```
+
+**Subcommands:**
+
+| Subcommand | Description |
+|---|---|
+| `completion bash` | Print bash completion script |
+| `completion fish` | Print fish completion script |
+| `completion install <shell>` | Install the completion script for <bash|zsh|fish> |
+| `completion zsh` | Print zsh completion script |
+
+**Examples:**
+
+```bash
+ggc completion bash                   # Print the bash completion to stdout
+ggc completion install zsh            # Install zsh completion under ~/.zsh/completions/
+ggc completion fish > ~/.config/fish/completions/ggc.fish
+```
+
 ### `ggc debug-keys` {#cmd-debug-keys}
 
 Debug keybinding issues and capture raw key sequences.

--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -64,38 +64,28 @@ sudo mv ggc /usr/local/bin/
 
 ## Shell completions
 
-`ggc` does not generate completions at runtime. Instead, pre-built scripts for Bash, Zsh, and Fish live in
-[`tools/completions/`](https://github.com/bmf-san/ggc/tree/main/tools/completions). Source the one matching your shell from your rc file.
-
-### Bash
+The completion scripts are embedded in the `ggc` binary. One command per shell:
 
 ```bash
-# installed via `go install` (path varies by version)
-if [ -f "$(go env GOPATH)/pkg/mod/github.com/bmf-san/ggc/v8@*/tools/completions/ggc.bash" ]; then
-  . "$(go env GOPATH)"/pkg/mod/github.com/bmf-san/ggc/v8@*/tools/completions/ggc.bash
-fi
-
-# or from a local clone
-. /path/to/ggc/tools/completions/ggc.bash
+ggc completion install bash   # -> ~/.local/share/bash-completion/completions/ggc
+ggc completion install zsh    # -> ~/.zsh/completions/_ggc
+ggc completion install fish   # -> ~/.config/fish/completions/ggc.fish
 ```
 
-### Zsh
+Restart your shell (or for zsh: make sure `~/.zsh/completions` is on `$fpath`).
 
-```zsh
-if [ -f "$(go env GOPATH)/pkg/mod/github.com/bmf-san/ggc/v8@*/tools/completions/ggc.zsh" ]; then
-  . "$(go env GOPATH)"/pkg/mod/github.com/bmf-san/ggc/v8@*/tools/completions/ggc.zsh
-fi
+### Piping to a custom location
+
+`ggc completion <shell>` prints the script to stdout, so you can redirect it anywhere:
+
+```bash
+ggc completion zsh  | sudo tee /usr/local/share/zsh/site-functions/_ggc
+ggc completion bash | sudo tee /etc/bash_completion.d/ggc
 ```
 
-### Fish
+### Reading the pre-built files directly
 
-```fish
-if test -f (go env GOPATH)/pkg/mod/github.com/bmf-san/ggc/v8@*/tools/completions/ggc.fish
-    source (go env GOPATH)/pkg/mod/github.com/bmf-san/ggc/v8@*/tools/completions/ggc.fish
-end
-```
-
-To regenerate the scripts (maintainers): `make completions`. They are produced from the command registry, so a missing completion means the command is not in the registry.
+Source files are also versioned in [`cmd/completions/`](https://github.com/bmf-san/ggc/tree/main/cmd/completions); they are regenerated from the command registry by `make completions`.
 
 ## Verify
 

--- a/install.sh
+++ b/install.sh
@@ -199,7 +199,7 @@ function __ggc_load_completion
     end
 
     # Look for completion file in go modules
-    for completion_file in "$gopath"/pkg/mod/github.com/bmf-san/ggc/v8@*/tools/completions/ggc.fish
+    for completion_file in "$gopath"/pkg/mod/github.com/bmf-san/ggc/v8@*/cmd/completions/ggc.fish
         if test -f "$completion_file"
             source "$completion_file"
             return 0
@@ -207,7 +207,7 @@ function __ggc_load_completion
     end
 
     # Fallback: find completion file
-    set -l completion_file (find "$gopath/pkg/mod/github.com/bmf-san" -name "ggc.fish" -path "*/tools/completions/*" 2>/dev/null | head -1)
+    set -l completion_file (find "$gopath/pkg/mod/github.com/bmf-san" -name "ggc.fish" -path "*/cmd/completions/*" 2>/dev/null | head -1)
     if test -n "$completion_file"; and test -f "$completion_file"
         source "$completion_file"
         return 0
@@ -242,14 +242,14 @@ load_ggc_completion() {
 		return 1
 	fi
 
-	for completion_file in "$gopath"/pkg/mod/github.com/bmf-san/ggc/v8@*/tools/completions/ggc.bash; do
+	for completion_file in "$gopath"/pkg/mod/github.com/bmf-san/ggc/v8@*/cmd/completions/ggc.bash; do
 		if [ -f "$completion_file" ]; then
 			source "$completion_file"
 			return 0
 		fi
 	done
 
-	completion_file=$(find "$gopath/pkg/mod/github.com/bmf-san" -name "ggc.bash" -path "*/tools/completions/*" 2>/dev/null | head -1)
+	completion_file=$(find "$gopath/pkg/mod/github.com/bmf-san" -name "ggc.bash" -path "*/cmd/completions/*" 2>/dev/null | head -1)
 	if [ -n "$completion_file" ] && [ -f "$completion_file" ]; then
 		source "$completion_file"
 		return 0
@@ -275,14 +275,14 @@ load_ggc_completion() {
 		return 1
 	fi
 
-	for completion_file in "$gopath"/pkg/mod/github.com/bmf-san/ggc/v8@*/tools/completions/ggc.zsh; do
+	for completion_file in "$gopath"/pkg/mod/github.com/bmf-san/ggc/v8@*/cmd/completions/ggc.zsh; do
 		if [ -f "$completion_file" ]; then
 			source "$completion_file"
 			return 0
 		fi
 	done
 
-	completion_file=$(find "$gopath/pkg/mod/github.com/bmf-san" -name "ggc.zsh" -path "*/tools/completions/*" 2>/dev/null | head -1)
+	completion_file=$(find "$gopath/pkg/mod/github.com/bmf-san" -name "ggc.zsh" -path "*/cmd/completions/*" 2>/dev/null | head -1)
 	if [ -n "$completion_file" ] && [ -f "$completion_file" ]; then
 		source "$completion_file"
 		return 0

--- a/tools/cmd/gencompletions/main.go
+++ b/tools/cmd/gencompletions/main.go
@@ -25,9 +25,9 @@ func main() {
 	}
 
 	writers := map[string]string{
-		"bash": filepath.Join("tools", "completions", "ggc.bash"),
-		"zsh":  filepath.Join("tools", "completions", "ggc.zsh"),
-		"fish": filepath.Join("tools", "completions", "ggc.fish"),
+		"bash": filepath.Join("cmd", "completions", "ggc.bash"),
+		"zsh":  filepath.Join("cmd", "completions", "ggc.zsh"),
+		"fish": filepath.Join("cmd", "completions", "ggc.fish"),
 	}
 
 	funcMap := template.FuncMap{


### PR DESCRIPTION
## Summary

- `ggc completion <bash|zsh|fish>` prints the completion script to stdout.
- `ggc completion install <shell>` writes it into the standard per-user location:
  - bash: `~/.local/share/bash-completion/completions/ggc`
  - zsh:  `~/.zsh/completions/_ggc`
  - fish: `~/.config/fish/completions/ggc.fish`
- Scripts are embedded with `go:embed`, so `go install` alone is enough. The canonical source now lives in `cmd/completions/` (moved from `tools/completions/`) and is still regenerated from the command registry by `make completions`.
- CI now runs `shellcheck -x install.sh` as a hard gate.

## Why

Previously, `go install github.com/bmf-san/ggc/v8@latest` set up the binary but users had to hunt for `tools/completions/` inside the module cache and source the file manually. Now a single command does it.

## Manual verification

```
go run . completion bash | head        # prints bash completion
HOME=/tmp/ggctest go run . completion install fish
ls /tmp/ggctest/.config/fish/completions/ggc.fish
shellcheck -x install.sh                # clean
```
