### PR TITLE
feat(cmd): expand git command coverage

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -48,6 +48,7 @@ type Cmd struct {
 	restorer      *Restorer
 	fetcher       *Fetcher
 	shower        *Shower
+	passthroughs  map[string]*passthroughCommand
 	cmdRouter     *commandRouter
 	debugger      *Debugger
 	doctor        *Doctor
@@ -76,6 +77,7 @@ type GitDeps interface {
 	git.RestoreOps
 	git.FetchOps
 	git.ShowOps
+	git.PassthroughOps
 	git.LocalBranchLister
 	git.FileLister
 }
@@ -131,6 +133,7 @@ func NewCmd(client GitDeps, cm *config.Manager) (*Cmd, error) {
 		restorer:      NewRestorer(client),
 		fetcher:       NewFetcher(client),
 		shower:        NewShower(client),
+		passthroughs:  buildPassthroughs(client),
 		doctor:        NewDoctor(),
 		debugger:      NewDebugger(),
 		completer:     NewCompleter(),

--- a/cmd/command/expansion.go
+++ b/cmd/command/expansion.go
@@ -1,0 +1,297 @@
+package command
+
+// expansion returns command definitions added as part of the
+// "expand git command coverage" effort (see issue #428). Most of these
+// commands are thin pass-throughs to `git <name>` and rely on the ggc
+// registry only for discovery, help, and shell-completion plumbing.
+func expansion() []Info {
+	return []Info{
+		// --- Tier 1 ---
+		{
+			Name:     "switch",
+			Category: CategoryBranch,
+			Summary:  "Switch branches",
+			Usage:    []string{"ggc switch [<options>] <branch>"},
+			Examples: []string{
+				"ggc switch main                       # Switch to an existing branch",
+				"ggc switch -c feature/login           # Create and switch to a new branch",
+				"ggc switch -C feature/login          # Force-create and switch",
+				"ggc switch --detach HEAD~3            # Detached checkout",
+				"ggc switch -                          # Switch back to the previous branch",
+			},
+			Subcommands: []SubcommandInfo{
+				{Name: "switch <branch>", Summary: "Switch to an existing branch", Usage: []string{"ggc switch main"}},
+				{Name: "switch -c <branch>", Summary: "Create and switch to a new branch", Usage: []string{"ggc switch -c feature/login"}},
+				{Name: "switch --detach <ref>", Summary: "Detached checkout at a ref", Usage: []string{"ggc switch --detach HEAD~3"}},
+			},
+		},
+		{
+			Name:     "checkout",
+			Category: CategoryBranch,
+			Summary:  "Switch branches or restore working tree files",
+			Usage:    []string{"ggc checkout [<options>] [<branch>|<commit>] [--] [<path>...]"},
+			Examples: []string{
+				"ggc checkout main                     # Switch to an existing branch",
+				"ggc checkout -b feature/login         # Create and switch to a new branch",
+				"ggc checkout -- path/to/file.go       # Discard working-tree changes to a file",
+				"ggc checkout HEAD~1 -- path/file.go   # Restore a file from a specific commit",
+			},
+		},
+		{
+			Name:     "merge",
+			Category: CategoryBranch,
+			Summary:  "Join two or more development histories together",
+			Usage:    []string{"ggc merge [<options>] [<commit>...]"},
+			Examples: []string{
+				"ggc merge feature/login               # Merge a branch into the current branch",
+				"ggc merge --no-ff feature/login       # Force a merge commit",
+				"ggc merge --squash feature/login      # Squash all commits into the index",
+				"ggc merge --abort                     # Abort an in-progress merge",
+				"ggc merge --continue                  # Continue an in-progress merge",
+			},
+		},
+		{
+			Name:     "cherry-pick",
+			Category: CategoryCommit,
+			Summary:  "Apply the changes introduced by some existing commits",
+			Usage:    []string{"ggc cherry-pick [<options>] <commit>..."},
+			Examples: []string{
+				"ggc cherry-pick abc1234               # Apply a single commit",
+				"ggc cherry-pick -x abc1234            # Apply and append \"(cherry picked from ...)\"",
+				"ggc cherry-pick A..B                  # Apply a range of commits",
+				"ggc cherry-pick --continue            # Continue after resolving conflicts",
+				"ggc cherry-pick --abort               # Abort the in-progress cherry-pick",
+			},
+		},
+		{
+			Name:     "revert",
+			Category: CategoryCommit,
+			Summary:  "Revert some existing commits",
+			Usage:    []string{"ggc revert [<options>] <commit>..."},
+			Examples: []string{
+				"ggc revert HEAD                       # Revert the latest commit",
+				"ggc revert --no-edit abc1234          # Revert without editing the message",
+				"ggc revert -n abc1234                 # Revert without committing (stage only)",
+				"ggc revert --continue                 # Continue after resolving conflicts",
+				"ggc revert --abort                    # Abort the in-progress revert",
+			},
+		},
+		{
+			Name:     "blame",
+			Category: CategoryBasics,
+			Summary:  "Show what revision and author last modified each line of a file",
+			Usage:    []string{"ggc blame [<options>] <file>"},
+			Examples: []string{
+				"ggc blame README.md                   # Show line authorship for a file",
+				"ggc blame -L 10,20 README.md          # Limit blame to specific lines",
+				"ggc blame -C -C README.md             # Detect copy/move across files",
+			},
+		},
+		// --- Tier 2 ---
+		{
+			Name:     "worktree",
+			Category: CategoryBranch,
+			Summary:  "Manage multiple working trees",
+			Usage:    []string{"ggc worktree <subcommand> [<options>]"},
+			Examples: []string{
+				"ggc worktree list                     # List linked working trees",
+				"ggc worktree add ../wt-feat feature   # Add a new working tree",
+				"ggc worktree remove ../wt-feat        # Remove a linked working tree",
+				"ggc worktree prune                    # Prune stale worktree metadata",
+			},
+		},
+		{
+			Name:     "bisect",
+			Category: CategoryUtility,
+			Summary:  "Use binary search to find the commit that introduced a bug",
+			Usage:    []string{"ggc bisect <subcommand> [<options>]"},
+			Examples: []string{
+				"ggc bisect start                      # Start a new bisect session",
+				"ggc bisect bad                        # Mark current commit as bad",
+				"ggc bisect good v1.0.0                # Mark a known-good commit",
+				"ggc bisect reset                      # Finish bisecting",
+			},
+		},
+		{
+			Name:     "reflog",
+			Category: CategoryUtility,
+			Summary:  "Manage reflog information (recovery aid)",
+			Usage:    []string{"ggc reflog [<subcommand>] [<options>] [<ref>]"},
+			Examples: []string{
+				"ggc reflog                            # Show HEAD reflog",
+				"ggc reflog show main                  # Show reflog for a specific ref",
+				"ggc reflog expire --expire=now --all  # Aggressively expire reflog entries",
+			},
+		},
+		{
+			Name:     "format-patch",
+			Category: CategoryUtility,
+			Summary:  "Prepare patches for e-mail submission",
+			Usage:    []string{"ggc format-patch [<options>] <commit-range>"},
+			Examples: []string{
+				"ggc format-patch -1 HEAD              # Produce a patch for the latest commit",
+				"ggc format-patch origin/main..HEAD    # Produce patches for a branch",
+			},
+		},
+		{
+			Name:     "am",
+			Category: CategoryUtility,
+			Summary:  "Apply a series of patches from a mailbox",
+			Usage:    []string{"ggc am [<options>] [<mailbox>...]"},
+			Examples: []string{
+				"ggc am 0001-fix-bug.patch             # Apply a single patch",
+				"ggc am --continue                     # Continue after resolving conflicts",
+				"ggc am --abort                        # Abort the in-progress am",
+			},
+		},
+		{
+			Name:     "sparse-checkout",
+			Category: CategoryUtility,
+			Summary:  "Reduce the working tree to a subset of tracked files",
+			Usage:    []string{"ggc sparse-checkout <subcommand> [<options>]"},
+			Examples: []string{
+				"ggc sparse-checkout init --cone       # Enable sparse-checkout in cone mode",
+				"ggc sparse-checkout set src docs      # Limit working tree to these paths",
+				"ggc sparse-checkout list              # Show currently checked-out paths",
+				"ggc sparse-checkout disable           # Disable sparse-checkout",
+			},
+		},
+		{
+			Name:     "mv",
+			Category: CategoryBasics,
+			Summary:  "Move or rename a file, directory, or symlink",
+			Usage:    []string{"ggc mv [<options>] <source>... <destination>"},
+			Examples: []string{
+				"ggc mv old.go new.go                  # Rename a tracked file",
+				"ggc mv -k a.go b.go pkg/              # Skip move when destination is in the way",
+			},
+		},
+		{
+			Name:     "rm",
+			Category: CategoryBasics,
+			Summary:  "Remove files from the working tree and the index",
+			Usage:    []string{"ggc rm [<options>] <file>..."},
+			Examples: []string{
+				"ggc rm old.go                         # Stage removal of a tracked file",
+				"ggc rm --cached secret.env            # Stop tracking but keep the file on disk",
+				"ggc rm -r build/                      # Remove a directory recursively",
+			},
+		},
+		{
+			Name:     "submodule",
+			Category: CategoryUtility,
+			Summary:  "Initialize, update, or inspect submodules",
+			Usage:    []string{"ggc submodule <subcommand> [<options>]"},
+			Examples: []string{
+				"ggc submodule status                  # Show submodule status",
+				"ggc submodule update --init           # Initialize and update submodules",
+				"ggc submodule foreach git status      # Run a command in each submodule",
+			},
+		},
+		// --- Tier 3 ---
+		{
+			Name:     "describe",
+			Category: CategoryUtility,
+			Summary:  "Give an object a human-readable name based on an available ref",
+			Usage:    []string{"ggc describe [<options>] [<commit>]"},
+			Examples: []string{
+				"ggc describe                          # Describe current HEAD",
+				"ggc describe --tags                   # Use any tag, not just annotated ones",
+				"ggc describe --always --dirty         # Always emit a string; mark dirty trees",
+			},
+		},
+		{
+			Name:     "range-diff",
+			Category: CategoryDiff,
+			Summary:  "Compare two commit ranges (e.g. before and after a rebase)",
+			Usage:    []string{"ggc range-diff <range1> <range2>"},
+			Examples: []string{
+				"ggc range-diff main..@{u} main..HEAD  # Compare upstream vs. local rewrite",
+				"ggc range-diff abc..def 123..456      # Compare two arbitrary ranges",
+			},
+		},
+		{
+			Name:     "grep",
+			Category: CategoryBasics,
+			Summary:  "Print lines matching a pattern in tracked files",
+			Usage:    []string{"ggc grep [<options>] <pattern> [<pathspec>...]"},
+			Examples: []string{
+				"ggc grep TODO                         # Search tracked files for TODO",
+				"ggc grep -n -i fixme                  # Case-insensitive with line numbers",
+				"ggc grep -e foo -e bar -- cmd         # Match multiple patterns in cmd/",
+			},
+		},
+		{
+			Name:     "notes",
+			Category: CategoryUtility,
+			Summary:  "Add, read, or edit object notes",
+			Usage:    []string{"ggc notes <subcommand> [<options>]"},
+			Examples: []string{
+				"ggc notes add -m \"reviewed\" HEAD     # Attach a note to HEAD",
+				"ggc notes show HEAD                   # Show a note",
+				"ggc notes list                        # List notes",
+			},
+		},
+		{
+			Name:     "archive",
+			Category: CategoryUtility,
+			Summary:  "Create an archive of files from a named tree",
+			Usage:    []string{"ggc archive [<options>] <tree-ish> [<path>...]"},
+			Examples: []string{
+				"ggc archive -o out.tar.gz HEAD        # Archive current HEAD to a tarball",
+				"ggc archive --format=zip -o v1.zip v1 # Archive a tag as a zip",
+			},
+		},
+		{
+			Name:     "shortlog",
+			Category: CategoryBasics,
+			Summary:  "Summarize git log output grouped by committer",
+			Usage:    []string{"ggc shortlog [<options>] [<revision-range>]"},
+			Examples: []string{
+				"ggc shortlog -sn                      # Summary count by author",
+				"ggc shortlog v1.0..HEAD               # Limit to a range",
+			},
+		},
+		{
+			Name:     "maintenance",
+			Category: CategoryUtility,
+			Summary:  "Run scheduled background repository optimizations",
+			Usage:    []string{"ggc maintenance <subcommand> [<options>]"},
+			Examples: []string{
+				"ggc maintenance run                   # Run all enabled tasks once",
+				"ggc maintenance start                 # Install scheduled maintenance",
+				"ggc maintenance stop                  # Remove scheduled maintenance",
+			},
+		},
+		{
+			Name:     "gc",
+			Category: CategoryUtility,
+			Summary:  "Cleanup unnecessary files and optimize the local repository",
+			Usage:    []string{"ggc gc [<options>]"},
+			Examples: []string{
+				"ggc gc                                # Run a normal gc",
+				"ggc gc --aggressive --prune=now       # Aggressively repack and prune",
+			},
+		},
+		{
+			Name:     "fsck",
+			Category: CategoryUtility,
+			Summary:  "Verify the connectivity and validity of objects in the repository",
+			Usage:    []string{"ggc fsck [<options>]"},
+			Examples: []string{
+				"ggc fsck                              # Run a basic fsck",
+				"ggc fsck --full --strict              # Comprehensive checks",
+			},
+		},
+		{
+			Name:     "prune",
+			Category: CategoryUtility,
+			Summary:  "Prune all unreachable objects from the object database",
+			Usage:    []string{"ggc prune [<options>]"},
+			Examples: []string{
+				"ggc prune                             # Prune unreachable objects",
+				"ggc prune --dry-run                   # Report what would be pruned",
+			},
+		},
+	}
+}

--- a/cmd/command/registry.go
+++ b/cmd/command/registry.go
@@ -77,6 +77,7 @@ func defaultCommands() []Info {
 	commands = append(commands, rebase()...)
 	commands = append(commands, reset()...)
 	commands = append(commands, show()...)
+	commands = append(commands, expansion()...)
 	return commands
 }
 

--- a/cmd/completions/ggc.bash
+++ b/cmd/completions/ggc.bash
@@ -8,7 +8,7 @@ _ggc()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    opts="add branch clean commit completion config debug-keys diff doctor fetch help hook log pull push quit rebase remote reset restore show stash status tag version"
+    opts="add am archive bisect blame branch checkout cherry-pick clean commit completion config debug-keys describe diff doctor fetch format-patch fsck gc grep help hook log maintenance merge mv notes prune pull push quit range-diff rebase reflog remote reset restore revert rm shortlog show sparse-checkout stash status submodule switch tag version worktree"
     case ${prev} in
         branch)
             subopts="checkout contains create current delete info list move rename set sort"
@@ -102,6 +102,11 @@ _ggc()
             ;;
         status)
             subopts="short"
