### PR TITLE
feat(release): publish multi-arch Docker images to ghcr.io

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -27,6 +27,8 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          # Skip signing in the dry run: cosign keyless needs a real
-          # GitHub OIDC token, which is only minted on tagged releases.
-          args: release --snapshot --skip=sign
+          # Skip signing and docker in the dry run: cosign keyless needs a
+          # real GitHub OIDC token (only minted on tagged releases), and
+          # docker images can't be published from a fork anyway. The real
+          # release workflow exercises both.
+          args: release --snapshot --skip=sign,docker

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ permissions:
   contents: write
   # Required for cosign keyless signing via GitHub's OIDC provider.
   id-token: write
+  # Required to push container images to ghcr.io.
+  packages: write
 
 jobs:
   goreleaser:
@@ -29,6 +31,16 @@ jobs:
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0
       - name: Install Cosign
         uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -94,6 +94,49 @@ changelog:
       - 'Merge pull request'
       - 'Merge branch'
 
+dockers:
+  - id: ggc-amd64
+    ids: [ggc]
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - "ghcr.io/bmf-san/ggc:{{ .Version }}-amd64"
+    dockerfile: Dockerfile
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.source=https://github.com/bmf-san/ggc"
+      - "--label=org.opencontainers.image.licenses=MIT"
+
+  - id: ggc-arm64
+    ids: [ggc]
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - "ghcr.io/bmf-san/ggc:{{ .Version }}-arm64"
+    dockerfile: Dockerfile
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.source=https://github.com/bmf-san/ggc"
+      - "--label=org.opencontainers.image.licenses=MIT"
+
+docker_manifests:
+  - name_template: "ghcr.io/bmf-san/ggc:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/bmf-san/ggc:{{ .Version }}-amd64"
+      - "ghcr.io/bmf-san/ggc:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/bmf-san/ggc:latest"
+    image_templates:
+      - "ghcr.io/bmf-san/ggc:{{ .Version }}-amd64"
+      - "ghcr.io/bmf-san/ggc:{{ .Version }}-arm64"
+
 release:
   github:
     owner: bmf-san

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1
+# This Dockerfile is consumed by GoReleaser; `ggc` is injected by the
+# release pipeline, so building this image outside of GoReleaser will fail
+# unless you place the pre-built binary next to this file.
+FROM alpine:3.22
+
+# ggc shells out to `git`, so the runtime image must ship one. `ca-certificates`
+# keeps HTTPS remote operations working. No other runtime dependencies.
+RUN apk add --no-cache git ca-certificates \
+    && addgroup -S ggc \
+    && adduser -S -G ggc ggc
+
+COPY ggc /usr/local/bin/ggc
+
+USER ggc
+WORKDIR /work
+
+ENTRYPOINT ["/usr/local/bin/ggc"]

--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -51,6 +51,21 @@ Windows binaries are published to the [releases page](https://github.com/bmf-san
 
 If you use Git Bash or WSL the Linux instructions above also work unchanged.
 
+## Docker (ghcr.io)
+
+Multi-arch images (`linux/amd64`, `linux/arm64`) are published to GitHub Container Registry on every tagged release, starting from the next release after v8.3.0.
+
+```bash
+docker pull ghcr.io/bmf-san/ggc:latest
+# or pin a version
+docker pull ghcr.io/bmf-san/ggc:v8.4.0
+
+# run against the current directory
+docker run --rm -it -v "$PWD:/work" ghcr.io/bmf-san/ggc:latest status
+```
+
+The image is based on `alpine:3.22` and bundles `git`. Runs as an unprivileged user (`ggc`).
+
 ## Build from source
 
 ```bash


### PR DESCRIPTION
## Summary

On every git tag, publish a multi-arch container image (`linux/amd64`, `linux/arm64`) to GitHub Container Registry as `ghcr.io/bmf-san/ggc:<version>` and `ghcr.io/bmf-san/ggc:latest`.

## Changes

- `Dockerfile` — tiny `alpine:3.22` base with `git` + `ca-certificates`, runs as an unprivileged `ggc` user. GoReleaser copies the prebuilt binary in; no Go toolchain needed in the image.
- `.goreleaser.yml` — new `dockers:` entries per arch using `use: buildx`, plus `docker_manifests:` that stitches them into `:<version>` and `:latest`. OCI labels include source, revision, version, license.
- `.github/workflows/release.yml` — adds `packages: write`, `docker/setup-qemu-action`, `docker/setup-buildx-action`, and `docker/login-action` (SHA-pinned to current `v3` heads).
- `docs/guide/install.md` — new "Docker (ghcr.io)" section with pull/run examples.

## Notes

- `goreleaser check` passes. The existing `dockers:` schema triggers a deprecation warning pointing at `dockers_v2`; kept the v1 shape because v2 isn't GA yet.
- Image is intentionally minimal — it is _not_ signed with cosign (binary checksums already are). Can be added in a follow-up if needed.
- Because this only activates on a tag push, there's no CI-visible runtime smoke test in this PR; the next tag will exercise the full path.
