### PR TITLE
ci: trigger on pull_request and add concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         run: make cover
 
       - name: Upload coverage to Codecov
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
         run: make cover
 
       - name: Upload coverage to Codecov
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,12 @@ name: CI
 
 on:
   push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: write


### PR DESCRIPTION
## Description of Changes

Switches the CI workflow trigger from `on: push` to `push (main only) + pull_request`, and adds a `concurrency` group that cancels in-progress runs for the same PR / ref.

## Motivation

Required status checks (`test (ubuntu-latest, 1.25.0)`, `test (macos-latest, 1.25.0)`) occasionally get stuck on **"Expected — Waiting for status to be reported"** and never resolve. With the previous `on: push` only trigger this happens in several common situations:

- PRs from forks (push fires on the fork, not upstream → no status posted to the PR)
- PR reopen / base-branch change / ready-for-review transitions (no push event)
- Force-push or rebase that cancels the in-flight run with no follow-up push
- Same-SHA pushes that GitHub debounces

## What changes

```yaml
on:
  push:
    branches: [main]
  pull_request:

concurrency:
  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

- `pull_request` ensures every PR (including from forks) gets a check reported against its head SHA.
- Restricting `push` to `main` avoids running CI twice for feature branches that also have an open PR.
- `concurrency` with `cancel-in-progress` keeps the latest run as the authoritative status so branch protection never sees a stale "Waiting".

## Notes

- Job names (`test (ubuntu-latest, 1.25.0)`, `test (macos-latest, 1.25.0)`) are unchanged, so existing branch-protection required-check entries continue to match.
- If the matrix `go-version` is updated in the future, the required-check names will need to be updated in repo settings. A follow-up could introduce a single `ci-success` gate job to decouple required checks from matrix values.

## Related Issue
No related issue.

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/bmf-san/ggc/blob/main/CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated the documentation (if required)
- [x] Code is formatted with `make fmt`
- [x] Code passes linter checks via `make lint`
- [x] All tests are passing
- [x] If commands were added/modified: I have run `make docs` to update README.md
- [ ] I have run `make demos` to regenerate demo assets (if applicable)