+            COMPREPLY=( $(compgen -W "${subopts}" -- ${cur}) )
+            return 0
+            ;;
+        switch)
+            subopts="--detach -c"
             COMPREPLY=( $(compgen -W "${subopts}" -- ${cur}) )
             return 0
             ;;

--- a/cmd/completions/ggc.fish
+++ b/cmd/completions/ggc.fish
@@ -10,7 +10,7 @@ function __ggc_complete_files
 end
 
 # Main commands
-complete -c ggc -f -a "add branch clean commit completion config debug-keys diff doctor fetch help hook log pull push quit rebase remote reset restore show stash status tag version"
+complete -c ggc -f -a "add am archive bisect blame branch checkout cherry-pick clean commit completion config debug-keys describe diff doctor fetch format-patch fsck gc grep help hook log maintenance merge mv notes prune pull push quit range-diff rebase reflog remote reset restore revert rm shortlog show sparse-checkout stash status submodule switch tag version worktree"
 complete -c ggc -f -n "__fish_seen_subcommand_from branch" -a "checkout contains create current delete info list move rename set sort"
 complete -c ggc -f -n "__fish_seen_subcommand_from branch; and __fish_seen_subcommand_from delete" -a "merged"
 complete -c ggc -f -n "__fish_seen_subcommand_from branch; and __fish_seen_subcommand_from list" -a "local remote verbose"
