### PR TITLE
chore(security): pin govulncheck install to commit SHA

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -24,5 +24,5 @@ jobs:
           go-version: '1.25.0'
       - name: Run govulncheck
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+          go install golang.org/x/vuln/cmd/govulncheck@d1f380186385b4f64e00313f31743df8e4b89a77 # v1.1.4
           govulncheck ./...


### PR DESCRIPTION
Pins the `go install` of `govulncheck` from `@latest` to the v1.1.4 commit SHA `d1f380186385b4f64e00313f31743df8e4b89a77`.

Addresses Scorecard `PinnedDependenciesID` alert (`.github/workflows/govulncheck.yml` line 27).

This supersedes the `@v1.1.4` tag pin proposed in PR #452: Scorecard requires the install reference to be a commit SHA, not a tag. If #452 merges first, this PR will need a trivial rebase keeping the SHA line.

Verification:
```
$ curl -fsSL https://api.github.com/repos/golang/vuln/git/refs/tags/v1.1.4 | jq -r .object.sha
d1f380186385b4f64e00313f31743df8e4b89a77
```