### PR TITLE
chore(security): pin Dockerfile alpine base image to sha256 digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # This Dockerfile is consumed by GoReleaser; `ggc` is injected by the
 # release pipeline, so building this image outside of GoReleaser will fail
 # unless you place the pre-built binary next to this file.
-FROM alpine:3.22
+FROM alpine:3.22@sha256:310c62b5e7ca5b08167e4384c68db0fd2905dd9c7493756d356e893909057601
 
 # ggc shells out to `git`, so the runtime image must ship one. `ca-certificates`
 # keeps HTTPS remote operations working. No other runtime dependencies.


### PR DESCRIPTION
Pins the Docker base image `alpine:3.22` to its sha256 manifest digest as recommended by OpenSSF Scorecard.

Addresses Scorecard `PinnedDependenciesID` alert (Dockerfile line 5).

The digest `sha256:310c62b5e7ca5b08167e4384c68db0fd2905dd9c7493756d356e893909057601` was suggested by Scorecard itself. Future alpine 3.22 patch updates will require re-pinning (renovate/dependabot can automate this with the `docker` ecosystem).