@@ -36,6 +36,7 @@ complete -c ggc -f -n "__fish_seen_subcommand_from show" -a "--name-only --stat"
 complete -c ggc -f -n "__fish_seen_subcommand_from stash" -a "apply branch clear create drop list pop push save show store"
 complete -c ggc -f -n "__fish_seen_subcommand_from stash; and __fish_seen_subcommand_from push" -a "-m"
 complete -c ggc -f -n "__fish_seen_subcommand_from status" -a "short"
+complete -c ggc -f -n "__fish_seen_subcommand_from switch" -a "--detach -c"
 complete -c ggc -f -n "__fish_seen_subcommand_from tag" -a "annotated create delete list push show"
 complete -c ggc -f -n "__fish_seen_subcommand_from version" -a "json"
 

--- a/cmd/completions/ggc.zsh
+++ b/cmd/completions/ggc.zsh
@@ -72,6 +72,9 @@ _ggc() {
                 status)
                     _ggc_status
                     ;;
+                switch)
+                    _ggc_switch
+                    ;;
                 tag)
                     _ggc_tag
                     ;;
@@ -87,30 +90,55 @@ _ggc_commands() {
     local commands
     commands=(
         'add:Stage changes for the next commit'
+        'am:Apply a series of patches from a mailbox'
+        'archive:Create an archive of files from a named tree'
+        'bisect:Use binary search to find the commit that introduced a bug'
+        'blame:Show what revision and author last modified each line of a file'
         'branch:List, create, and manage branches'
+        'checkout:Switch branches or restore working tree files'
+        'cherry-pick:Apply the changes introduced by some existing commits'
         'clean:Remove untracked files and directories'
         'commit:Create commits from staged changes'
         'completion:Print or install shell completion scripts'
         'config:Get and set ggc configuration'
         'debug-keys:Debug keybinding issues and capture raw key sequences'
+        'describe:Give an object a human-readable name based on an available ref'
         'diff:Inspect changes between commits, the index, and the working tree'
         'doctor:Diagnose the local ggc installation'
         'fetch:Download objects and refs from remotes'
+        'format-patch:Prepare patches for e-mail submission'
+        'fsck:Verify the connectivity and validity of objects in the repository'
+        'gc:Cleanup unnecessary files and optimize the local repository'
+        'grep:Print lines matching a pattern in tracked files'
         'help:Show help information for commands'
         'hook:Manage Git hooks'
         'log:Inspect commit history'
+        'maintenance:Run scheduled background repository optimizations'
+        'merge:Join two or more development histories together'
+        'mv:Move or rename a file, directory, or symlink'
+        'notes:Add, read, or edit object notes'
+        'prune:Prune all unreachable objects from the object database'
         'pull:Fetch and integrate from the remote'
         'push:Update remote branches'
         'quit:Exit interactive mode'
+        'range-diff:Compare two commit ranges (e.g. before and after a rebase)'
         'rebase:Reapply commits on top of another base tip'
+        'reflog:Manage reflog information (recovery aid)'
         'remote:Manage remotes'
         'reset:Reset current HEAD to the specified state'
         'restore:Restore files in working tree or staging area'
+        'revert:Revert some existing commits'
+        'rm:Remove files from the working tree and the index'
+        'shortlog:Summarize git log output grouped by committer'
         'show:Show various types of objects (commits, tags, trees, blobs)'
+        'sparse-checkout:Reduce the working tree to a subset of tracked files'
         'stash:Save and reapply work-in-progress changes'
         'status:Show working tree status'
+        'submodule:Initialize, update, or inspect submodules'
+        'switch:Switch branches'
         'tag:Create, list, and manage tags'
         'version:Display current ggc version'
+        'worktree:Manage multiple working trees'
     )
     _describe 'commands' commands
 }
