### PR TITLE
ci(release): use a GitHub App token for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,42 +5,35 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
-  # The reusable GoReleaser workflow declares its own `permissions` block,
-  # but a called workflow can only request permissions that the caller has
-  # already granted. We declare id-token and packages here so the called
-  # workflow can perform cosign keyless signing (via GitHub's OIDC
-  # provider) and push container images to ghcr.io.
-  id-token: write
-  packages: write
+# The job itself runs with no special permissions; it authenticates as a
+# dedicated GitHub App (see `actions/create-github-app-token` below).
+# Using an App installation token instead of the default `GITHUB_TOKEN`
+# is what allows the release PR and the release tag pushed by
+# release-please to trigger downstream workflows (CI on the release PR,
+# `release.yml` on `push: tags`). Events authored by `GITHUB_TOKEN` are
+# intentionally barred from starting new workflow runs by GitHub.
+permissions: {}
 
 jobs:
   release-please:
     name: Run release-please
     runs-on: ubuntu-latest
-    outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
+      - name: Generate GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
+
       - name: release-please
-        id: release
         uses: googleapis/release-please-action@v5
         with:
+          token: ${{ steps.app-token.outputs.token }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  # Tags created by release-please-action with the default GITHUB_TOKEN do
-  # not trigger workflows listening on `push: tags`, so we explicitly invoke
-  # the reusable GoReleaser workflow here whenever a release is created.
-  # This ensures pre-compiled binaries are attached to every release
-  # (see issue #433).
-  goreleaser:
-    name: Build release artifacts
-    needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
-    uses: ./.github/workflows/release.yml
-    with:
-      tag_name: ${{ needs.release-please.outputs.tag_name }}
-    secrets: inherit
+  # Note: no explicit GoReleaser job here. Because the release tag is now
+  # pushed by the GitHub App installation token (not `GITHUB_TOKEN`), the
+  # `on: push: tags:` trigger in `release.yml` fires naturally. Keeping a
+  # `workflow_call` invocation here too would just double the build.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,12 @@ on:
   push:
     tags:
       - '*'
-  # Allow other workflows (e.g. release-please) to invoke this workflow
-  # directly. Tags created by release-please-action using the default
-  # GITHUB_TOKEN do not trigger downstream `push: tags` workflows due to a
-  # well-known GitHub Actions safeguard against recursive triggers. Exposing
-  # this workflow via `workflow_call` lets release-please trigger GoReleaser
-  # explicitly so pre-compiled binaries get attached to every release.
+  # Manual / programmatic escape hatch. The normal path is `push: tags`,
+  # which fires automatically because release-please now publishes its
+  # release tag with a GitHub App installation token (the default
+  # `GITHUB_TOKEN` would have been blocked from starting downstream
+  # workflows). `workflow_call` stays available so the release can be
+  # rebuilt for an existing tag without re-tagging.
   workflow_call:
     inputs:
       tag_name:


### PR DESCRIPTION
## Why

The release-please workflow currently uses the default `GITHUB_TOKEN`. GitHub intentionally blocks events authored by `GITHUB_TOKEN` from starting new workflow runs (to prevent recursive bot triggers). That has two visible consequences for this repo:

- **CI never runs on the release PR.** Example: #450 (`chore(main): release 8.6.0`) currently shows `mergeStateStatus: BLOCKED` because the required `CI/test (...)` checks have no runs to evaluate. To merge it today a maintainer has to close-then-reopen the PR by hand.
- **The release tag push doesn't fire `release.yml`'s `on: push: tags:` trigger**, which is why `release-please.yml` currently has an explicit `goreleaser:` job that calls `release.yml` via `workflow_call` (added in #433 / #444).

## What

- Mint a dedicated GitHub App installation token via [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token) and pass it to `googleapis/release-please-action`. Tags and PRs pushed under that token are treated as authored by the App, so downstream workflows (CI on the release PR, GoReleaser on the tag) start automatically.
- Drop the explicit `goreleaser:` job in `release-please.yml`. With the App token in place the tag push naturally triggers `release.yml`; keeping both paths would double the build. The `workflow_call` entrypoint stays on `release.yml` itself as a manual re-build escape hatch.
- Tighten `release-please.yml`'s `permissions:` to `{}` since the job no longer needs the default token to write anything — all writes happen through the App's scoped token.

## Required maintainer setup (one-time, outside the diff)

1. **Create a GitHub App** under your account (Settings → Developer settings → GitHub Apps → New GitHub App):
   - Permissions: `Contents: Read & write`, `Pull requests: Read & write`.
   - Webhook: disable.
   - Where can be installed: This account only.
2. **Install the App on `bmf-san/ggc`** (and only this repo).
3. **Generate a private key** from the App page (downloads a `.pem`).
4. **Add two repository secrets** (Settings → Secrets and variables → Actions):
   - `RELEASE_BOT_APP_ID` — the App's numeric Application ID.
   - `RELEASE_BOT_APP_PRIVATE_KEY` — the full `.pem` contents.

Until the secrets exist the release-please workflow run will fail at the `create-github-app-token` step, so this PR should land together with the secret setup. Happy to walk through the App creation on a call / Discord if useful.

## After merge

#450 (and any future release PR) will run CI automatically. GoReleaser will fire on the tag push from release-please, so artifacts continue to be attached to every release. No change to user-facing behavior.

## References

- GitHub docs: ["Triggering a workflow from a workflow"](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow) — the `GITHUB_TOKEN` recursion guard.
- `actions/create-github-app-token` — official action for minting installation tokens.
