### PR TITLE
docs(ci): clarify caller-side permissions requirement for reusable workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,8 +8,11 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  # Inherited by the reusable GoReleaser workflow for cosign keyless signing
-  # and pushing container images to ghcr.io.
+  # The reusable GoReleaser workflow declares its own `permissions` block,
+  # but a called workflow can only request permissions that the caller has
+  # already granted. We declare id-token and packages here so the called
+  # workflow can perform cosign keyless signing (via GitHub's OIDC
+  # provider) and push container images to ghcr.io.
   id-token: write
   packages: write
 


### PR DESCRIPTION
## Description of Changes

Fixes a misleading comment in `.github/workflows/release-please.yml` that was introduced in #444.

The previous comment said the `id-token` / `packages` permissions were "Inherited by the reusable GoReleaser workflow". That wording was inaccurate: a called (reusable) workflow declares its own `permissions` block, but it can only request permissions that the caller has already granted — caller permissions act as an **upper bound**, not a source of inheritance.

The new comment explains the actual mechanism so future readers understand why these two extra permissions are declared at the caller level.

No behavioural change.

## Related Issue

Follow-up to #433 / #444.

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/bmf-san/ggc/blob/main/CONTRIBUTING.md)
- [ ] I have added or updated tests (N/A – comment-only change)
- [ ] I have updated the documentation (N/A)
- [x] Code is formatted with `make fmt` (N/A – YAML comment)
- [x] Code passes linter checks via `make lint` (N/A – YAML comment)
- [x] All tests are passing (no source code changes)
- [ ] If commands were added/modified: I have run `make docs` (N/A)
- [ ] I have run `make demos` to regenerate demo assets (N/A)