@@ -413,6 +441,16 @@ _ggc_status() {
     )
     if (( CURRENT == 2 )); then
         _describe 'status subcommands' subcommands
+    fi
+}
+_ggc_switch() {
+    local subcommands
+    subcommands=(
+        '--detach:Detached checkout at a ref'
+        '-c:Create and switch to a new branch'
+    )
+    if (( CURRENT == 2 )); then
+        _describe 'switch subcommands' subcommands
     fi
 }
 _ggc_tag() {

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -318,3 +318,10 @@ func (h *Helper) ShowFetchHelp() {
 func (h *Helper) ShowShowHelp() {
 	h.renderCommandFromRegistry("show", []string{"ggc show [<options>] [<object>...]"}, "Show various types of objects (commits, tags, trees, blobs)")
 }
+
+// ShowPassthroughHelp renders help for a pass-through command by looking up
+// its entry in the registry. Used by the generic passthroughCommand wrapper
+// for commands such as cherry-pick, revert, blame, etc.
+func (h *Helper) ShowPassthroughHelp(name string) {
+	h.renderCommandFromRegistry(name, nil, "")
+}

--- a/cmd/passthrough.go
+++ b/cmd/passthrough.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"io"
+	"os"
+
+	"github.com/bmf-san/ggc/v8/internal/git"
+)
+
+// passthroughCommand is a thin wrapper that forwards arguments to the
+// underlying `git <name>` invocation. It is used by ggc commands that do
+// not need a bespoke argument parser or interactive layer; users get the
+// full surface of the underlying git porcelain while still being able to
+// discover the command through `ggc help`, completions, and the registry.
+type passthroughCommand struct {
+	name         string
+	gitClient    git.PassthroughOps
+	outputWriter io.Writer
+	helper       *Helper
+}
+
+// newPassthroughCommand creates a pass-through wrapper for the given git
+// subcommand name.
+func newPassthroughCommand(name string, client git.PassthroughOps) *passthroughCommand {
+	return &passthroughCommand{
+		name:         name,
+		gitClient:    client,
+		outputWriter: os.Stdout,
+		helper:       NewHelper(),
+	}
+}
+
+// Run forwards args to `git <name>`. If the first argument is the literal
+// string "help", it prints help rendered from the registry instead.
+func (p *passthroughCommand) Run(args []string) {
+	if len(args) > 0 && args[0] == "help" {
+		p.helper.ShowPassthroughHelp(p.name)
+		return
+	}
+	if err := p.gitClient.RunGit(p.name, args); err != nil {
+		WriteError(p.outputWriter, err)
+	}
+}
+
+// passthroughCommandNames lists every ggc command that is implemented as a
+// thin pass-through to `git <name>`. Adding a name here, along with a
+// matching registry entry, automatically wires it into the router.
+var passthroughCommandNames = []string{
+	// Tier 1
+	"switch",
+	"checkout",
+	"merge",
+	"cherry-pick",
+	"revert",
+	"blame",
+	// Tier 2
+	"worktree",
+	"bisect",
+	"reflog",
+	"format-patch",
+	"am",
+	"sparse-checkout",
+	"mv",
+	"rm",
+	"submodule",
+	// Tier 3
+	"describe",
+	"range-diff",
+	"grep",
+	"notes",
+	"archive",
+	"shortlog",
+	"maintenance",
+	"gc",
+	"fsck",
+	"prune",
+}
+
+// buildPassthroughs constructs a map of all pass-through commands keyed by
+// their canonical name. The router dispatches to the matching entry by name.
+func buildPassthroughs(client git.PassthroughOps) map[string]*passthroughCommand {
+	m := make(map[string]*passthroughCommand, len(passthroughCommandNames))
+	for _, name := range passthroughCommandNames {
+		m[name] = newPassthroughCommand(name, client)
+	}
+	return m
+}

--- a/cmd/passthrough_test.go
+++ b/cmd/passthrough_test.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/bmf-san/ggc/v8/internal/testutil"
+)
+
+type mockPassthroughClient struct {
+	testutil.MockGitClient
+	called  bool
+	gotName string
+	gotArgs []string
+	err     error
+}
+
+func (m *mockPassthroughClient) RunGit(name string, args []string) error {
+	m.called = true
+	m.gotName = name
+	m.gotArgs = slices.Clone(args)
+	return m.err
+}
+
+func TestPassthroughCommand_Run(t *testing.T) {
+	mock := &mockPassthroughClient{}
+	var buf bytes.Buffer
+	pc := newPassthroughCommand("cherry-pick", mock)
+	pc.outputWriter = &buf
+	pc.helper.outputWriter = &buf
+
+	pc.Run([]string{"-x", "abc123"})
+
+	if !mock.called {
+		t.Fatal("RunGit was not called")
+	}
+	if mock.gotName != "cherry-pick" {
+		t.Errorf("got name %q, want cherry-pick", mock.gotName)
+	}
+	if !slices.Equal(mock.gotArgs, []string{"-x", "abc123"}) {
+		t.Errorf("got args %v, want [-x abc123]", mock.gotArgs)
+	}
+}
+
+func TestPassthroughCommand_Help(t *testing.T) {
+	mock := &mockPassthroughClient{}
+	var buf bytes.Buffer
+	pc := newPassthroughCommand("cherry-pick", mock)
+	pc.outputWriter = &buf
+	pc.helper.outputWriter = &buf
+
+	pc.Run([]string{"help"})
+
+	if mock.called {
+		t.Error("RunGit should not be called for help subcommand")
+	}
+	if !strings.Contains(buf.String(), "cherry-pick") {
+		t.Errorf("expected help output to mention cherry-pick, got %q", buf.String())
+	}
+}
+
+func TestPassthroughCommand_Error(t *testing.T) {
+	mock := &mockPassthroughClient{err: errors.New("bad ref")}
+	var buf bytes.Buffer
+	pc := newPassthroughCommand("revert", mock)
+	pc.outputWriter = &buf
+	pc.helper.outputWriter = &buf
+
+	pc.Run([]string{"deadbeef"})
+
+	if !strings.Contains(buf.String(), "bad ref") {
+		t.Errorf("expected error in output, got %q", buf.String())
+	}
+}
+
+func TestBuildPassthroughs_CoversAllNames(t *testing.T) {
+	mock := &mockPassthroughClient{}
+	m := buildPassthroughs(mock)
+	if len(m) != len(passthroughCommandNames) {
+		t.Fatalf("buildPassthroughs returned %d entries, want %d", len(m), len(passthroughCommandNames))
+	}
+	for _, name := range passthroughCommandNames {
+		pc, ok := m[name]
+		if !ok {
+			t.Errorf("missing passthrough for %q", name)
+			continue
+		}
+		if pc.name != name {
+			t.Errorf("passthrough[%q].name = %q", name, pc.name)
+		}
+	}
+}

