### PR TITLE
feat(cmd): add dedicated `ggc bisect` with guided start/run flow

### DIFF
--- a/cmd/bisect.go
+++ b/cmd/bisect.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"io"
+	"os"
+
+	"github.com/bmf-san/ggc/v8/internal/git"
+)
+
+// Bisector handles git bisect operations.
+type Bisector struct {
+	gitClient    git.PassthroughOps
+	outputWriter io.Writer
+	helper       *Helper
+}
+
+// NewBisector creates a new Bisector instance.
+func NewBisector(client git.PassthroughOps) *Bisector {
+	return &Bisector{
+		gitClient:    client,
+		outputWriter: os.Stdout,
+		helper:       NewHelper(),
+	}
+}
+
+// Bisect executes git bisect commands.
+//
+// Supported guided flows:
+//   - ggc bisect start <bad> <good>
+//   - ggc bisect run <script-or-command>
+//
+// Other bisect subcommands are forwarded to git as-is.
+func (b *Bisector) Bisect(args []string) {
+	if len(args) == 0 || args[0] == "help" {
+		b.helper.ShowPassthroughHelp("bisect")
+		return
+	}
+
+	switch args[0] {
+	case "start":
+		b.start(args[1:])
+	case "run":
+		b.run(args[1:])
+	default:
+		b.forward(args)
+	}
+}
+
+func (b *Bisector) start(args []string) {
+	if len(args) < 2 {
+		WriteLine(b.outputWriter, "Usage: ggc bisect start <bad> <good>")
+		return
+	}
+	b.forward(append([]string{"start"}, args...))
+}
+
+func (b *Bisector) run(args []string) {
+	if len(args) == 0 {
+		WriteLine(b.outputWriter, "Usage: ggc bisect run <script-or-command>")
+		return
+	}
+	b.forward(append([]string{"run"}, args...))
+}
+
+func (b *Bisector) forward(args []string) {
+	if err := b.gitClient.RunGit("bisect", args); err != nil {
+		WriteError(b.outputWriter, err)
+	}
+}

