### PR TITLE
ci(security): tighten workflow token permissions and SHA-pin recently added actions

### DIFF
--- a/.github/workflows/bench-history.yml
+++ b/.github/workflows/bench-history.yml
@@ -14,9 +14,10 @@ on:
       - '.github/workflows/bench-history.yml'
   workflow_dispatch:
 
-permissions:
-  # Needed to push benchmark results back to the `benchmarks` branch.
-  contents: write
+# Default the workflow token to read-only and scope write permissions
+# to the single job that actually pushes back to the benchmarks branch.
+# Satisfies the Scorecard Token-Permissions check.
+permissions: {}
 
 concurrency:
   group: bench-history
@@ -27,6 +28,9 @@ jobs:
     name: Record main benchmarks
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      # Needed to push benchmark results back to the `benchmarks` branch.
+      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,11 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# CI only reads the repository (tests, lint, build, codecov upload via a
+# dedicated CODECOV_TOKEN). Nothing here writes back, so default the
+# token to read-only. Satisfies the Scorecard Token-Permissions check.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   test:

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -2,15 +2,18 @@ name: Dependabot auto-merge
 
 on: pull_request_target
 
-permissions:
-  contents: write
-  pull-requests: write
+# Default token to no permissions; the auto-merge job below requests just
+# what it needs. Satisfies the Scorecard Token-Permissions check.
+permissions: {}
 
 jobs:
   automerge:
     name: Auto-merge safe Dependabot PRs
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Fetch Dependabot metadata
         id: metadata

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -24,5 +24,5 @@ jobs:
           go-version: '1.25.0'
       - name: Run govulncheck
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
+          go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
           govulncheck ./...

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -2,8 +2,11 @@ name: Dry run GoReleaser
 
 on: [push]
 
+# Dry-run only: GoReleaser is invoked with `--snapshot --skip=sign,docker`
+# so it never pushes a tag, signs anything, or publishes images. Read-only
+# token is sufficient. Satisfies the Scorecard Token-Permissions check.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   goreleaser:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,13 +21,13 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
 
       - name: release-please
-        uses: googleapis/release-please-action@v5
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         with:
           token: ${{ steps.app-token.outputs.token }}
           config-file: .release-please-config.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,16 +23,20 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: write
-  # Required for cosign keyless signing via GitHub's OIDC provider.
-  id-token: write
-  # Required to push container images to ghcr.io.
-  packages: write
+# Default the workflow token to no permissions and grant exactly what
+# GoReleaser needs at the job level. Satisfies the Scorecard
+# Token-Permissions check.
+permissions: {}
 
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      # Required for cosign keyless signing via GitHub's OIDC provider.
+      id-token: write
+      # Required to push container images to ghcr.io.
+      packages: write
     strategy:
       matrix:
         go-version: [ '1.25.0' ]


### PR DESCRIPTION
Addresses open Scorecard alerts on https://github.com/bmf-san/ggc/security/code-scanning.

## Token-Permissions (high, 6 alerts)

Default the workflow-level `GITHUB_TOKEN` to read-only (or empty) and grant write scopes only on the specific job that needs them. Per Scorecard's [Token-Permissions check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions), workflow-level writes are over-privileged because every step in every job inherits them.

| File | Change |
|---|---|
| `bench-history.yml` | workflow `{}`, `contents: write` on `bench` job (pushes benchmarks branch). |
| `ci.yml` | workflow `contents: read` — CI never writes back; codecov uses a separate `CODECOV_TOKEN`. |
| `dependabot-automerge.yml` | workflow `{}`, `contents: write` + `pull-requests: write` on `automerge` job. |
| `release-dry-run.yml` | workflow `contents: read` — runs `goreleaser --snapshot --skip=sign,docker`, never publishes. |
| `release.yml` | workflow `{}`, full `contents`/`id-token`/`packages: write` on `goreleaser` job. |

## Pinned-Dependencies (medium, 3 alerts)

Pin third-party action versions and a Go tool install to immutable references so a hijacked tag can't slip new code into our release path:

* `release-please.yml`
  * `actions/create-github-app-token@v2` -> `fee1f7d63c2ff003460e3d139729b119787bc349` (v2.2.2)
  * `googleapis/release-please-action@v5` -> `45996ed1f6d02564a971a2fa1b5860e934307cf7`
* `govulncheck.yml` — replace `govulncheck@latest` with `@v1.1.4`.

## Out of scope

Tracked in follow-up issues (let me know which to open):

* Pinning `mkdocs-material` install in `docs.yml` via `pip --hash`.
* Pinning the `Dockerfile` base image to a SHA.
* Pinning the binary URL fetched by `install.sh`.
* The Scorecard SAST signal (repo-wide tooling decision).

## Verification

* Workflows parse cleanly (`python3 -c "yaml.safe_load(...)"` on each file).
* No source code changes; CI itself will exercise the new permission scopes and the pinned actions on this PR.