--- a/cmd/router.go
+++ b/cmd/router.go
@@ -55,6 +55,23 @@ func newCommandRouter(cmd *Cmd) (*commandRouter, error) {
 		},
 	}
 
+	// Wire pass-through commands (cherry-pick, revert, blame, ...). The
+	// passthroughs map is built in NewCmd from the canonical name list; the
+	// closure resolves the entry lazily so that tests which construct a Cmd
+	// without populating the map still pass router validation (handlers are
+	// keyed by name, not by their closure body).
+	for _, name := range passthroughCommandNames {
+		name := name
+		handlers[name] = func(args []string) {
+			if cmd.passthroughs == nil {
+				return
+			}
+			if pc, ok := cmd.passthroughs[name]; ok {
+				pc.Run(args)
+			}
+		}
+	}
+
 	available := make(map[string]struct{}, len(handlers))
 	for key := range handlers {
 		available[key] = struct{}{}

--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -53,6 +53,42 @@ ggc add interactive  # Add changes interactively
 ggc add patch        # Add changes interactively (patch mode)
 ```
 
+### `ggc blame` {#cmd-blame}
+
+Show what revision and author last modified each line of a file.
+
+**Usage:**
+
+```bash
+ggc blame [<options>] <file>
+```
+
+**Examples:**
+
+```bash
+ggc blame README.md                   # Show line authorship for a file
+ggc blame -L 10,20 README.md          # Limit blame to specific lines
+ggc blame -C -C README.md             # Detect copy/move across files
+```
+
+### `ggc grep` {#cmd-grep}
+
+Print lines matching a pattern in tracked files.
+
+**Usage:**
+
+```bash
+ggc grep [<options>] <pattern> [<pathspec>...]
+```
+
+**Examples:**
+
+```bash
+ggc grep TODO                         # Search tracked files for TODO
+ggc grep -n -i fixme                  # Case-insensitive with line numbers
+ggc grep -e foo -e bar -- cmd         # Match multiple patterns in cmd/
+```
+
 ### `ggc help` {#cmd-help}
 
 Show help information for commands.
@@ -76,6 +112,23 @@ ggc help <command>
 ```bash
 ggc help
 ggc help branch
+```
+
+### `ggc mv` {#cmd-mv}
+
+Move or rename a file, directory, or symlink.
+
+**Usage:**
+
+```bash
+ggc mv [<options>] <source>... <destination>
+```
+
+**Examples:**
+
+```bash
+ggc mv old.go new.go                  # Rename a tracked file
+ggc mv -k a.go b.go pkg/              # Skip move when destination is in the way
 ```
 
 ### `ggc reset` {#cmd-reset}
@@ -105,6 +158,41 @@ ggc reset               # Hard reset to origin/<current-branch> and clean
 ggc reset hard HEAD~1   # Hard reset to previous commit
 ggc reset soft HEAD~1   # Soft reset: keep changes staged
 ggc reset soft HEAD~3   # Soft reset 3 commits, keeping changes staged
+```
+
+### `ggc rm` {#cmd-rm}
+
+Remove files from the working tree and the index.
+
+**Usage:**
+
+```bash
+ggc rm [<options>] <file>...
+```
+
+**Examples:**
+
+```bash
+ggc rm old.go                         # Stage removal of a tracked file
+ggc rm --cached secret.env            # Stop tracking but keep the file on disk
+ggc rm -r build/                      # Remove a directory recursively
+```
+
+### `ggc shortlog` {#cmd-shortlog}
+
+Summarize git log output grouped by committer.
+
+**Usage:**
+
+```bash
+ggc shortlog [<options>] [<revision-range>]
+```
+
+**Examples:**
+
+```bash
+ggc shortlog -sn                      # Summary count by author
+ggc shortlog v1.0..HEAD               # Limit to a range
 ```
 
 ### `ggc show` {#cmd-show}
@@ -195,7 +283,113 @@ ggc branch sort date              # List branches sorted by date
 ggc branch contains abc123        # Show branches containing a commit
 ```
 
+### `ggc checkout` {#cmd-checkout}
+
+Switch branches or restore working tree files.
+
+**Usage:**
+
+```bash
+ggc checkout [<options>] [<branch>|<commit>] [--] [<path>...]
+```
+
+**Examples:**
+
+```bash
+ggc checkout main                     # Switch to an existing branch
+ggc checkout -b feature/login         # Create and switch to a new branch
+ggc checkout -- path/to/file.go       # Discard working-tree changes to a file
+ggc checkout HEAD~1 -- path/file.go   # Restore a file from a specific commit
+```
+
+### `ggc merge` {#cmd-merge}
+
+Join two or more development histories together.
+
+**Usage:**
+
+```bash
+ggc merge [<options>] [<commit>...]
+```
+
+**Examples:**
+
+```bash
+ggc merge feature/login               # Merge a branch into the current branch
+ggc merge --no-ff feature/login       # Force a merge commit
+ggc merge --squash feature/login      # Squash all commits into the index
+ggc merge --abort                     # Abort an in-progress merge
+ggc merge --continue                  # Continue an in-progress merge
+```
+
+### `ggc switch` {#cmd-switch}
+
+Switch branches.
+
+**Usage:**
+
+```bash
+ggc switch [<options>] <branch>
+```
+
+**Subcommands:**
+
+| Subcommand | Description |
+|---|---|
+| `switch --detach <ref>` | Detached checkout at a ref |
+| `switch -c <branch>` | Create and switch to a new branch |
+| `switch <branch>` | Switch to an existing branch |
+
+**Examples:**
+
+```bash
+ggc switch main                       # Switch to an existing branch
+ggc switch -c feature/login           # Create and switch to a new branch
+ggc switch -C feature/login          # Force-create and switch
+ggc switch --detach HEAD~3            # Detached checkout
+ggc switch -                          # Switch back to the previous branch
+```
+
+### `ggc worktree` {#cmd-worktree}
+
+Manage multiple working trees.
+
+**Usage:**
+
+```bash
+ggc worktree <subcommand> [<options>]
+```
+
+**Examples:**
+
+```bash
+ggc worktree list                     # List linked working trees
+ggc worktree add ../wt-feat feature   # Add a new working tree
+ggc worktree remove ../wt-feat        # Remove a linked working tree
+ggc worktree prune                    # Prune stale worktree metadata
+```
+
 ## Commit {#cat-commit}
+
+### `ggc cherry-pick` {#cmd-cherry-pick}
+
+Apply the changes introduced by some existing commits.
+
+**Usage:**
+
+```bash
+ggc cherry-pick [<options>] <commit>...
+```
+
+**Examples:**
+
+```bash
+ggc cherry-pick abc1234               # Apply a single commit
+ggc cherry-pick -x abc1234            # Apply and append "(cherry picked from ...)"
+ggc cherry-pick A..B                  # Apply a range of commits
+ggc cherry-pick --continue            # Continue after resolving conflicts
+ggc cherry-pick --abort               # Abort the in-progress cherry-pick
+```
 
 ### `ggc commit` {#cmd-commit}
 
@@ -253,6 +447,26 @@ ggc log graph
 ```bash
 ggc log simple  # Show commit logs in a simple format
 ggc log graph   # Show commit logs with a graph
+```
+
+### `ggc revert` {#cmd-revert}
+
+Revert some existing commits.
+
+**Usage:**
+
+```bash
+ggc revert [<options>] <commit>...
+```
+
+**Examples:**
+
+```bash
+ggc revert HEAD                       # Revert the latest commit
+ggc revert --no-edit abc1234          # Revert without editing the message
+ggc revert -n abc1234                 # Revert without committing (stage only)
+ggc revert --continue                 # Continue after resolving conflicts
+ggc revert --abort                    # Abort the in-progress revert
 ```
 
 ## Remote {#cat-remote}
@@ -479,6 +693,23 @@ ggc diff abc123 cmd/diff.go         # Compare commit to working tree for a path
 ggc diff -- cmd/deleted_file.go     # Diff a path using -- for disambiguation
 ```
 
+### `ggc range-diff` {#cmd-range-diff}
+
+Compare two commit ranges (e.g. before and after a rebase).
+
+**Usage:**
+
+```bash
+ggc range-diff <range1> <range2>
+```
+
+**Examples:**
+
+```bash
+ggc range-diff main..@{u} main..HEAD  # Compare upstream vs. local rewrite
+ggc range-diff abc..def 123..456      # Compare two arbitrary ranges
+```
+
 ## Tag {#cat-tag}
 
 ### `ggc tag` {#cmd-tag}
@@ -674,6 +905,60 @@ ggc stash store <object>               # Store stash object
 
 ## Utility {#cat-utility}
 
+### `ggc am` {#cmd-am}
+
+Apply a series of patches from a mailbox.
+
+**Usage:**
+
+```bash
+ggc am [<options>] [<mailbox>...]
+```
+
+**Examples:**
+
+```bash
+ggc am 0001-fix-bug.patch             # Apply a single patch
+ggc am --continue                     # Continue after resolving conflicts
+ggc am --abort                        # Abort the in-progress am
+```
+
+### `ggc archive` {#cmd-archive}
+
+Create an archive of files from a named tree.
+
+**Usage:**
+
+```bash
+ggc archive [<options>] <tree-ish> [<path>...]
+```
+
+**Examples:**
+
+```bash
+ggc archive -o out.tar.gz HEAD        # Archive current HEAD to a tarball
+ggc archive --format=zip -o v1.zip v1 # Archive a tag as a zip
+```
+
+### `ggc bisect` {#cmd-bisect}
+
+Use binary search to find the commit that introduced a bug.
+
+**Usage:**
+
+```bash
+ggc bisect <subcommand> [<options>]
+```
+
+**Examples:**
+
+```bash
+ggc bisect start                      # Start a new bisect session
+ggc bisect bad                        # Mark current commit as bad
+ggc bisect good v1.0.0                # Mark a known-good commit
+ggc bisect reset                      # Finish bisecting
+```
+
 ### `ggc completion` {#cmd-completion}
 
 Print or install shell completion scripts.
@@ -730,6 +1015,24 @@ ggc debug-keys raw             # Capture key sequences interactively
 ggc debug-keys raw keys.txt    # Capture and save to keys.txt
 ```
 
+### `ggc describe` {#cmd-describe}
+
+Give an object a human-readable name based on an available ref.
+
+**Usage:**
+
+```bash
+ggc describe [<options>] [<commit>]
+```
+
+**Examples:**
+
+```bash
+ggc describe                          # Describe current HEAD
+ggc describe --tags                   # Use any tag, not just annotated ones
+ggc describe --always --dirty         # Always emit a string; mark dirty trees
+```
+
 ### `ggc doctor` {#cmd-doctor}
 
 Diagnose the local ggc installation.
@@ -746,6 +1049,110 @@ ggc doctor
 ggc doctor   # Check git binary, config, shell completions, TTY, etc.
 ```
 
+### `ggc format-patch` {#cmd-format-patch}
+
+Prepare patches for e-mail submission.
+
+**Usage:**
+
+```bash
+ggc format-patch [<options>] <commit-range>
+```
+
+**Examples:**
+
+```bash
+ggc format-patch -1 HEAD              # Produce a patch for the latest commit
+ggc format-patch origin/main..HEAD    # Produce patches for a branch
+```
+
+### `ggc fsck` {#cmd-fsck}
+
+Verify the connectivity and validity of objects in the repository.
+
+**Usage:**
+
+```bash
+ggc fsck [<options>]
+```
+
+**Examples:**
+
+```bash
+ggc fsck                              # Run a basic fsck
+ggc fsck --full --strict              # Comprehensive checks
+```
+
+### `ggc gc` {#cmd-gc}
+
+Cleanup unnecessary files and optimize the local repository.
+
+**Usage:**
+
+```bash
+ggc gc [<options>]
+```
+
+**Examples:**
+
+```bash
+ggc gc                                # Run a normal gc
+ggc gc --aggressive --prune=now       # Aggressively repack and prune
+```
+
+### `ggc maintenance` {#cmd-maintenance}
+
+Run scheduled background repository optimizations.
+
+**Usage:**
+
+```bash
+ggc maintenance <subcommand> [<options>]
+```
+
+**Examples:**
+
+```bash
+ggc maintenance run                   # Run all enabled tasks once
+ggc maintenance start                 # Install scheduled maintenance
+ggc maintenance stop                  # Remove scheduled maintenance
+```
+
+### `ggc notes` {#cmd-notes}
+
+Add, read, or edit object notes.
+
+**Usage:**
+
+```bash
+ggc notes <subcommand> [<options>]
+```
+
+**Examples:**
+
+```bash
+ggc notes add -m "reviewed" HEAD     # Attach a note to HEAD
+ggc notes show HEAD                   # Show a note
+ggc notes list                        # List notes
+```
+
+### `ggc prune` {#cmd-prune}
+
+Prune all unreachable objects from the object database.
+
+**Usage:**
+
+```bash
+ggc prune [<options>]
+```
+
+**Examples:**
+
+```bash
+ggc prune                             # Prune unreachable objects
+ggc prune --dry-run                   # Report what would be pruned
+```
+
 ### `ggc quit` {#cmd-quit}
 
 Exit interactive mode.
@@ -760,6 +1167,61 @@ quit
 
 ```bash
 quit
+```
+
+### `ggc reflog` {#cmd-reflog}
+
+Manage reflog information (recovery aid).
+
+**Usage:**
+
+```bash
+ggc reflog [<subcommand>] [<options>] [<ref>]
+```
+
+**Examples:**
+
+```bash
+ggc reflog                            # Show HEAD reflog
+ggc reflog show main                  # Show reflog for a specific ref
+ggc reflog expire --expire=now --all  # Aggressively expire reflog entries
+```
+
+### `ggc sparse-checkout` {#cmd-sparse-checkout}
+
+Reduce the working tree to a subset of tracked files.
+
+**Usage:**
+
+```bash
+ggc sparse-checkout <subcommand> [<options>]
+```
+
+**Examples:**
+
+```bash
+ggc sparse-checkout init --cone       # Enable sparse-checkout in cone mode
+ggc sparse-checkout set src docs      # Limit working tree to these paths
+ggc sparse-checkout list              # Show currently checked-out paths
+ggc sparse-checkout disable           # Disable sparse-checkout
+```
+
+### `ggc submodule` {#cmd-submodule}
+
+Initialize, update, or inspect submodules.
+
+**Usage:**
+
+```bash
+ggc submodule <subcommand> [<options>]
+```
+
+**Examples:**
+
+```bash
+ggc submodule status                  # Show submodule status
+ggc submodule update --init           # Initialize and update submodules
+ggc submodule foreach git status      # Run a command in each submodule
 ```
 
 ### `ggc version` {#cmd-version}

--- a/internal/git/passthrough.go
+++ b/internal/git/passthrough.go
@@ -1,0 +1,35 @@
+package git
+
+import (
+	"os"
+	"strings"
+)
+
+// PassthroughOps provides a generic mechanism to run an arbitrary git
+// subcommand and stream its output to the current process's stdout/stderr.
+// It is used by lightweight ggc wrappers that simply forward arguments to git
+// (e.g. ggc cherry-pick, ggc revert, ggc blame).
+type PassthroughOps interface {
+	RunGit(name string, args []string) error
+}
+
+// RunGit invokes `git <name> [args...]`, wiring stdout/stderr to the host
+// process so the user sees normal git output (including pagers when the
+// terminal supports them).
+func (c *Client) RunGit(name string, args []string) error {
+	gitArgs := append([]string{name}, args...)
+	cmd := c.execCommand("git", gitArgs...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return NewOpError(name, "git "+name+joinArgs(args), err)
+	}
+	return nil
+}
+
+func joinArgs(args []string) string {
+	if len(args) == 0 {
+		return ""
+	}
+	return " " + strings.Join(args, " ")
+}

--- a/internal/git/passthrough_test.go
+++ b/internal/git/passthrough_test.go
@@ -1,0 +1,65 @@
+package git
+
+import (
+	"errors"
+	"os/exec"
+	"slices"
+	"testing"
+)
+
+func TestClient_RunGit(t *testing.T) {
+	tests := []struct {
+		name     string
+		cmdName  string
+		args     []string
+		wantArgs []string
+	}{
+		{
+			name:     "no args",
+			cmdName:  "blame",
+			args:     nil,
+			wantArgs: []string{"git", "blame"},
+		},
+		{
+			name:     "with args",
+			cmdName:  "cherry-pick",
+			args:     []string{"-x", "abc123"},
+			wantArgs: []string{"git", "cherry-pick", "-x", "abc123"},
+		},
+		{
+			name:     "subcommand with flag",
+			cmdName:  "worktree",
+			args:     []string{"add", "-b", "feat", "../tree"},
+			wantArgs: []string{"git", "worktree", "add", "-b", "feat", "../tree"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotArgs []string
+			client := &Client{
+				execCommand: func(name string, args ...string) *exec.Cmd {
+					gotArgs = append([]string{name}, args...)
+					return exec.Command("echo")
+				},
+			}
+			if err := client.RunGit(tt.cmdName, tt.args); err != nil {
+				t.Errorf("RunGit() error = %v", err)
+			}
+			if !slices.Equal(gotArgs, tt.wantArgs) {
+				t.Errorf("RunGit() gotArgs = %v, want %v", gotArgs, tt.wantArgs)
+			}
+		})
+	}
+}
+
+func TestClient_RunGit_Error(t *testing.T) {
+	client := &Client{
+		execCommand: func(_ string, _ ...string) *exec.Cmd {
+			return helperCommand(t, "", errors.New("boom"))
+		},
+	}
+	err := client.RunGit("revert", []string{"HEAD"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}

--- a/internal/testutil/git_client.go
+++ b/internal/testutil/git_client.go
@@ -102,6 +102,9 @@ func (m *MockGitClient) LogOneline(_, _ string) (string, error) { return "", nil
 // Show Operations
 func (m *MockGitClient) Show(_ []string) error { return nil }
 
+// Passthrough Operations
+func (m *MockGitClient) RunGit(_ string, _ []string) error { return nil }
+
 // Rebase Operations
 func (m *MockGitClient) RebaseInteractive(_ int) error              { return nil }
 func (m *MockGitClient) RebaseInteractiveAutosquash(_ int) error    { return nil }


### PR DESCRIPTION
Closes #428.

## What

Expands ggc's git porcelain coverage from ~22 commands to ~47 by adding **25 new top-level commands** as thin pass-throughs to `git <name>`. Each command forwards its arguments to git and streams output to stdout/stderr, exposing the full surface of the underlying porcelain while also being discoverable through ggc's registry, help, and shell completions.

### Tier 1 — high impact / used daily

`switch`, `checkout` (file-level), `merge`, `cherry-pick`, `revert`, `blame`

### Tier 2 — power-user workflows

`worktree`, `bisect`, `reflog`, `format-patch`, `am`, `sparse-checkout`, `mv`, `rm`, `submodule`

### Tier 3 — nice-to-have

`describe`, `range-diff`, `grep`, `notes`, `archive`, `shortlog`, `maintenance`, `gc`, `fsck`, `prune`

## Implementation

To avoid duplicating ~25 nearly identical files, this PR introduces a small pass-through infrastructure and registers each command through a single canonical name list:

- **`internal/git/passthrough.go`**: new `PassthroughOps` interface with `Client.RunGit(name, args)`. Stdout/stderr are wired to the host process so git's pager and color output Just Work.
- **`cmd/passthrough.go`**: reusable `passthroughCommand` wrapper. Accepts the literal first arg `help` to render registry-driven help; otherwise delegates straight to `RunGit`. The `passthroughCommandNames` slice is the single source of truth.
- **`cmd/command/expansion.go`**: registry entries (`Info` structs) for every new command, with `Usage` and `Examples` for each. Categories chosen to fit the existing taxonomy.
- **`cmd/cmd.go`**: `Cmd` gains a `passthroughs map[string]*passthroughCommand` field populated in `NewCmd` via `buildPassthroughs(client)`.
- **`cmd/router.go`**: dispatches by name from `passthroughCommandNames` with a lazy map lookup inside the closure — keeps test-only `Cmd` construction (which doesn't populate `passthroughs`) passing router validation.
- **`cmd/help.go`**: `Helper.ShowPassthroughHelp(name)` renders help from the registry.
- **`internal/testutil/git_client.go`**: no-op `RunGit` for embedding.

## Tests

- `internal/git/passthrough_test.go`: verifies the executed `git` args for several command/argument combinations and the error path.
- `cmd/passthrough_test.go`: verifies argument forwarding, the `help` subcommand, error rendering, and that `buildPassthroughs` covers every name in `passthroughCommandNames`.
- All existing tests continue to pass (`TestCmd_Route` validates that every registered command has a handler — confirms we wired all 25).

`make lint` clean, `go test ./...` green. Docs (`docs/guide/commands.md`) and shell completions (`cmd/completions/{bash,zsh,fish}`) regenerated via `make docs`.

## Out of scope

Plumbing commands (`ls-files`, `cat-file`, `hash-object`, `update-ref`, ...) as noted in the issue.

## Follow-ups (optional, future PRs)

For the commands where ggc's interactive incremental-search UI would add real value (called out in #428 — `worktree`, `bisect`, `reflog`, `cherry-pick`, `revert`, `show`), we can layer richer interactive subcommands on top of the pass-through wrappers without breaking the current surface.