--- a/cmd/bisect_test.go
+++ b/cmd/bisect_test.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/bmf-san/ggc/v8/internal/testutil"
+)
+
+type mockBisectClient struct {
+	testutil.MockGitClient
+	called  bool
+	gotName string
+	gotArgs []string
+	err     error
+}
+
+func (m *mockBisectClient) RunGit(name string, args []string) error {
+	m.called = true
+	m.gotName = name
+	m.gotArgs = slices.Clone(args)
+	return m.err
+}
+
+func TestBisector_Bisect_Help(t *testing.T) {
+	var buf bytes.Buffer
+	mockClient := &mockBisectClient{}
+	b := NewBisector(mockClient)
+	b.outputWriter = &buf
+	b.helper.outputWriter = &buf
+
+	b.Bisect(nil)
+
+	if mockClient.called {
+		t.Fatal("RunGit should not be called for help")
+	}
+	if !strings.Contains(buf.String(), "ggc bisect") {
+		t.Fatalf("expected bisect help output, got: %q", buf.String())
+	}
+}
+
+func TestBisector_Bisect_Start_RequiresBadAndGood(t *testing.T) {
+	var buf bytes.Buffer
+	mockClient := &mockBisectClient{}
+	b := NewBisector(mockClient)
+	b.outputWriter = &buf
+
+	b.Bisect([]string{"start", "bad-ref-only"})
+
+	if mockClient.called {
+		t.Fatal("RunGit should not be called when args are invalid")
+	}
+	if !strings.Contains(buf.String(), "Usage: ggc bisect start <bad> <good>") {
+		t.Fatalf("expected usage output, got: %q", buf.String())
+	}
+}
+
+func TestBisector_Bisect_Start_ForwardsToGit(t *testing.T) {
+	mockClient := &mockBisectClient{}
+	b := NewBisector(mockClient)
+	b.outputWriter = &bytes.Buffer{}
+
+	b.Bisect([]string{"start", "deadbeef", "v1.0.0"})
+
+	if !mockClient.called {
+		t.Fatal("expected RunGit to be called")
+	}
+	if mockClient.gotName != "bisect" {
+		t.Fatalf("expected bisect command, got %q", mockClient.gotName)
+	}
+	if !slices.Equal(mockClient.gotArgs, []string{"start", "deadbeef", "v1.0.0"}) {
+		t.Fatalf("unexpected args: %v", mockClient.gotArgs)
+	}
+}
+
+func TestBisector_Bisect_Run_RequiresScriptOrCommand(t *testing.T) {
+	var buf bytes.Buffer
+	mockClient := &mockBisectClient{}
+	b := NewBisector(mockClient)
+	b.outputWriter = &buf
+
+	b.Bisect([]string{"run"})
+
+	if mockClient.called {
+		t.Fatal("RunGit should not be called when run target is missing")
+	}
+	if !strings.Contains(buf.String(), "Usage: ggc bisect run <script-or-command>") {
+		t.Fatalf("expected usage output, got: %q", buf.String())
+	}
+}
+
+func TestBisector_Bisect_Run_ForwardsToGit(t *testing.T) {
+	mockClient := &mockBisectClient{}
+	b := NewBisector(mockClient)
+	b.outputWriter = &bytes.Buffer{}
+
+	b.Bisect([]string{"run", "./scripts/test.sh", "--fast"})
+
+	if !mockClient.called {
+		t.Fatal("expected RunGit to be called")
+	}
+	if mockClient.gotName != "bisect" {
+		t.Fatalf("expected bisect command, got %q", mockClient.gotName)
+	}
+	if !slices.Equal(mockClient.gotArgs, []string{"run", "./scripts/test.sh", "--fast"}) {
+		t.Fatalf("unexpected args: %v", mockClient.gotArgs)
+	}
+}
+
+func TestBisector_Bisect_FallbackSubcommand_ForwardsToGit(t *testing.T) {
+	mockClient := &mockBisectClient{}
+	b := NewBisector(mockClient)
+	b.outputWriter = &bytes.Buffer{}
+
+	b.Bisect([]string{"bad"})
+
+	if !mockClient.called {
+		t.Fatal("expected RunGit to be called")
+	}
+	if mockClient.gotName != "bisect" {
+		t.Fatalf("expected bisect command, got %q", mockClient.gotName)
+	}
+	if !slices.Equal(mockClient.gotArgs, []string{"bad"}) {
+		t.Fatalf("unexpected args: %v", mockClient.gotArgs)
+	}
+}
+
+func TestBisector_Bisect_ForwardError(t *testing.T) {
+	var buf bytes.Buffer
+	mockClient := &mockBisectClient{err: errors.New("bisect failed")}
+	b := NewBisector(mockClient)
+	b.outputWriter = &buf
+
+	b.Bisect([]string{"bad"})
+
+	if !strings.Contains(buf.String(), "Error: bisect failed") {
+		t.Fatalf("expected error output, got: %q", buf.String())
+	}
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -38,6 +38,7 @@ type Cmd struct {
 	adder         *Adder
 	remoter       *Remoter
 	rebaser       *Rebaser
+	bisector      *Bisector
 	stasher       *Stasher
 	configurer    *Configurer
 	hooker        *Hooker
@@ -123,6 +124,7 @@ func NewCmd(client GitDeps, cm *config.Manager) (*Cmd, error) {
 		adder:         NewAdder(client),
 		remoter:       NewRemoter(client),
 		rebaser:       NewRebaser(client),
+		bisector:      NewBisector(client),
 		stasher:       NewStasher(client),
 		configurer:    NewConfigurer(client),
 		hooker:        NewHooker(client),
@@ -172,6 +174,11 @@ func (c *Cmd) Remote(args []string) {
 // Rebase executes the rebase command with the given arguments.
 func (c *Cmd) Rebase(args []string) {
 	c.rebaser.Rebase(args)
+}
+
+// Bisect executes the bisect command with the given arguments.
+func (c *Cmd) Bisect(args []string) {
+	c.bisector.Bisect(args)
 }
 
 // Stash executes the stash command with the given arguments.

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -292,6 +292,9 @@ func TestNewCmd(t *testing.T) {
 	if cmd.rebaser == nil {
 		t.Error("rebaser should not be nil")
 	}
+	if cmd.bisector == nil {
+		t.Error("bisector should not be nil")
+	}
 	if cmd.remoter == nil {
 		t.Error("remoteer should not be nil")
 	}

--- a/cmd/command/expansion.go
+++ b/cmd/command/expansion.go
@@ -106,7 +106,8 @@ func expansion() []Info {
 			Summary:  "Use binary search to find the commit that introduced a bug",
 			Usage:    []string{"ggc bisect <subcommand> [<options>]"},
 			Examples: []string{
-				"ggc bisect start                      # Start a new bisect session",
+				"ggc bisect start <bad> <good>         # Start a new bisect session with known refs",
+				"ggc bisect run ./scripts/test.sh      # Auto-mark commits with an executable script",
 				"ggc bisect bad                        # Mark current commit as bad",
 				"ggc bisect good v1.0.0                # Mark a known-good commit",
 				"ggc bisect reset                      # Finish bisecting",

--- a/cmd/constructor_test.go
+++ b/cmd/constructor_test.go
@@ -257,6 +257,7 @@ func TestNewCmd_Constructor(t *testing.T) {
 		adder:      &Adder{gitClient: mockClient, outputWriter: &buf},
 		remoter:    &Remoter{outputWriter: &buf, helper: NewHelper()},
 		rebaser:    &Rebaser{outputWriter: &buf, helper: NewHelper()},
+		bisector:   &Bisector{outputWriter: &buf, helper: NewHelper()},
 		stasher:    &Stasher{outputWriter: &buf, helper: NewHelper()},
 		fetcher:    &Fetcher{outputWriter: &buf, helper: NewHelper()},
 		statuser:   &Statuser{outputWriter: &buf, helper: NewHelper()},
@@ -276,7 +277,7 @@ func TestNewCmd_Constructor(t *testing.T) {
 	if cmd.brancher == nil || cmd.committer == nil || cmd.logger == nil ||
 		cmd.puller == nil || cmd.pusher == nil || cmd.resetter == nil ||
 		cmd.cleaner == nil || cmd.adder == nil ||
-		cmd.remoter == nil || cmd.rebaser == nil || cmd.stasher == nil ||
+		cmd.remoter == nil || cmd.rebaser == nil || cmd.bisector == nil || cmd.stasher == nil ||
 		cmd.fetcher == nil || cmd.statuser == nil ||
 		cmd.differ == nil || cmd.tagger == nil || cmd.versioner == nil ||
 		cmd.configurer == nil || cmd.hooker == nil || cmd.restorer == nil {

--- a/cmd/passthrough.go
+++ b/cmd/passthrough.go
@@ -55,7 +55,6 @@ var passthroughCommandNames = []string{
 	"blame",
 	// Tier 2
 	"worktree",
-	"bisect",
 	"reflog",
 	"format-patch",
 	"am",

--- a/cmd/router.go
+++ b/cmd/router.go
@@ -40,6 +40,7 @@ func newCommandRouter(cmd *Cmd) (*commandRouter, error) {
 		"version":    func(args []string) { cmd.Version(args) },
 		"remote":     func(args []string) { cmd.Remote(args) },
 		"rebase":     func(args []string) { cmd.Rebase(args) },
+		"bisect":     func(args []string) { cmd.Bisect(args) },
 		"stash":      func(args []string) { cmd.Stash(args) },
 		"config":     func(args []string) { cmd.Config(args) },
 		"hook":       func(args []string) { cmd.Hook(args) },

--- a/docs/content/guide/commands.md
+++ b/docs/content/guide/commands.md
@@ -959,7 +959,8 @@ ggc bisect <subcommand> [<options>]
 **Examples:**
 
 ```bash
-ggc bisect start                      # Start a new bisect session
+ggc bisect start <bad> <good>         # Start a new bisect session with known refs
+ggc bisect run ./scripts/test.sh      # Auto-mark commits with an executable script
 ggc bisect bad                        # Mark current commit as bad
 ggc bisect good v1.0.0                # Mark a known-good commit
 ggc bisect reset                      # Finish bisecting


### PR DESCRIPTION
## Summary
- add a dedicated `Bisector` command handler instead of relying only on passthrough
- support guided flows for:
  - `ggc bisect start <bad> <good>`
  - `ggc bisect run <script-or-command>`
- keep existing bisect subcommands (`bad`, `good`, `reset`, etc.) as passthrough behavior
- wire `bisect` into command construction and router dispatch
- update command examples to include the new guided flows
- add unit tests for help, validation, forwarding, and error paths

## Validation
- `go test ./cmd/...`
- `go test ./...`

Closes #484